### PR TITLE
Add the Agent37 gateway (Hermes worker adapter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# All optional — defaults work for a local Hermes install.
+
+# --- Gateway HTTP server ---
+PORT=3737                 # Port to listen on
+HOST=0.0.0.0              # Interface to bind (0.0.0.0 so the host/Docker can reach it)
+
+# --- Gateway state ---
+AGENT37_GATEWAY_HOME=~/.agent37-gateway   # Root for the SQLite db, logs, and the agent workspace
+DB_PATH=                                  # Override the SQLite path (default: <home>/data/gateway.db)
+GATEWAY_WORKSPACE_DIR=                     # Override the agent's working directory (default: <home>/workspace)
+
+# --- Hermes (the agent the worker imports) ---
+HERMES_HOME=~/.hermes                      # Hermes install root
+HERMES_AGENT_DIR=~/.hermes/hermes-agent    # Hermes agent source (auto-detected if unset)
+HERMES_PYTHON=                             # Path to a Python with Hermes deps (auto-detected if unset)
+HERMES_AGENT_RUN_LIMIT=10                  # Max concurrent agent runs in the Python worker
+GATEWAY_MODEL_LIST_CACHE_TTL_SECONDS=60    # Cache TTL for GET /v1/models

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+dist/
+.env
+*.tsbuildinfo
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Editor / OS
+.vscode/
+.DS_Store
+
+# Workspace collaboration dir (Conductor)
+.context/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,198 @@
+# Agent37 Gateway
+
+**One API to talk to an agent on an instance.**
+
+The Agent37 Gateway runs inside each agent instance and exposes a small,
+Responses-style HTTP API. You send it a turn; it routes that turn to the
+instance's agent, streams the work back, and keeps the conversation going. The
+streaming contract and request shape are the same whatever agent is behind it —
+so client code doesn't change when the agent does.
+
+Today it routes to **Hermes**. The adapter seam is built so **OpenClaw** and
+**Claude Code** slot in next.
+
+> This is the per-instance request plane. Creating, sizing, and billing
+> instances is the job of the Agent37 Cloud control plane, which routes a
+> request to the right container and forwards it here. Inside the container
+> there is exactly one gateway, and it has no concept of instances — it just
+> answers.
+
+MIT licensed.
+
+## How it talks to Hermes
+
+The gateway is a small TypeScript/Express server. It spawns a Python worker
+(`server/workers/hermes_worker.py`) and speaks newline-delimited JSON to it over
+stdin/stdout. The worker imports the Hermes `AIAgent` **directly** — there is no
+Hermes HTTP gateway in the loop — which gives structured streaming events,
+per-turn model and reasoning control, and direct access to Hermes' `SessionDB`
+for transcript history and replay.
+
+```
+HTTP / SSE client
+  ↕  HTTP + Server-Sent Events
+Agent37 Gateway  (Express, :3737)
+  ↕  JSONL over stdin/stdout
+Python worker    (hermes_worker.py)
+  ↕  direct Python import
+Hermes AIAgent
+```
+
+State is split deliberately:
+
+- **In-memory live registry** buffers the SSE events of each in-flight (and
+  just-finished) response, so a dropped client can reconnect and replay.
+- **SQLite** (`<home>/data/gateway.db`) holds response and session **metadata**
+  — enough to fetch a response by id or list sessions after a restart.
+- **Transcript history** is never duplicated; it's projected on demand from
+  Hermes' `SessionDB`.
+
+## Quickstart
+
+**Prerequisites:** Node.js 24+ and a working [Hermes](https://hermes-agent.nousresearch.com)
+install (the worker auto-detects `~/.hermes/hermes-agent`; override with
+`HERMES_AGENT_DIR` / `HERMES_PYTHON`).
+
+```bash
+npm install
+npm run dev          # tsx watch on http://localhost:3737
+# or
+npm run prod         # build + run the compiled server
+```
+
+Check the worker can reach Hermes without booting the server:
+
+```bash
+npm run selftest:worker
+```
+
+## API
+
+Base path is `/v1`. There is no auth in the gateway — it's a localhost service
+behind the host, which handles and forwards authentication.
+
+### Send a turn — `POST /v1/responses`
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `input` | string, required | The message or task. |
+| `session_id` | string | Continue a conversation. Omit to start a new one. |
+| `stream` | boolean | `true` for Server-Sent Events; default `false`. |
+| `model` / `provider` | string | The LLM to run on. List options at `GET /v1/models`. |
+| `reasoning_effort` | string | `none` … `xhigh`. |
+| `mode` | string | `chat` (default). `goal` is reserved (returns `validation_error` for now). |
+| `metadata` | object | Up to 16 key/value pairs, echoed back. |
+
+Non-streaming returns the finished response object:
+
+```jsonc
+{
+  "id": "resp_…",
+  "session_id": "sess_…",
+  "status": "completed",          // in_progress | completed | failed | cancelled
+  "agent": "hermes",
+  "model": null,
+  "provider": null,
+  "output_text": "…",
+  "usage": { "input_tokens": 1840, "output_tokens": 920, "cost_usd": 0.0137 },
+  "error": null,
+  "metadata": null,
+  "created": 1748400000000
+}
+```
+
+With `stream: true` the body is a Server-Sent Events stream of named events:
+
+| Event | Payload |
+| --- | --- |
+| `response.created` | `{ id, session_id }` |
+| `response.reasoning.delta` | `{ text }` |
+| `response.output_text.delta` | `{ text }` |
+| `response.tool_call.started` | `{ tool, label }` |
+| `response.tool_call.completed` | `{ tool, duration_ms }` |
+| `response.tool_call.failed` | `{ tool, error }` |
+| `response.completed` | `{ output_text, usage }` |
+| `response.failed` | `{ error: { code, message } }` |
+
+### Follow up on a response
+
+| Action | Endpoint |
+| --- | --- |
+| Fetch by id | `GET /v1/responses/{id}` |
+| Reconnect a dropped stream | `GET /v1/responses/{id}/stream` (replays a snapshot, then resumes live) |
+| Cancel a running turn | `POST /v1/responses/{id}/cancel` |
+
+### Sessions
+
+| Action | Endpoint |
+| --- | --- |
+| List | `GET /v1/sessions` → `{ data: [...] }` |
+| Retrieve, with history | `GET /v1/sessions/{id}` |
+| Delete | `DELETE /v1/sessions/{id}` |
+
+### Models & health
+
+| Action | Endpoint |
+| --- | --- |
+| Models the agent can run | `GET /v1/models` |
+| Liveness + worker reachability | `GET /v1/health` |
+| Version | `GET /v1/version` |
+
+### Errors
+
+Every error returns a stable, machine-readable body. Branch on `code`, show
+`message`:
+
+```json
+{ "error": { "code": "validation_error", "message": "input is required…", "param": "input" } }
+```
+
+| Code | HTTP | When |
+| --- | --- | --- |
+| `validation_error` | 400 | A request field was invalid (see `param`). |
+| `session_not_found` | 404 | No session with that id. |
+| `response_not_found` | 404 | No response with that id. |
+| `not_found` | 404 | Unknown route. |
+| `session_busy` | 409 | A response is already running on the session. |
+| `payload_too_large` | 413 | Request body exceeded the size limit. |
+| `rate_limited` | 429 | The upstream agent/provider was rate-limited. |
+| `agent_error` | 502 | The agent backend failed (auth, model, provider, etc.). |
+| `internal_error` | 500 | An unexpected gateway error. |
+
+Agent/worker failures surface their own `code` and `hint` where available (e.g.
+`auth_error`, `quota_exhausted`, `model_error`). One response runs at a time per
+session; sending a new turn while one is in flight returns `409 session_busy`.
+
+## Testing
+
+```bash
+npm test          # integration suite against the real local Hermes worker/LLM
+```
+
+`npm test` drives the real Express app over HTTP/SSE against a throwaway gateway
+state dir. Response tests call the local Hermes worker and configured LLM; the
+suite also covers replay, `session_busy`, cancel, persistence, history, and
+error bodies.
+
+### Poke it by hand (Bruno)
+
+A [Bruno](https://www.usebruno.com/) collection lives in [`bruno/`](bruno/) —
+open that folder in Bruno, pick the **local** environment (`baseUrl`
+`http://localhost:3737`), and run the requests top to bottom. *Create Response*
+saves the `session_id` and `resp_` id into the environment, so *Continue
+Session*, *Get Response*, *Cancel*, and *Delete Session* just work.
+
+## Configuration
+
+All optional — see [`.env.example`](.env.example). Highlights: `PORT` (3737),
+`HOST` (0.0.0.0), `AGENT37_GATEWAY_HOME` (`~/.agent37-gateway`), and the
+`HERMES_*` variables that locate the Hermes install.
+
+## Roadmap
+
+- **`goal` mode** — autonomous, multi-turn runs (the worker primitives are in place).
+- **More adapters** — OpenClaw and Claude Code, behind the same `AgentAdapter` seam.
+
+## License
+
+[MIT](LICENSE).

--- a/bin/agent37-gateway.mjs
+++ b/bin/agent37-gateway.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { dirname, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = resolve(here, '..', 'package.json');
+const serverEntry = resolve(here, '..', 'dist', 'server', 'server', 'index.js');
+const [command] = process.argv.slice(2);
+
+function readPackageMetadata() {
+  try {
+    return JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  } catch {
+    return { name: 'agent37-gateway', version: 'unknown' };
+  }
+}
+
+if (command === '--version' || command === '-v' || command === 'version') {
+  console.log(readPackageMetadata().version);
+  process.exit(0);
+}
+
+if (command === '--help' || command === '-h' || command === 'help') {
+  const metadata = readPackageMetadata();
+  console.log(`Usage: agent37-gateway
+
+${metadata.description ?? 'Unified adapter API for agent instances.'}
+
+Options:
+  -v, --version  Print the installed gateway version
+  -h, --help     Show this help message
+
+Environment:
+  PORT           Port to listen on (default 3737)
+  HOST           Interface to bind (default 0.0.0.0)
+  HERMES_HOME    Hermes install root (default ~/.hermes)`);
+  process.exit(0);
+}
+
+if (!existsSync(serverEntry)) {
+  console.error(
+    `agent37-gateway: built server entry not found at ${serverEntry}.\n` +
+      `If you are running from a source checkout, use "npm run dev" or "npm run prod" instead.`,
+  );
+  process.exit(1);
+}
+
+await import(pathToFileURL(serverEntry).href);

--- a/bruno/.gitignore
+++ b/bruno/.gitignore
@@ -1,0 +1,1 @@
+environments/local.bru

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -1,0 +1,27 @@
+# Agent37 Gateway — Bruno collection
+
+API requests for poking the gateway locally, using [Bruno](https://www.usebruno.com/).
+
+## Use it
+
+1. Start the gateway: `npm run prod` (or `npm run dev`) — it listens on `http://localhost:3737`.
+2. In Bruno: **Open Collection** → select this `bruno/` folder.
+3. Pick the **local** environment (top-right). It sets `baseUrl` to `http://localhost:3737`.
+4. Run the requests in order. They chain through env vars:
+   - **04 Create Response** saves `session_id` and `responseId`.
+   - **05 Continue Session**, **06 Get Response**, **10 Get Session**, **11 Cancel**, **12 Delete** reuse them.
+
+There's no auth — the gateway is a localhost service (the host/Docker handles
+auth in production), so every request uses `auth: none`.
+
+## Environments
+
+`environments/local.example.bru` is committed; copy it to `environments/local.bru`
+(gitignored) if you want a private one. A ready-to-use `local.bru` is included.
+
+## Notes
+
+- **07 Create Response (streaming)** returns Server-Sent Events. Bruno shows the
+  assembled stream; for raw frames use `curl -N`.
+- The requests default to `reasoning_effort: low` and tiny prompts to keep live
+  turns fast and cheap.

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "Agent37 Gateway",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/bruno/environments/local.example.bru
+++ b/bruno/environments/local.example.bru
@@ -1,0 +1,5 @@
+vars {
+  baseUrl: http://localhost:3737
+  sessionId:
+  responseId:
+}

--- a/bruno/gateway/01 Health.bru
+++ b/bruno/gateway/01 Health.bru
@@ -1,0 +1,27 @@
+meta {
+  name: 01 Health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/v1/health
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("agent reachable", function () {
+    expect(res.body.ok).to.equal(true);
+    expect(res.body.hermes).to.equal(true);
+  });
+}
+
+docs {
+  Liveness + whether the Hermes worker is reachable.
+  No auth — the gateway runs on localhost behind the host/Docker.
+}

--- a/bruno/gateway/02 Version.bru
+++ b/bruno/gateway/02 Version.bru
@@ -1,0 +1,17 @@
+meta {
+  name: 02 Version
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/version
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/gateway/03 List Models.bru
+++ b/bruno/gateway/03 List Models.bru
@@ -1,0 +1,26 @@
+meta {
+  name: 03 List Models
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/v1/models
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has a model list", function () {
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The models this instance's agent can run on. Pass any `id` as `model`
+  (with its `provider`) on a Create Response call.
+}

--- a/bruno/gateway/04 Create Response.bru
+++ b/bruno/gateway/04 Create Response.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 04 Create Response
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "Reply with exactly the words: hello from hermes",
+    "reasoning_effort": "low"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body) {
+    if (res.body.session_id) bru.setEnvVar("sessionId", res.body.session_id, { persist: true });
+    if (res.body.id) bru.setEnvVar("responseId", res.body.id, { persist: true });
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("completed with text", function () {
+    expect(res.body.id).to.be.a("string");
+    expect(res.body.session_id).to.be.a("string");
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.output_text).to.be.a("string");
+  });
+}
+
+docs {
+  Start a new conversation: send `input` with no `session_id`. The reply returns
+  a `session_id` (saved to the env) you reuse to continue the thread, and a
+  `resp_` id (also saved) for Get Response / Cancel.
+
+  Other optional fields: `model`, `provider`, `reasoning_effort`
+  (none|minimal|low|medium|high|xhigh), `metadata` (<=16 keys), `stream`.
+}

--- a/bruno/gateway/05 Continue Session.bru
+++ b/bruno/gateway/05 Continue Session.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 05 Continue Session
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "session_id": "{{sessionId}}",
+    "input": "In one short sentence, what did I just ask you to say?",
+    "reasoning_effort": "low"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("same session, completed", function () {
+    expect(res.body.session_id).to.equal(bru.getEnvVar("sessionId"));
+    expect(res.body.status).to.equal("completed");
+  });
+}
+
+docs {
+  Continue the conversation from Create Response: reuse `session_id` and send
+  only the new `input`. The session keeps the full history, so you never resend
+  the transcript.
+}

--- a/bruno/gateway/06 Get Response.bru
+++ b/bruno/gateway/06 Get Response.bru
@@ -1,0 +1,21 @@
+meta {
+  name: 06 Get Response
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/v1/responses/{{responseId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("matches the created response", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("responseId"));
+  });
+}

--- a/bruno/gateway/07 Create Response (streaming).bru
+++ b/bruno/gateway/07 Create Response (streaming).bru
@@ -1,0 +1,36 @@
+meta {
+  name: 07 Create Response (streaming)
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "Count from 1 to 5, one number per line.",
+    "reasoning_effort": "low",
+    "stream": true
+  }
+}
+
+docs {
+  With `stream: true` the gateway returns Server-Sent Events:
+    response.created -> response.reasoning.delta / response.output_text.delta /
+    response.tool_call.* -> response.completed (or response.failed)
+
+  Bruno shows the assembled event stream in the Response pane. For raw frames,
+  curl is handy:
+
+    curl -N localhost:3737/v1/responses \
+      -H 'content-type: application/json' \
+      -d '{"input":"hi","stream":true}'
+}

--- a/bruno/gateway/08 Reconnect Stream.bru
+++ b/bruno/gateway/08 Reconnect Stream.bru
@@ -1,0 +1,17 @@
+meta {
+  name: 08 Reconnect Stream
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/v1/responses/{{responseId}}/stream
+  body: none
+  auth: none
+}
+
+docs {
+  Reconnect to a response's stream. Replays a snapshot of everything so far,
+  then resumes live — so a dropped connection never loses the answer. For a
+  response that already finished, it replays the snapshot and ends.
+}

--- a/bruno/gateway/09 List Sessions.bru
+++ b/bruno/gateway/09 List Sessions.bru
@@ -1,0 +1,21 @@
+meta {
+  name: 09 List Sessions
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has session list", function () {
+    expect(res.body.data).to.be.an("array");
+  });
+}

--- a/bruno/gateway/10 Get Session (with history).bru
+++ b/bruno/gateway/10 Get Session (with history).bru
@@ -1,0 +1,27 @@
+meta {
+  name: 10 Get Session (with history)
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions/{{sessionId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("includes transcript history", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("sessionId"));
+    expect(res.body.history).to.be.an("array");
+  });
+}
+
+docs {
+  The session plus its full transcript, projected on demand from Hermes'
+  SessionDB (the gateway never duplicates messages).
+}

--- a/bruno/gateway/11 Cancel Response.bru
+++ b/bruno/gateway/11 Cancel Response.bru
@@ -1,0 +1,23 @@
+meta {
+  name: 11 Cancel Response
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{baseUrl}}/v1/responses/{{responseId}}/cancel
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+}
+
+docs {
+  Stop a running turn. Best-effort: the turn unwinds and ends with
+  status "cancelled". Cancelling an already-finished response is a no-op that
+  returns its terminal state.
+}

--- a/bruno/gateway/12 Delete Session.bru
+++ b/bruno/gateway/12 Delete Session.bru
@@ -1,0 +1,26 @@
+meta {
+  name: 12 Delete Session
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{baseUrl}}/v1/sessions/{{sessionId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("deleted", function () {
+    expect(res.body.deleted).to.equal(true);
+  });
+}
+
+docs {
+  Permanently remove the conversation and its history. Other sessions on the
+  instance are untouched.
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1966 @@
+{
+  "name": "agent37-gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent37-gateway",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^12.2.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
+        "express": "^4.21.2"
+      },
+      "bin": {
+        "agent37-gateway": "bin/agent37-gateway.mjs"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^5.0.0",
+        "@types/node": "^24.0.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "agent37-gateway",
+  "version": "0.1.0",
+  "description": "A unified, Responses-style adapter API that runs on each instance and routes turns to an agent. Hermes today; OpenClaw and Claude Code next.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "agent37-gateway": "bin/agent37-gateway.mjs"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "dev": "NODE_ENV=development tsx watch --include='server/workers/**/*.py' server/index.ts",
+    "clean": "rm -rf dist",
+    "build": "npm run clean && npm run build:server && npm run build:assets",
+    "build:server": "tsc -p server/tsconfig.json",
+    "build:assets": "rsync -a --prune-empty-dirs --exclude='__pycache__' --include='*/' --include='*.sql' --include='*.py' --exclude='*' server/ dist/server/server/",
+    "start": "NODE_ENV=production node dist/server/server/index.js",
+    "prod": "npm run build && npm run start",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test test/*.test.ts",
+    "selftest:worker": "python3 server/workers/hermes_worker.py --self-test",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.2.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/server/adapters/hermes-worker.ts
+++ b/server/adapters/hermes-worker.ts
@@ -1,0 +1,574 @@
+import { spawn, execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync, mkdirSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { createInterface, type Interface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  GoalDecision,
+  GoalStateSnapshot,
+  HermesMessage,
+  SessionMetadata,
+} from '../../shared/types.js';
+import type { AgentAdapter, AgentRunOptions, GoalCapableAdapter, StreamEvent } from './types.js';
+import type { WorkerEvent, WorkerRequest, WorkerResult, WorkerErrorPayload } from './worker-protocol.js';
+import { expandHomePrefix, resolveHermesHome, resolveWorkspaceDir } from '../paths.js';
+
+const WORKER_READY_TIMEOUT_MS = 10_000;
+const WORKER_INTERRUPT_TIMEOUT_MS = 10_000;
+
+type WorkerRequestInput = WorkerRequest extends infer Request
+  ? Request extends WorkerRequest
+    ? Omit<Request, 'id'>
+    : never
+  : never;
+
+type PendingRequest = {
+  kind: 'request';
+  resolve: (value: WorkerResult) => void;
+  reject: (error: Error) => void;
+};
+
+type PendingStream = {
+  kind: 'stream';
+  push: (event: WorkerEvent) => void;
+  end: () => void;
+  fail: (error: Error) => void;
+};
+
+type Pending = PendingRequest | PendingStream;
+
+function resolveAgentDirFromHermesCli(): string | undefined {
+  try {
+    const hermesBin = execFileSync('which', ['hermes'], { encoding: 'utf8' }).trim();
+    const real = realpathSync(hermesBin);
+    // Typical layout: <agent-dir>/venv/bin/hermes → agent dir is 3 levels up
+    const candidate = resolve(dirname(real), '..', '..');
+    if (existsSync(join(candidate, 'run_agent.py'))) return candidate;
+  } catch {
+    // `which` failed or path doesn't resolve — not installed via standard installer
+  }
+  return undefined;
+}
+
+function resolvePython(): string {
+  if (process.env.HERMES_PYTHON) return expandHomePrefix(process.env.HERMES_PYTHON);
+
+  const candidates: string[] = [];
+  if (process.env.HERMES_AGENT_DIR) {
+    candidates.push(join(expandHomePrefix(process.env.HERMES_AGENT_DIR), 'venv/bin/python'));
+  }
+  candidates.push(join(resolveHermesHome(), 'hermes-agent/venv/bin/python'));
+
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (found) return found;
+
+  const cliAgentDir = resolveAgentDirFromHermesCli();
+  if (cliAgentDir) {
+    const venvPython = join(cliAgentDir, 'venv/bin/python');
+    if (existsSync(venvPython)) return venvPython;
+  }
+
+  return 'python3';
+}
+
+function resolveWorkerScript(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, '../workers/hermes_worker.py'),
+    resolve(here, '../../server/workers/hermes_worker.py'),
+    resolve(process.cwd(), 'server/workers/hermes_worker.py'),
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) throw new Error(`Hermes worker script not found. Tried: ${candidates.join(', ')}`);
+  return found;
+}
+
+function formatWorkerError(error: string | WorkerErrorPayload | undefined): string {
+  if (!error) return 'Hermes worker error';
+  if (typeof error === 'string') return error;
+
+  const code = error.code ? `[${error.code}] ` : '';
+  const hint = error.hint ? ` ${error.hint}` : '';
+  return `${code}${error.message}${hint}`;
+}
+
+function workerErrorCode(error: string | WorkerErrorPayload | undefined): string | undefined {
+  return typeof error === 'object' ? error.code : undefined;
+}
+
+function workerErrorHint(error: string | WorkerErrorPayload | undefined): string | undefined {
+  return typeof error === 'object' ? error.hint : undefined;
+}
+
+class HermesWorkerError extends Error {
+  code?: string;
+  hint?: string;
+
+  constructor(error: string | WorkerErrorPayload | undefined) {
+    super(typeof error === 'object' ? error.message : formatWorkerError(error));
+    this.name = 'HermesWorkerError';
+    this.code = workerErrorCode(error);
+    this.hint = workerErrorHint(error);
+  }
+}
+
+function createAsyncQueue<T>() {
+  const values: T[] = [];
+  const waiters: {
+    resolve: (value: IteratorResult<T>) => void;
+    reject: (error: Error) => void;
+  }[] = [];
+  let ended = false;
+  let failure: Error | null = null;
+
+  return {
+    push(value: T) {
+      const waiter = waiters.shift();
+      if (waiter) waiter.resolve({ value, done: false });
+      else values.push(value);
+    },
+    end() {
+      ended = true;
+      while (waiters.length > 0) {
+        waiters.shift()?.resolve({ value: undefined as T, done: true });
+      }
+    },
+    fail(error: Error) {
+      failure = error;
+      while (waiters.length > 0) {
+        waiters.shift()?.reject(error);
+      }
+    },
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (values.length > 0) {
+            return Promise.resolve({ value: values.shift() as T, done: false });
+          }
+          if (failure) return Promise.reject(failure);
+          if (ended) return Promise.resolve({ value: undefined as T, done: true });
+          return new Promise((resolveNext, reject) => {
+            waiters.push({ resolve: resolveNext, reject });
+          });
+        },
+        return(): Promise<IteratorResult<T>> {
+          ended = true;
+          values.length = 0;
+          return Promise.resolve({ value: undefined as T, done: true });
+        },
+      };
+    },
+  };
+}
+
+class HermesWorkerClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private readline: Interface | null = null;
+  private pending = new Map<string, Pending>();
+  private ready = false;
+  private readyPromise: Promise<void> | null = null;
+
+  async start(): Promise<void> {
+    this.ensureStarted();
+    if (this.ready) return;
+
+    if (!this.readyPromise) {
+      const request = { id: randomUUID(), type: 'health' } as WorkerRequest;
+      this.readyPromise = this.sendRequest<{ ok: boolean }>(request, WORKER_READY_TIMEOUT_MS)
+        .then((result) => {
+          if (!result.ok) throw new Error('Hermes worker healthcheck failed');
+          this.ready = true;
+        })
+        .catch((error) => {
+          this.ready = false;
+          if (this.child && !this.child.killed) this.child.kill();
+          throw error;
+        })
+        .finally(() => {
+          this.readyPromise = null;
+        });
+    }
+
+    await this.readyPromise;
+  }
+
+  async stop(signal: NodeJS.Signals = 'SIGTERM'): Promise<void> {
+    const child = this.child;
+    this.child = null;
+    this.ready = false;
+    this.readyPromise = null;
+
+    if (this.readline) {
+      this.readline.close();
+      this.readline = null;
+    }
+
+    this.failPending(new Error('Hermes worker stopped'));
+
+    if (!child || child.exitCode !== null) return;
+
+    await new Promise<void>((resolveStop) => {
+      let settled = false;
+      let forceTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        if (forceTimer) clearTimeout(forceTimer);
+        resolveStop();
+      };
+
+      forceTimer = setTimeout(() => {
+        if (child.exitCode === null) child.kill('SIGKILL');
+        done();
+      }, 500);
+      forceTimer.unref();
+
+      child.once('exit', done);
+      child.once('error', done);
+
+      try {
+        if (!child.stdin.destroyed) child.stdin.end();
+      } catch {
+        // The worker may already be exiting.
+      }
+
+      if (!child.killed) child.kill(signal);
+    });
+  }
+
+  async request<T extends WorkerResult>(input: WorkerRequest['type'] | WorkerRequestInput, timeoutMs?: number): Promise<T> {
+    await this.start();
+    const id = randomUUID();
+    const request = typeof input === 'string'
+      ? { id, type: input } as WorkerRequest
+      : { ...input, id } as WorkerRequest;
+    return await this.sendRequest<T>(request, timeoutMs);
+  }
+
+  async *stream(request: Omit<Extract<WorkerRequest, { type: 'chat' }>, 'id'>): AsyncIterable<WorkerEvent> {
+    await this.start();
+    const id = randomUUID();
+    const queue = createAsyncQueue<WorkerEvent>();
+
+    try {
+      this.pending.set(id, {
+        kind: 'stream',
+        push: queue.push,
+        end: queue.end,
+        fail: queue.fail,
+      });
+
+      this.write({ ...request, id });
+
+      for await (const event of queue) {
+        yield event;
+      }
+    } finally {
+      this.pending.delete(id);
+    }
+  }
+
+  private async sendRequest<T extends WorkerResult>(request: WorkerRequest, timeoutMs?: number): Promise<T> {
+    this.ensureStarted();
+
+    return await new Promise<T>((resolveRequest, reject) => {
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      const clearRequestTimeout = () => {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+      };
+
+      this.pending.set(request.id, {
+        kind: 'request',
+        resolve: (value) => {
+          clearRequestTimeout();
+          resolveRequest(value as T);
+        },
+        reject: (error) => {
+          clearRequestTimeout();
+          reject(error);
+        },
+      });
+
+      if (timeoutMs) {
+        timeout = setTimeout(() => {
+          this.pending.delete(request.id);
+          reject(new Error(`Hermes worker did not respond within ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
+
+      try {
+        this.write(request);
+      } catch (error) {
+        clearRequestTimeout();
+        this.pending.delete(request.id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private ensureStarted(): void {
+    if (this.child && !this.child.killed && this.child.exitCode === null) return;
+
+    const python = resolvePython();
+    const script = resolveWorkerScript();
+    const workspace = resolveWorkspaceDir();
+    mkdirSync(workspace, { recursive: true });
+    const child = spawn(python, [script], {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        HERMES_QUIET: '1',
+        HERMES_YOLO_MODE: '1',
+      },
+    });
+
+    this.child = child;
+    this.ready = false;
+    this.readline = createInterface({ input: child.stdout });
+    this.readline.on('line', (line) => this.handleLine(line));
+    child.stderr.on('data', (chunk) => process.stderr.write(String(chunk)));
+    child.on('error', (error) => this.handleExit(error));
+    child.on('exit', (code, signal) => {
+      this.handleExit(new Error(`Hermes worker exited (${signal ?? code ?? 'unknown'})`));
+    });
+  }
+
+  private handleLine(line: string): void {
+    let event: WorkerEvent;
+    try {
+      event = JSON.parse(line) as WorkerEvent;
+    } catch {
+      process.stderr.write(`[hermes-worker] non-json stdout: ${line}\n`);
+      return;
+    }
+
+    const pending = this.pending.get(event.id);
+    if (!pending) return;
+
+    if (pending.kind === 'request') {
+      if (event.type === 'result') {
+        this.pending.delete(event.id);
+        pending.resolve(event.data);
+      } else if (event.type === 'error') {
+        this.pending.delete(event.id);
+        pending.reject(new HermesWorkerError(event.error));
+      }
+      return;
+    }
+
+    if (pending.kind !== 'stream') return;
+
+    pending.push(event);
+    if (event.type === 'done') {
+      this.pending.delete(event.id);
+      pending.end();
+    }
+  }
+
+  private handleExit(error: Error): void {
+    if (this.readline) {
+      this.readline.close();
+      this.readline = null;
+    }
+    this.child = null;
+    this.ready = false;
+
+    this.failPending(new Error(`Hermes worker crashed: ${error.message}`));
+  }
+
+  private write(request: WorkerRequest): void {
+    if (!this.child || !this.child.stdin.writable) {
+      throw new Error('Hermes worker is not running');
+    }
+    this.child.stdin.write(`${JSON.stringify(request)}\n`);
+  }
+
+  private failPending(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      if (pending.kind === 'request') pending.reject(error);
+      else pending.fail(error);
+      this.pending.delete(id);
+    }
+  }
+}
+
+export class HermesWorkerAdapter implements AgentAdapter, GoalCapableAdapter {
+  private client = new HermesWorkerClient();
+
+  async start(): Promise<void> {
+    await this.client.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.client.stop();
+  }
+
+  async *chatStream(
+    sessionId: string,
+    message: string,
+    options?: AgentRunOptions,
+  ): AsyncIterable<StreamEvent> {
+    for await (const event of this.client.stream({
+      type: 'chat',
+      sessionId,
+      message,
+      systemMessage: options?.systemMessage,
+      settings: options?.settings ?? {},
+      taskId: sessionId,
+    })) {
+      switch (event.type) {
+        case 'text_delta':
+          yield { type: 'text_delta', content: event.content ?? '' };
+          break;
+        case 'thinking_delta':
+          yield { type: 'thinking_delta', content: event.content ?? '' };
+          break;
+        case 'tool_progress':
+          yield {
+            type: 'tool_progress',
+            tool: event.tool ?? 'tool',
+            status: event.status ?? 'running',
+            duration: event.duration,
+            label: event.label ?? undefined,
+          };
+          break;
+        case 'error':
+          yield {
+            type: 'error',
+            error: formatWorkerError(event.error),
+            code: workerErrorCode(event.error),
+            hint: workerErrorHint(event.error),
+          };
+          break;
+        case 'done':
+          yield {
+            type: 'done',
+            sessionId: event.sessionId ?? sessionId,
+            context: event.context,
+            usage: event.usage,
+            interrupted: event.interrupted,
+          };
+          break;
+        case 'result':
+          break;
+      }
+    }
+  }
+
+  async interruptChat(sessionId: string, reason?: string): Promise<boolean> {
+    const result = await this.client.request<{ interrupted: boolean }>({
+      type: 'chat.interrupt',
+      sessionId,
+      taskId: sessionId,
+      reason,
+    }, WORKER_INTERRUPT_TIMEOUT_MS);
+    return result.interrupted;
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.client.start();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    const result = await this.client.request<{ messages: HermesMessage[] }>({
+      type: 'session.messages.get',
+      sessionId,
+      taskId: sessionId,
+    });
+    return result.messages;
+  }
+
+  async getSessionMetadata(sessionId: string): Promise<SessionMetadata | null> {
+    const result = await this.client.request<{ session: SessionMetadata | null }>({
+      type: 'session.get',
+      sessionId,
+    });
+    return result.session;
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    const result = await this.client.request<{ deleted: boolean }>({
+      type: 'session.delete',
+      sessionId,
+    });
+    return result.deleted;
+  }
+
+  async getModels(): Promise<AgentModelsResponse> {
+    return await this.client.request<AgentModelsResponse>('models.list');
+  }
+
+  async getDefaults(): Promise<AgentDefaults> {
+    return await this.client.request<AgentDefaults>('settings.get');
+  }
+
+  // --- Goal primitives (reserved for the goal-mode fast-follow) -------------
+
+  async getGoalStatus(sessionId: string): Promise<GoalStateSnapshot | null> {
+    const result = await this.client.request<{ goal: GoalStateSnapshot | null }>({
+      type: 'goal.status',
+      sessionId,
+    });
+    return result.goal;
+  }
+
+  async setGoal(
+    sessionId: string,
+    goal: string,
+    options?: { maxTurns?: number | null },
+  ): Promise<GoalStateSnapshot> {
+    const result = await this.client.request<{ goal: GoalStateSnapshot | null }>({
+      type: 'goal.set',
+      sessionId,
+      goal,
+      maxTurns: options?.maxTurns,
+    });
+    if (!result.goal) throw new Error('Hermes did not return goal state');
+    return result.goal;
+  }
+
+  async pauseGoal(sessionId: string, reason?: string): Promise<GoalStateSnapshot | null> {
+    const result = await this.client.request<{ goal: GoalStateSnapshot | null }>({
+      type: 'goal.pause',
+      sessionId,
+      reason,
+    });
+    return result.goal;
+  }
+
+  async resumeGoal(sessionId: string): Promise<GoalStateSnapshot | null> {
+    const result = await this.client.request<{ goal: GoalStateSnapshot | null }>({
+      type: 'goal.resume',
+      sessionId,
+    });
+    return result.goal;
+  }
+
+  async clearGoal(sessionId: string): Promise<boolean> {
+    const result = await this.client.request<{ cleared: boolean }>({
+      type: 'goal.clear',
+      sessionId,
+    });
+    return result.cleared;
+  }
+
+  async evaluateGoal(sessionId: string, responseText: string): Promise<GoalDecision> {
+    return await this.client.request<GoalDecision>({
+      type: 'goal.evaluate',
+      sessionId,
+      responseText,
+    });
+  }
+}

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -1,0 +1,82 @@
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  AgentRunSettings,
+  ContextUsage,
+  GoalDecision,
+  GoalStateSnapshot,
+  HermesMessage,
+  SessionMetadata,
+  TurnUsage,
+} from '../../shared/types.js';
+
+export type { AgentRunSettings, ContextUsage };
+
+export interface AgentRunOptions {
+  /** Optional system prompt. The gateway is a thin passthrough and normally
+   *  leaves this unset, so the caller's input reaches the agent verbatim. */
+  systemMessage?: string;
+  settings?: AgentRunSettings;
+}
+
+/** A normalized streaming event from an agent turn. */
+export interface StreamEvent {
+  type: 'text_delta' | 'thinking_delta' | 'tool_progress' | 'done' | 'error';
+  content?: string;
+  error?: string;
+  code?: string;
+  hint?: string;
+  sessionId?: string;
+  tool?: string;
+  status?: 'running' | 'completed' | 'error';
+  duration?: number;
+  label?: string;
+  context?: ContextUsage | null;
+  usage?: TurnUsage | null;
+  interrupted?: boolean;
+}
+
+/**
+ * The seam every agent backend implements. v1 ships one implementation,
+ * HermesWorkerAdapter; OpenClaw and Claude Code adapters slot in here later.
+ */
+export interface AgentAdapter {
+  /** Stream a single turn. The async iterable ends after a `done` or `error`. */
+  chatStream(
+    sessionId: string,
+    message: string,
+    options?: AgentRunOptions,
+  ): AsyncIterable<StreamEvent>;
+
+  /** Stop a running turn for a session. Returns whether anything was stopped. */
+  interruptChat(sessionId: string, reason?: string): Promise<boolean>;
+
+  /** True when the backend is reachable and ready. */
+  healthCheck(): Promise<boolean>;
+
+  /** Projected transcript for a session, from the backend's own store. */
+  getMessages(sessionId: string): Promise<HermesMessage[]>;
+
+  /** Token/cost metadata for a session. */
+  getSessionMetadata(sessionId: string): Promise<SessionMetadata | null>;
+
+  /** Best-effort delete of the backend's transcript for a session. */
+  deleteSession(sessionId: string): Promise<boolean>;
+
+  /** Models the backend can run. */
+  getModels(): Promise<AgentModelsResponse>;
+
+  /** The backend's current default model/provider/reasoning. */
+  getDefaults(): Promise<AgentDefaults>;
+}
+
+/** Goal-mode primitives, implemented by the worker and reserved for the
+ *  goal-mode fast-follow. Not part of the v1 request path. */
+export interface GoalCapableAdapter {
+  getGoalStatus(sessionId: string): Promise<GoalStateSnapshot | null>;
+  setGoal(sessionId: string, goal: string, options?: { maxTurns?: number | null }): Promise<GoalStateSnapshot>;
+  pauseGoal(sessionId: string, reason?: string): Promise<GoalStateSnapshot | null>;
+  resumeGoal(sessionId: string): Promise<GoalStateSnapshot | null>;
+  clearGoal(sessionId: string): Promise<boolean>;
+  evaluateGoal(sessionId: string, responseText: string): Promise<GoalDecision>;
+}

--- a/server/adapters/worker-protocol.ts
+++ b/server/adapters/worker-protocol.ts
@@ -1,0 +1,77 @@
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  AgentRunSettings,
+  ContextUsage,
+  GoalDecision,
+  GoalStateSnapshot,
+  HermesMessage,
+  SessionMetadata,
+  TurnUsage,
+} from '../../shared/types.js';
+
+export type WorkerRequest =
+  | { id: string; type: 'health' }
+  | { id: string; type: 'settings.get' }
+  | { id: string; type: 'settings.set'; provider?: string | null; model?: string | null; reasoningEffort?: string | null }
+  | { id: string; type: 'models.list' }
+  | { id: string; type: 'session.messages.get'; sessionId: string; taskId?: string }
+  | { id: string; type: 'session.get'; sessionId: string }
+  | { id: string; type: 'session.delete'; sessionId: string }
+  | { id: string; type: 'goal.status'; sessionId: string }
+  | { id: string; type: 'goal.set'; sessionId: string; goal: string; maxTurns?: number | null }
+  | { id: string; type: 'goal.pause'; sessionId: string; reason?: string }
+  | { id: string; type: 'goal.resume'; sessionId: string }
+  | { id: string; type: 'goal.clear'; sessionId: string }
+  | { id: string; type: 'goal.evaluate'; sessionId: string; responseText: string }
+  | { id: string; type: 'chat.interrupt'; sessionId: string; taskId?: string; reason?: string }
+  | {
+      id: string;
+      type: 'chat';
+      sessionId: string;
+      message: string;
+      systemMessage?: string;
+      settings: AgentRunSettings;
+      taskId?: string;
+      taskTitle?: string | null;
+    };
+
+export interface WorkerErrorPayload {
+  message: string;
+  code?: string;
+  hint?: string;
+}
+
+export type WorkerResult =
+  | { ok: boolean; agentDir?: string | null; python?: string | null }
+  | AgentDefaults
+  | AgentModelsResponse
+  | { messages: HermesMessage[] }
+  | { session: SessionMetadata | null }
+  | { deleted: boolean }
+  | { goal: GoalStateSnapshot | null }
+  | { cleared: boolean }
+  | { interrupted: boolean }
+  | GoalDecision;
+
+export type WorkerEvent =
+  | { id: string; type: 'result'; data: WorkerResult }
+  | { id: string; type: 'text_delta'; content?: string }
+  | { id: string; type: 'thinking_delta'; content?: string }
+  | {
+      id: string;
+      type: 'tool_progress';
+      tool?: string;
+      status?: 'running' | 'completed' | 'error';
+      duration?: number;
+      label?: string | null;
+    }
+  | {
+      id: string;
+      type: 'done';
+      sessionId?: string;
+      context?: ContextUsage | null;
+      usage?: TurnUsage | null;
+      interrupted?: boolean;
+    }
+  | { id: string; type: 'error'; error: string | WorkerErrorPayload };

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -1,0 +1,20 @@
+import { HermesWorkerAdapter } from './adapters/hermes-worker.js';
+import type { AgentAdapter } from './adapters/types.js';
+
+/** An AgentAdapter plus the optional process lifecycle the worker-backed
+ *  implementation needs. */
+export interface GatewayAdapter extends AgentAdapter {
+  start?(): Promise<void>;
+  stop?(): Promise<void>;
+}
+
+// The single agent backend this build routes to. It's an exported `let` (a live
+// ESM binding) so tests can swap in a deterministic fake via setAdapter() and
+// every importer immediately sees it. Adding OpenClaw / Claude Code later means
+// selecting an adapter here.
+export let adapter: GatewayAdapter = new HermesWorkerAdapter();
+
+/** Replace the agent backend. Intended for tests. */
+export function setAdapter(next: GatewayAdapter): void {
+  adapter = next;
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,62 @@
+import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import cors from 'cors';
+import { adapter } from './agent.js';
+import { responsesRouter } from './routes/responses.js';
+import { sessionsRouter } from './routes/sessions.js';
+import { modelsRouter } from './routes/models.js';
+import { getAppVersion } from './version.js';
+import { GatewayError } from './errors.js';
+
+const app = express();
+
+app.use(cors());
+// A turn request is small (input text + a few fields). Keep the limit modest so
+// an oversized body can't be a memory vector; oversize → 413 payload_too_large.
+app.use(express.json({ limit: '2mb' }));
+
+app.get('/v1/health', async (_req, res) => {
+  const hermes = await adapter.healthCheck();
+  res.json({ ok: true, hermes });
+});
+
+app.get('/v1/version', (_req, res) => {
+  res.json(getAppVersion());
+});
+
+app.use('/v1/responses', responsesRouter);
+app.use('/v1/sessions', sessionsRouter);
+app.use('/v1/models', modelsRouter);
+
+// Unknown route → documented JSON error body.
+app.use((req: Request, res: Response) => {
+  res.status(404).json({
+    error: { code: 'not_found', message: `No route for ${req.method} ${req.path}.` },
+  });
+});
+
+// Central error handler. Renders the stable `{ error: { code, message, ... } }`
+// body. Once an SSE stream's headers are sent we can't emit JSON, so defer.
+app.use((error: unknown, _req: Request, res: Response, next: NextFunction) => {
+  if (res.headersSent) return next(error);
+
+  if (error instanceof GatewayError) {
+    res.status(error.status).json(error.toBody());
+    return;
+  }
+
+  const type = (error as { type?: string } | null)?.type;
+  if (type === 'entity.too.large') {
+    res.status(413).json({ error: { code: 'payload_too_large', message: 'Request body is too large.' } });
+    return;
+  }
+  if (type === 'entity.parse.failed') {
+    res.status(400).json({ error: { code: 'validation_error', message: 'Request body is not valid JSON.' } });
+    return;
+  }
+
+  console.error('Unhandled error:', error);
+  res.status(500).json({ error: { code: 'internal_error', message: 'Something went wrong.' } });
+});
+
+export default app;

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,0 +1,21 @@
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveGatewayDbPath, ensureGatewayStateDirs } from '../paths.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+ensureGatewayStateDirs();
+
+const dbPath = resolveGatewayDbPath();
+
+const db: import('better-sqlite3').Database = new Database(dbPath);
+
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+const schema = readFileSync(join(__dirname, 'schema.sql'), 'utf-8');
+db.exec(schema);
+
+export default db;

--- a/server/db/queries.ts
+++ b/server/db/queries.ts
@@ -1,0 +1,197 @@
+import db from './index.js';
+import type {
+  AgentName,
+  ApiError,
+  ResponseObject,
+  ResponseStatus,
+  SessionObject,
+  TurnUsage,
+} from '../../shared/types.js';
+
+// --- Row shapes -------------------------------------------------------------
+
+interface SessionRow {
+  id: string;
+  agent: string;
+  model: string | null;
+  provider: string | null;
+  created: number;
+  last_response_at: number | null;
+}
+
+interface ResponseRow {
+  id: string;
+  session_id: string;
+  status: string;
+  agent: string;
+  model: string | null;
+  provider: string | null;
+  output_text: string;
+  usage: string | null;
+  error: string | null;
+  metadata: string | null;
+  created: number;
+}
+
+function parseJson<T>(value: string | null): T | null {
+  if (value == null) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Serialize a value for a nullable JSON column: null/undefined stays SQL NULL. */
+function stringifyJson(value: unknown): string | null {
+  return value == null ? null : JSON.stringify(value);
+}
+
+function rowToSession(row: SessionRow): SessionObject {
+  return {
+    id: row.id,
+    agent: row.agent as AgentName,
+    model: row.model,
+    provider: row.provider,
+    created: row.created,
+    last_response_at: row.last_response_at,
+  };
+}
+
+function rowToResponse(row: ResponseRow): ResponseObject {
+  return {
+    id: row.id,
+    session_id: row.session_id,
+    status: row.status as ResponseStatus,
+    agent: row.agent as AgentName,
+    model: row.model,
+    provider: row.provider,
+    output_text: row.output_text,
+    usage: parseJson<TurnUsage>(row.usage),
+    error: parseJson<ApiError>(row.error),
+    metadata: parseJson<Record<string, unknown>>(row.metadata),
+    created: row.created,
+  };
+}
+
+// --- Sessions ---------------------------------------------------------------
+
+const stmtInsertSession = db.prepare(`
+  INSERT INTO sessions (id, agent, model, provider, created, last_response_at)
+  VALUES (@id, @agent, @model, @provider, @created, @last_response_at)
+`);
+const stmtGetSession = db.prepare('SELECT * FROM sessions WHERE id = ?');
+const stmtListSessions = db.prepare('SELECT * FROM sessions ORDER BY created DESC');
+const stmtSetSessionModel = db.prepare('UPDATE sessions SET model = @model, provider = @provider WHERE id = @id');
+const stmtMarkSessionResponded = db.prepare('UPDATE sessions SET last_response_at = @at WHERE id = @id');
+const stmtDeleteSession = db.prepare('DELETE FROM sessions WHERE id = ?');
+
+export function insertSession(input: {
+  id: string;
+  agent: AgentName;
+  model?: string | null;
+  provider?: string | null;
+}): SessionObject {
+  const row: SessionRow = {
+    id: input.id,
+    agent: input.agent,
+    model: input.model ?? null,
+    provider: input.provider ?? null,
+    created: Date.now(),
+    last_response_at: null,
+  };
+  stmtInsertSession.run(row);
+  return rowToSession(row);
+}
+
+export function getSession(id: string): SessionObject | undefined {
+  const row = stmtGetSession.get(id) as SessionRow | undefined;
+  return row ? rowToSession(row) : undefined;
+}
+
+export function listSessions(): SessionObject[] {
+  return (stmtListSessions.all() as SessionRow[]).map(rowToSession);
+}
+
+export function setSessionModel(id: string, model: string | null, provider: string | null): void {
+  stmtSetSessionModel.run({ id, model, provider });
+}
+
+export function markSessionResponded(id: string, at = Date.now()): void {
+  stmtMarkSessionResponded.run({ id, at });
+}
+
+export function deleteSession(id: string): boolean {
+  return stmtDeleteSession.run(id).changes > 0;
+}
+
+// --- Responses --------------------------------------------------------------
+
+const stmtInsertResponse = db.prepare(`
+  INSERT INTO responses (id, session_id, status, agent, model, provider, output_text, usage, error, metadata, created)
+  VALUES (@id, @session_id, @status, @agent, @model, @provider, '', NULL, NULL, @metadata, @created)
+`);
+const stmtGetResponse = db.prepare('SELECT * FROM responses WHERE id = ?');
+const stmtDeleteResponsesForSession = db.prepare('DELETE FROM responses WHERE session_id = ?');
+const stmtFinalizeResponse = db.prepare(`
+  UPDATE responses
+  SET status = @status, output_text = @output_text, usage = @usage, error = @error,
+      model = @model, provider = @provider
+  WHERE id = @id
+`);
+const stmtSetResponseStatus = db.prepare('UPDATE responses SET status = @status WHERE id = @id');
+
+export function insertResponse(input: {
+  id: string;
+  session_id: string;
+  agent: AgentName;
+  model?: string | null;
+  provider?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): void {
+  stmtInsertResponse.run({
+    id: input.id,
+    session_id: input.session_id,
+    status: 'in_progress' satisfies ResponseStatus,
+    agent: input.agent,
+    model: input.model ?? null,
+    provider: input.provider ?? null,
+    metadata: stringifyJson(input.metadata),
+    created: Date.now(),
+  });
+}
+
+export function getResponse(id: string): ResponseObject | undefined {
+  const row = stmtGetResponse.get(id) as ResponseRow | undefined;
+  return row ? rowToResponse(row) : undefined;
+}
+
+export function finalizeResponse(
+  id: string,
+  fields: {
+    status: ResponseStatus;
+    output_text: string;
+    usage: TurnUsage | null;
+    error: ApiError | null;
+    model: string | null;
+    provider: string | null;
+  },
+): void {
+  stmtFinalizeResponse.run({
+    id,
+    status: fields.status,
+    output_text: fields.output_text,
+    usage: stringifyJson(fields.usage),
+    error: stringifyJson(fields.error),
+    model: fields.model,
+    provider: fields.provider,
+  });
+}
+
+export function setResponseStatus(id: string, status: ResponseStatus): void {
+  stmtSetResponseStatus.run({ id, status });
+}
+
+export function deleteResponsesForSession(sessionId: string): number {
+  return stmtDeleteResponsesForSession.run(sessionId).changes;
+}

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -1,0 +1,29 @@
+-- Gateway metadata only. Transcript history lives in Hermes' SessionDB and is
+-- projected on demand; we never duplicate messages here.
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id                TEXT PRIMARY KEY,
+  agent             TEXT NOT NULL DEFAULT 'hermes',
+  model             TEXT,
+  provider          TEXT,
+  created           INTEGER NOT NULL,
+  last_response_at  INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_created ON sessions(created DESC);
+
+CREATE TABLE IF NOT EXISTS responses (
+  id           TEXT PRIMARY KEY,
+  session_id   TEXT NOT NULL,
+  status       TEXT NOT NULL DEFAULT 'in_progress',
+  agent        TEXT NOT NULL DEFAULT 'hermes',
+  model        TEXT,
+  provider     TEXT,
+  output_text  TEXT NOT NULL DEFAULT '',
+  usage        TEXT,   -- JSON: TurnUsage
+  error        TEXT,   -- JSON: ApiError
+  metadata     TEXT,   -- JSON: arbitrary key/value echoed back
+  created      INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_responses_session ON responses(session_id, created DESC);

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,0 +1,138 @@
+import type { ApiError } from '../shared/types.js';
+
+/**
+ * An error that carries an HTTP status and the stable, machine-readable body
+ * (see the error-code table in the README). Throw these from routes; the error
+ * middleware renders them as `{ error: { code, message, param?, hint? } }`.
+ */
+export class GatewayError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly param?: string;
+  readonly hint?: string;
+
+  constructor(
+    status: number,
+    code: string,
+    message: string,
+    options?: { param?: string; hint?: string },
+  ) {
+    super(message);
+    this.name = 'GatewayError';
+    this.status = status;
+    this.code = code;
+    this.param = options?.param;
+    this.hint = options?.hint;
+  }
+
+  toBody(): { error: ApiError } {
+    const error: ApiError = { code: this.code, message: this.message };
+    if (this.param) error.param = this.param;
+    if (this.hint) error.hint = this.hint;
+    return { error };
+  }
+}
+
+export function validationError(message: string, param?: string, hint?: string): GatewayError {
+  return new GatewayError(400, 'validation_error', message, { param, hint });
+}
+
+export function sessionNotFound(id: string): GatewayError {
+  return new GatewayError(404, 'session_not_found', `No session with id '${id}'.`);
+}
+
+export function responseNotFound(id: string): GatewayError {
+  return new GatewayError(404, 'response_not_found', `No response with id '${id}'.`);
+}
+
+export function sessionBusy(): GatewayError {
+  return new GatewayError(409, 'session_busy', 'A response is already running on this session.', {
+    hint: 'Cancel the running response, or start another session.',
+  });
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function toErrorMessage(error: unknown, fallback = 'Something went wrong'): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function errorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const code = (error as Error & { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+/**
+ * The HTTP status and documented-style API code for each known worker error
+ * code, defined once so the two stay in sync. The 503 group is "instance not
+ * ready / Hermes unavailable". Codes absent here (auth_error, quota_exhausted,
+ * model_error, invalid_provider, provider_error, worker_error, …) fall through
+ * to the defaults: a 502 (the upstream agent failed) and the raw code as its
+ * own API code.
+ */
+const WORKER_CODE_MAP: Record<string, { status: number; apiCode: string }> = {
+  bad_request: { status: 400, apiCode: 'validation_error' },
+  task_busy: { status: 409, apiCode: 'session_busy' },
+  rate_limit: { status: 429, apiCode: 'rate_limited' },
+  hermes_not_found: { status: 503, apiCode: 'hermes_not_found' },
+  import_error: { status: 503, apiCode: 'import_error' },
+  session_db_unavailable: { status: 503, apiCode: 'session_db_unavailable' },
+  session_load_error: { status: 503, apiCode: 'session_load_error' },
+};
+
+/** Map a worker error code to the HTTP status the gateway should return. */
+function httpStatusForWorkerCode(code: string | undefined): number {
+  return (code ? WORKER_CODE_MAP[code]?.status : undefined) ?? 502;
+}
+
+/** Translate an internal worker code to a documented-style API code. */
+function apiCodeForWorkerCode(code: string | undefined): string {
+  if (!code) return 'agent_error';
+  return WORKER_CODE_MAP[code]?.apiCode ?? code;
+}
+
+/**
+ * Convert an error thrown by the adapter/worker into a GatewayError suitable
+ * for an HTTP response (used by non-streaming calls: models, session reads).
+ */
+export function gatewayErrorFromWorker(error: unknown, fallback = 'Agent request failed'): GatewayError {
+  if (error instanceof GatewayError) return error;
+  const code = errorCode(error);
+  const message = toErrorMessage(error, fallback);
+  const hint = error instanceof Error ? (error as Error & { hint?: string }).hint : undefined;
+  return new GatewayError(httpStatusForWorkerCode(code), apiCodeForWorkerCode(code), message, {
+    hint: typeof hint === 'string' ? hint : undefined,
+  });
+}
+
+/** Build a `response.failed` error body from a worker `error` stream event. */
+export function apiErrorFromStreamEvent(
+  event: { code?: string; error?: string; hint?: string },
+  fallback = 'The turn ended on an error.',
+): ApiError {
+  const apiError: ApiError = {
+    code: apiCodeForWorkerCode(event.code),
+    message: event.error ?? fallback,
+  };
+  if (event.hint) apiError.hint = event.hint;
+  return apiError;
+}
+
+/** Build the streamed `response.failed` error body from any caught error. */
+export function apiErrorFromUnknown(error: unknown, fallback = 'The turn ended on an error.'): ApiError {
+  if (error instanceof GatewayError) {
+    const body = error.toBody().error;
+    return body;
+  }
+  const code = errorCode(error);
+  const hint = error instanceof Error ? (error as Error & { hint?: string }).hint : undefined;
+  const apiError: ApiError = {
+    code: apiCodeForWorkerCode(code),
+    message: toErrorMessage(error, fallback),
+  };
+  if (typeof hint === 'string') apiError.hint = hint;
+  return apiError;
+}

--- a/server/ids.ts
+++ b/server/ids.ts
@@ -1,0 +1,24 @@
+import { randomUUID } from 'node:crypto';
+
+function compactUuid(): string {
+  return randomUUID().replace(/-/g, '');
+}
+
+/** Mint a session id. Used verbatim as the Hermes session id (the worker
+ *  resolves Hermes resume/compression chains internally). */
+export function newSessionId(): string {
+  return `sess_${compactUuid()}`;
+}
+
+/** Mint a response id for a single turn. */
+export function newResponseId(): string {
+  return `resp_${compactUuid()}`;
+}
+
+export function isSessionId(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith('sess_');
+}
+
+export function isResponseId(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith('resp_');
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,103 @@
+import 'dotenv/config';
+import './logging.js';
+import './db/index.js';
+import { createServer, type Server } from 'node:http';
+import app from './app.js';
+import { adapter } from './agent.js';
+import { shutdownLiveRuns } from './live-runs.js';
+
+const PORT = parseInt(process.env.PORT || '3737', 10);
+const HOST = process.env.HOST || '0.0.0.0';
+const PORT_FALLBACK_ATTEMPTS = 20;
+
+const httpServer = createServer(app);
+let shuttingDown = false;
+
+type ShutdownReason = NodeJS.Signals | 'startup-error';
+
+async function listenWithFallback(server: Server, startPort: number, maxAttempts: number): Promise<number> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const tryPort = startPort + i;
+    try {
+      await new Promise<void>((resolveListen, rejectListen) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.off('listening', onListening);
+          rejectListen(err);
+        };
+        const onListening = () => {
+          server.off('error', onError);
+          resolveListen();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(tryPort, HOST);
+      });
+      if (tryPort !== startPort) {
+        console.warn(`Port ${startPort} was busy — using port ${tryPort} instead.`);
+      }
+      return tryPort;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
+    }
+  }
+  throw new Error(`Could not find a free port after ${maxAttempts} attempts starting from ${startPort}.`);
+}
+
+async function main() {
+  try {
+    await adapter.start?.();
+  } catch (error) {
+    console.error(
+      'Hermes worker failed to start — the gateway will serve but agent calls fail until the worker recovers:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+
+  const boundPort = await listenWithFallback(httpServer, PORT, PORT_FALLBACK_ATTEMPTS);
+  console.log(`Agent37 Gateway listening on http://${HOST}:${boundPort}`);
+}
+
+function closeHttpServer(): Promise<void> {
+  return new Promise((resolveClose, rejectClose) => {
+    if (!httpServer.listening) {
+      resolveClose();
+      return;
+    }
+    httpServer.close((error?: Error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+    httpServer.closeAllConnections();
+  });
+}
+
+async function shutdown(reason: ShutdownReason, exitCode = 0): Promise<void> {
+  if (shuttingDown) {
+    httpServer.closeAllConnections();
+    process.exit(1);
+  }
+  shuttingDown = true;
+
+  const forceExit = setTimeout(() => {
+    console.error(`Forced shutdown after ${reason}`);
+    process.exit(1);
+  }, 5000);
+  forceExit.unref();
+
+  shutdownLiveRuns();
+  const results = await Promise.allSettled([closeHttpServer(), adapter.stop?.() ?? Promise.resolve()]);
+  for (const result of results) {
+    if (result.status === 'rejected') console.error(result.reason);
+  }
+
+  clearTimeout(forceExit);
+  process.exit(results.some((result) => result.status === 'rejected') ? 1 : exitCode);
+}
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));
+
+main().catch((error) => {
+  console.error(error);
+  void shutdown('startup-error', 1);
+});

--- a/server/live-runs.ts
+++ b/server/live-runs.ts
@@ -1,0 +1,172 @@
+import type { Response } from 'express';
+import type { ResponseStatus, ResponseStreamEvent } from '../shared/types.js';
+import { writeStreamEvent, writeComment } from './sse.js';
+
+// In-memory registry of in-flight (and just-finished) responses. It buffers the
+// ordered SSE events for each response so a dropped client can reconnect and
+// replay everything so far, then resume live. Durable response/session metadata
+// lives in SQLite; this is the ephemeral streaming layer.
+
+interface LiveRun {
+  responseId: string;
+  sessionId: string;
+  status: ResponseStatus;
+  events: ResponseStreamEvent[];
+  /** Set once the replay buffer hit its cap and stopped recording events. */
+  truncated: boolean;
+  finished: boolean;
+  subscribers: Set<Response>;
+  updatedAt: number;
+}
+
+/** Cap on buffered events per run, so a runaway agent can't exhaust the heap.
+ *  Live subscribers still receive every event; only reconnect-replay is capped. */
+const MAX_BUFFERED_EVENTS = 100_000;
+
+const runs = new Map<string, LiveRun>();
+/** sessionId -> responseId, only while that response is in_progress. */
+const activeBySession = new Map<string, string>();
+const expiryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const KEEPALIVE_INTERVAL_MS = 30_000;
+/** How long a finished run lingers in memory so late clients can replay it. */
+const FINISHED_TTL_MS = 60_000;
+
+let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+
+function startKeepalive(): void {
+  if (keepaliveTimer) return;
+  keepaliveTimer = setInterval(() => {
+    let anySubscribers = false;
+    for (const run of runs.values()) {
+      for (const subscriber of run.subscribers) {
+        anySubscribers = true;
+        if (!writeComment(subscriber, 'keepalive')) run.subscribers.delete(subscriber);
+      }
+    }
+    if (!anySubscribers && keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+      keepaliveTimer = null;
+    }
+  }, KEEPALIVE_INTERVAL_MS);
+  keepaliveTimer.unref();
+}
+
+function clearExpiry(responseId: string): void {
+  const timer = expiryTimers.get(responseId);
+  if (timer) {
+    clearTimeout(timer);
+    expiryTimers.delete(responseId);
+  }
+}
+
+export function createRun(responseId: string, sessionId: string): void {
+  clearExpiry(responseId);
+  runs.set(responseId, {
+    responseId,
+    sessionId,
+    status: 'in_progress',
+    events: [],
+    truncated: false,
+    finished: false,
+    subscribers: new Set(),
+    updatedAt: Date.now(),
+  });
+  activeBySession.set(sessionId, responseId);
+}
+
+/** Append an event to the buffer and fan it out to live subscribers. */
+export function emit(responseId: string, event: ResponseStreamEvent): void {
+  const run = runs.get(responseId);
+  if (!run) return;
+
+  if (run.events.length < MAX_BUFFERED_EVENTS) {
+    run.events.push(event);
+  } else if (!run.truncated) {
+    run.truncated = true;
+    console.warn(
+      `Live run ${responseId} exceeded ${MAX_BUFFERED_EVENTS} buffered events; reconnect replay will be partial.`,
+    );
+  }
+  run.updatedAt = Date.now();
+
+  for (const subscriber of run.subscribers) {
+    if (!writeStreamEvent(subscriber, event)) run.subscribers.delete(subscriber);
+  }
+}
+
+/** Mark a run terminal: end its live subscribers and schedule its removal. */
+export function markFinished(responseId: string, status: ResponseStatus): void {
+  const run = runs.get(responseId);
+  if (!run) return;
+  run.status = status;
+  run.finished = true;
+  run.updatedAt = Date.now();
+  if (activeBySession.get(run.sessionId) === responseId) {
+    activeBySession.delete(run.sessionId);
+  }
+  for (const subscriber of run.subscribers) {
+    try {
+      subscriber.end();
+    } catch {
+      // already closed
+    }
+  }
+  run.subscribers.clear();
+
+  clearExpiry(responseId);
+  const timer = setTimeout(() => {
+    runs.delete(responseId);
+    expiryTimers.delete(responseId);
+  }, FINISHED_TTL_MS);
+  timer.unref();
+  expiryTimers.set(responseId, timer);
+}
+
+export type AttachResult = 'attached' | 'finished' | 'missing';
+
+/**
+ * Replay the buffered events to a fresh SSE client, then either keep it
+ * subscribed for live events or signal that the run already finished (the
+ * caller should end the response).
+ */
+export function attach(responseId: string, res: Response): AttachResult {
+  const run = runs.get(responseId);
+  if (!run) return 'missing';
+
+  for (const event of run.events) {
+    writeStreamEvent(res, event);
+  }
+
+  if (run.finished) return 'finished';
+
+  run.subscribers.add(res);
+  res.on('close', () => {
+    run.subscribers.delete(res);
+  });
+  startKeepalive();
+  return 'attached';
+}
+
+/** The in_progress response on a session, if any. */
+export function activeResponseForSession(sessionId: string): string | undefined {
+  return activeBySession.get(sessionId);
+}
+
+export function hasRun(responseId: string): boolean {
+  return runs.has(responseId);
+}
+
+export function getRunStatus(responseId: string): ResponseStatus | undefined {
+  return runs.get(responseId)?.status;
+}
+
+/** Clear timers for a clean process shutdown. */
+export function shutdownLiveRuns(): void {
+  if (keepaliveTimer) {
+    clearInterval(keepaliveTimer);
+    keepaliveTimer = null;
+  }
+  for (const timer of expiryTimers.values()) clearTimeout(timer);
+  expiryTimers.clear();
+}

--- a/server/logging.ts
+++ b/server/logging.ts
@@ -1,0 +1,53 @@
+// Prefix every stdout/stderr line with an ISO timestamp, so container logs are
+// greppable by time. Installed once, on import.
+
+const installedSymbol = Symbol.for('agent37-gateway.timestampedLoggingInstalled');
+
+type WritableStream = typeof process.stdout | typeof process.stderr;
+
+function prefixLogLines(text: string, atLineStart: { value: boolean }): string {
+  let output = '';
+
+  for (const char of text) {
+    if (atLineStart.value) {
+      output += `[${new Date().toISOString()}] `;
+      atLineStart.value = false;
+    }
+
+    output += char;
+    if (char === '\n') atLineStart.value = true;
+  }
+
+  return output;
+}
+
+function installTimestampPrefix(stream: WritableStream): void {
+  const originalWrite = stream.write.bind(stream);
+  const atLineStart = { value: true };
+
+  stream.write = ((chunk: unknown, encodingOrCallback?: unknown, callback?: unknown) => {
+    const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+    const prefixed = prefixLogLines(text, atLineStart);
+
+    if (typeof encodingOrCallback === 'function') {
+      return originalWrite(prefixed, encodingOrCallback as (error?: Error | null) => void);
+    }
+
+    return originalWrite(
+      prefixed,
+      encodingOrCallback as BufferEncoding | undefined,
+      callback as ((error?: Error | null) => void) | undefined,
+    );
+  }) as typeof stream.write;
+}
+
+export function installTimestampedLogging(): void {
+  const globalState = globalThis as typeof globalThis & { [installedSymbol]?: boolean };
+  if (globalState[installedSymbol]) return;
+  globalState[installedSymbol] = true;
+
+  installTimestampPrefix(process.stdout);
+  installTimestampPrefix(process.stderr);
+}
+
+installTimestampedLogging();

--- a/server/paths.ts
+++ b/server/paths.ts
@@ -1,0 +1,53 @@
+import { mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+
+export function expandHomePrefix(value: string): string {
+  if (value === '~') return homedir();
+  if (value.startsWith('~/')) return join(homedir(), value.slice(2));
+  return value;
+}
+
+function resolveHomeAwarePath(value: string): string {
+  return resolve(expandHomePrefix(value));
+}
+
+/** Where Hermes itself is installed — used to locate its Python venv. */
+export function resolveHermesHome(): string {
+  const configured = process.env.HERMES_HOME?.trim();
+  return resolveHomeAwarePath(configured || '~/.hermes');
+}
+
+/** Root for all gateway state (SQLite db, logs, the agent's workspace). */
+export function resolveGatewayHome(): string {
+  const configured = process.env.AGENT37_GATEWAY_HOME?.trim();
+  return resolveHomeAwarePath(configured || '~/.agent37-gateway');
+}
+
+export function resolveGatewayDataDir(): string {
+  return join(resolveGatewayHome(), 'data');
+}
+
+export function resolveGatewayLogsDir(): string {
+  return join(resolveGatewayHome(), 'logs');
+}
+
+/** The working directory the Hermes worker runs in (where the agent writes files). */
+export function resolveWorkspaceDir(): string {
+  const configured = process.env.GATEWAY_WORKSPACE_DIR?.trim();
+  return resolveHomeAwarePath(configured || join(resolveGatewayHome(), 'workspace'));
+}
+
+export function resolveGatewayDbPath(): string {
+  const configured = process.env.DB_PATH?.trim();
+  if (configured) return resolveHomeAwarePath(configured);
+  return join(resolveGatewayDataDir(), 'gateway.db');
+}
+
+export function ensureGatewayStateDirs(): void {
+  const dbPath = resolveGatewayDbPath();
+  mkdirSync(resolveGatewayDataDir(), { recursive: true });
+  mkdirSync(resolveGatewayLogsDir(), { recursive: true });
+  mkdirSync(resolveWorkspaceDir(), { recursive: true });
+  mkdirSync(dirname(dbPath), { recursive: true });
+}

--- a/server/responses.ts
+++ b/server/responses.ts
@@ -1,0 +1,245 @@
+// Turn orchestration: the glue between an incoming request, the agent adapter,
+// the live SSE registry, and the SQLite metadata store.
+//
+//   beginResponse  — synchronously validate, create/continue a session, insert
+//                    the response row, register the live run, emit created.
+//   driveResponse  — async: consume the agent stream, emit documented SSE
+//                    events, accumulate, then persist the terminal state.
+
+import type { AgentRunSettings, StreamEvent } from './adapters/types.js';
+import type {
+  AgentName,
+  ApiError,
+  ReasoningEffort,
+  ResponseObject,
+  ResponseStatus,
+  ResponseStreamEvent,
+  TurnUsage,
+} from '../shared/types.js';
+import { adapter } from './agent.js';
+import {
+  activeResponseForSession,
+  createRun,
+  emit,
+  markFinished,
+} from './live-runs.js';
+import {
+  finalizeResponse,
+  getResponse,
+  getSession,
+  insertResponse,
+  insertSession,
+  markSessionResponded,
+  setResponseStatus,
+  setSessionModel,
+} from './db/queries.js';
+import {
+  apiErrorFromStreamEvent,
+  apiErrorFromUnknown,
+  responseNotFound,
+  sessionBusy,
+  sessionNotFound,
+} from './errors.js';
+import { newResponseId, newSessionId } from './ids.js';
+
+export interface ResponseRequest {
+  sessionId?: string;
+  input: string;
+  agent: AgentName;
+  model: string | null;
+  provider: string | null;
+  reasoningEffort: ReasoningEffort | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface BegunResponse {
+  responseId: string;
+  sessionId: string;
+  settings: AgentRunSettings;
+  model: string | null;
+  provider: string | null;
+}
+
+/**
+ * Validate the request, resolve (or create) the session, persist an
+ * in_progress response row, and register the live run. Synchronous so the
+ * one-active-turn-per-session check is atomic. Throws GatewayError.
+ */
+export function beginResponse(req: ResponseRequest): BegunResponse {
+  let session = req.sessionId ? getSession(req.sessionId) : undefined;
+  if (req.sessionId && !session) throw sessionNotFound(req.sessionId);
+
+  const sessionId = session?.id ?? newSessionId();
+
+  if (activeResponseForSession(sessionId)) throw sessionBusy();
+
+  if (!session) {
+    session = insertSession({
+      id: sessionId,
+      agent: req.agent,
+      model: req.model,
+      provider: req.provider,
+    });
+  } else if (req.model !== null || req.provider !== null) {
+    setSessionModel(sessionId, req.model ?? session.model, req.provider ?? session.provider);
+  }
+
+  const responseId = newResponseId();
+  insertResponse({
+    id: responseId,
+    session_id: sessionId,
+    agent: req.agent,
+    model: req.model,
+    provider: req.provider,
+    metadata: req.metadata,
+  });
+
+  createRun(responseId, sessionId);
+  emit(responseId, { event: 'response.created', data: { id: responseId, session_id: sessionId } });
+
+  const settings: AgentRunSettings = {
+    model: req.model ?? undefined,
+    provider: req.provider ?? undefined,
+    reasoningEffort: req.reasoningEffort ?? undefined,
+  };
+
+  return { responseId, sessionId, settings, model: req.model, provider: req.provider };
+}
+
+function emitToolProgress(responseId: string, event: StreamEvent): void {
+  const tool = event.tool ?? 'tool';
+  if (event.status === 'completed') {
+    emit(responseId, { event: 'response.tool_call.completed', data: { tool, duration_ms: event.duration } });
+  } else if (event.status === 'error') {
+    emit(responseId, { event: 'response.tool_call.failed', data: { tool, error: event.label } });
+  } else {
+    emit(responseId, { event: 'response.tool_call.started', data: { tool, label: event.label } });
+  }
+}
+
+/**
+ * Run the turn to completion: stream from the agent, emit SSE events into the
+ * live run, accumulate output/usage/error, persist the terminal state, and
+ * resolve with the final response. Never rejects for agent/stream failures —
+ * those become a `failed` response.
+ */
+export async function driveResponse(begun: BegunResponse, input: string): Promise<ResponseObject> {
+  const { responseId, sessionId, settings, model, provider } = begun;
+
+  let outputText = '';
+  let usage: TurnUsage | null = null;
+  let apiError: ApiError | null = null;
+  let status: ResponseStatus = 'completed';
+  let sawTerminal = false;
+
+  try {
+    for await (const event of adapter.chatStream(sessionId, input, { settings })) {
+      switch (event.type) {
+        case 'text_delta':
+          if (event.content) {
+            outputText += event.content;
+            emit(responseId, { event: 'response.output_text.delta', data: { text: event.content } });
+          }
+          break;
+        case 'thinking_delta':
+          if (event.content) {
+            emit(responseId, { event: 'response.reasoning.delta', data: { text: event.content } });
+          }
+          break;
+        case 'tool_progress':
+          emitToolProgress(responseId, event);
+          break;
+        case 'done':
+          sawTerminal = true;
+          usage = event.usage ?? null;
+          status = event.interrupted ? 'cancelled' : 'completed';
+          break;
+        case 'error':
+          sawTerminal = true;
+          status = 'failed';
+          apiError = apiErrorFromStreamEvent(event);
+          break;
+      }
+    }
+  } catch (error) {
+    sawTerminal = true;
+    status = 'failed';
+    apiError = apiErrorFromUnknown(error, 'Hermes chat stream failed');
+  }
+
+  // A stream that ended without an explicit terminal event: treat what we have
+  // as a completed turn rather than failing it.
+  if (!sawTerminal) status = 'completed';
+
+  if (status === 'failed' && apiError) {
+    emit(responseId, { event: 'response.failed', data: { error: apiError } });
+  } else {
+    emit(responseId, { event: 'response.completed', data: { output_text: outputText, usage } });
+  }
+
+  // Persist the terminal state, but ALWAYS release the session and end live
+  // subscribers (markFinished) even if the DB write fails — otherwise a failed
+  // write would leave the session locked and the row stuck at in_progress.
+  try {
+    finalizeResponse(responseId, { status, output_text: outputText, usage, error: apiError, model, provider });
+    if (status !== 'failed') markSessionResponded(sessionId);
+  } catch (persistError) {
+    console.error(`Failed to persist response ${responseId}:`, persistError);
+    try {
+      setResponseStatus(responseId, status);
+    } catch {
+      // Last resort: the row may remain in_progress, but the session is freed below.
+    }
+  } finally {
+    markFinished(responseId, status);
+  }
+
+  return (
+    getResponse(responseId) ?? {
+      id: responseId,
+      session_id: sessionId,
+      status,
+      agent: 'hermes',
+      model,
+      provider,
+      output_text: outputText,
+      usage,
+      error: apiError,
+      metadata: null,
+      created: Date.now(),
+    }
+  );
+}
+
+/**
+ * Request cancellation of a running turn. The interrupt is best-effort; the
+ * running driveResponse unwinds and persists the terminal `cancelled` status.
+ */
+export async function cancelResponse(responseId: string): Promise<ResponseObject> {
+  const response = getResponse(responseId);
+  if (!response) throw responseNotFound(responseId);
+  if (response.status === 'in_progress') {
+    await adapter.interruptChat(response.session_id);
+  }
+  return getResponse(responseId) ?? response;
+}
+
+/** Reconstruct a terminal response's stream from stored state, for reconnects
+ *  after the live run has expired from memory. */
+export function synthesizeStreamEvents(response: ResponseObject): ResponseStreamEvent[] {
+  const events: ResponseStreamEvent[] = [
+    { event: 'response.created', data: { id: response.id, session_id: response.session_id } },
+  ];
+  if (response.output_text) {
+    events.push({ event: 'response.output_text.delta', data: { text: response.output_text } });
+  }
+  if (response.status === 'failed' && response.error) {
+    events.push({ event: 'response.failed', data: { error: response.error } });
+  } else {
+    events.push({
+      event: 'response.completed',
+      data: { output_text: response.output_text, usage: response.usage },
+    });
+  }
+  return events;
+}

--- a/server/routes/models.ts
+++ b/server/routes/models.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import type { ModelInfo } from '../../shared/types.js';
+import { adapter } from '../agent.js';
+import { gatewayErrorFromWorker } from '../errors.js';
+
+export const modelsRouter = Router();
+
+// GET /v1/models — the models this instance's agent can run on.
+modelsRouter.get('/', async (_req, res, next) => {
+  try {
+    const models = await adapter.getModels();
+    const data: ModelInfo[] = [];
+    for (const group of models.groups) {
+      for (const model of group.models) {
+        data.push({
+          id: model.id,
+          label: model.label,
+          provider: model.provider ?? (group.provider || null),
+          is_default: Boolean(model.isCurrentDefault),
+        });
+      }
+    }
+    res.json({
+      default_model: models.defaultModel,
+      default_provider: models.activeProvider,
+      data,
+    });
+  } catch (error) {
+    next(gatewayErrorFromWorker(error, 'Could not list models'));
+  }
+});

--- a/server/routes/responses.ts
+++ b/server/routes/responses.ts
@@ -1,0 +1,165 @@
+import { Router } from 'express';
+import {
+  DEFAULT_AGENT,
+  REASONING_EFFORTS,
+  RESPONSE_MODES,
+  SUPPORTED_AGENTS,
+} from '../../shared/types.js';
+import { isRecord, responseNotFound, validationError } from '../errors.js';
+import { initSSE, writeStreamEvent } from '../sse.js';
+import { attach, hasRun } from '../live-runs.js';
+import { getResponse } from '../db/queries.js';
+import {
+  beginResponse,
+  cancelResponse,
+  driveResponse,
+  synthesizeStreamEvents,
+  type ResponseRequest,
+} from '../responses.js';
+
+export const responsesRouter = Router();
+
+function optionalString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string' || !value.trim()) {
+    throw validationError(`${field} must be a non-empty string.`, field);
+  }
+  return value;
+}
+
+/** An optional field constrained to a fixed set: absent → `fallback`, present →
+ *  validated against `allowed` (throws otherwise). */
+function optionalEnum<T extends string>(value: unknown, field: string, allowed: readonly T[], fallback: T): T;
+function optionalEnum<T extends string>(value: unknown, field: string, allowed: readonly T[], fallback: null): T | null;
+function optionalEnum<T extends string>(
+  value: unknown,
+  field: string,
+  allowed: readonly T[],
+  fallback: T | null,
+): T | null {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw validationError(`${field} must be one of: ${allowed.join(', ')}.`, field);
+  }
+  return value as T;
+}
+
+function parseResponseBody(body: unknown): { request: ResponseRequest; stream: boolean } {
+  const b = isRecord(body) ? body : {};
+
+  const input = b.input;
+  if (typeof input !== 'string' || !input.trim()) {
+    throw validationError('input is required and must be a non-empty string.', 'input');
+  }
+
+  let sessionId: string | undefined;
+  if (b.session_id !== undefined && b.session_id !== null) {
+    if (typeof b.session_id !== 'string' || !b.session_id) {
+      throw validationError('session_id must be a string.', 'session_id');
+    }
+    sessionId = b.session_id;
+  }
+
+  const agent = optionalEnum(b.agent, 'agent', SUPPORTED_AGENTS, DEFAULT_AGENT);
+
+  const mode = optionalEnum(b.mode, 'mode', RESPONSE_MODES, 'chat');
+  if (mode === 'goal') {
+    throw validationError('goal mode is not yet supported on this gateway.', 'mode', 'Use mode "chat".');
+  }
+
+  const model = optionalString(b.model, 'model');
+  const provider = optionalString(b.provider, 'provider');
+
+  const reasoningEffort = optionalEnum(b.reasoning_effort, 'reasoning_effort', REASONING_EFFORTS, null);
+
+  let metadata: Record<string, unknown> | null = null;
+  if (b.metadata !== undefined && b.metadata !== null) {
+    if (!isRecord(b.metadata)) throw validationError('metadata must be an object.', 'metadata');
+    if (Object.keys(b.metadata).length > 16) {
+      throw validationError('metadata supports at most 16 key/value pairs.', 'metadata');
+    }
+    if (JSON.stringify(b.metadata).length > 64 * 1024) {
+      throw validationError('metadata is too large (max 64KB serialized).', 'metadata');
+    }
+    metadata = b.metadata;
+  }
+
+  // instance_id is accepted for client compatibility and ignored: routing to a
+  // container is the Cloud layer's job; inside the container there is one gateway.
+
+  return {
+    request: { sessionId, input, agent, model, provider, reasoningEffort, metadata },
+    stream: b.stream === true,
+  };
+}
+
+// POST /v1/responses — run a turn (start a session or continue one).
+responsesRouter.post('/', async (req, res, next) => {
+  let begun;
+  let request: ResponseRequest;
+  let stream: boolean;
+  try {
+    const parsed = parseResponseBody(req.body);
+    request = parsed.request;
+    stream = parsed.stream;
+    begun = beginResponse(request);
+  } catch (error) {
+    return next(error);
+  }
+
+  if (stream) {
+    initSSE(res);
+    attach(begun.responseId, res); // replays the buffered response.created, then goes live
+    void driveResponse(begun, request.input).catch((error) => {
+      console.error('driveResponse crashed:', error);
+      try {
+        res.end();
+      } catch {
+        // already closed
+      }
+    });
+    return;
+  }
+
+  try {
+    const response = await driveResponse(begun, request.input);
+    res.status(200).json(response);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /v1/responses/:id — fetch a response by id.
+responsesRouter.get('/:id', (req, res, next) => {
+  const response = getResponse(req.params.id);
+  if (!response) return next(responseNotFound(req.params.id));
+  res.json(response);
+});
+
+// GET /v1/responses/:id/stream — reconnect: replay a snapshot, then resume live.
+responsesRouter.get('/:id/stream', (req, res, next) => {
+  const id = req.params.id;
+
+  if (!hasRun(id)) {
+    const stored = getResponse(id);
+    if (!stored) return next(responseNotFound(id));
+    // The live run expired from memory; replay a snapshot from stored state.
+    initSSE(res);
+    for (const event of synthesizeStreamEvents(stored)) writeStreamEvent(res, event);
+    res.end();
+    return;
+  }
+
+  initSSE(res);
+  if (attach(id, res) === 'finished') res.end();
+});
+
+// POST /v1/responses/:id/cancel — stop a running turn.
+responsesRouter.post('/:id/cancel', async (req, res, next) => {
+  try {
+    const response = await cancelResponse(req.params.id);
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import type { SessionMessage } from '../../shared/types.js';
+import { adapter } from '../agent.js';
+import { gatewayErrorFromWorker, sessionNotFound } from '../errors.js';
+import {
+  deleteResponsesForSession,
+  deleteSession,
+  getSession,
+  listSessions,
+} from '../db/queries.js';
+
+export const sessionsRouter = Router();
+
+// GET /v1/sessions — list the sessions on this instance.
+sessionsRouter.get('/', (_req, res) => {
+  res.json({ data: listSessions() });
+});
+
+// GET /v1/sessions/:id — the session with its full transcript history.
+sessionsRouter.get('/:id', async (req, res, next) => {
+  const session = getSession(req.params.id);
+  if (!session) return next(sessionNotFound(req.params.id));
+
+  // No turns yet → no Hermes session exists, so history is empty.
+  if (session.last_response_at === null) {
+    return res.json({ ...session, history: [] });
+  }
+
+  try {
+    const messages = await adapter.getMessages(session.id);
+    const history: SessionMessage[] = messages.map((m) => ({
+      id: m.id,
+      session_id: session.id,
+      role: m.role,
+      content: m.content,
+      thinking: m.thinking,
+      created_at: m.created_at,
+    }));
+    res.json({ ...session, history });
+  } catch (error) {
+    next(gatewayErrorFromWorker(error, 'Session history unavailable'));
+  }
+});
+
+// DELETE /v1/sessions/:id — remove the conversation and its history.
+sessionsRouter.delete('/:id', async (req, res, next) => {
+  const session = getSession(req.params.id);
+  if (!session) return next(sessionNotFound(req.params.id));
+
+  // Best-effort removal of the Hermes transcript before dropping our records.
+  try {
+    await adapter.deleteSession(session.id);
+  } catch {
+    // The gateway's own records still get cleaned up below.
+  }
+  deleteResponsesForSession(session.id);
+  deleteSession(session.id);
+
+  res.json({ id: session.id, deleted: true });
+});

--- a/server/sse.ts
+++ b/server/sse.ts
@@ -1,0 +1,40 @@
+import type { Response } from 'express';
+import type { ResponseStreamEvent } from '../shared/types.js';
+
+/** Set the headers that begin a Server-Sent Events stream. */
+export function initSSE(res: Response): void {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+}
+
+// These return TRUE when the subscriber is still usable and FALSE only when the
+// connection is genuinely dead. A `false` return from `res.write()` signals
+// backpressure (the buffer is full) — the data is still queued and delivered, so
+// it is NOT a failure. Only a throw, or an already-ended/destroyed stream, means
+// the subscriber should be dropped. (Full drain-based flow control is overkill
+// for a localhost gateway; we cap the per-run event buffer instead.)
+
+/** Write one named SSE frame (`event:` + `data:`), per docs/agents-api/streaming. */
+export function writeStreamEvent(res: Response, event: ResponseStreamEvent): boolean {
+  if (res.writableEnded || res.destroyed) return false;
+  try {
+    res.write(`event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Write an SSE comment line (used for keepalives). */
+export function writeComment(res: Response, text = ''): boolean {
+  if (res.writableEnded || res.destroyed) return false;
+  try {
+    res.write(`:${text}\n\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "../dist/server",
+    "rootDir": "..",
+    "resolveJsonModule": true,
+    "declaration": false
+  },
+  "include": [".", "../shared"]
+}

--- a/server/version.ts
+++ b/server/version.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AppVersion } from '../shared/types.js';
+
+const FALLBACK_VERSION: AppVersion = {
+  name: 'agent37-gateway',
+  version: 'unknown',
+};
+
+function readAppVersion(): AppVersion {
+  let dir = dirname(fileURLToPath(import.meta.url));
+
+  for (let depth = 0; depth < 8; depth += 1) {
+    try {
+      const parsed = JSON.parse(readFileSync(resolve(dir, 'package.json'), 'utf8')) as {
+        name?: unknown;
+        version?: unknown;
+      };
+
+      return {
+        name: typeof parsed.name === 'string' ? parsed.name : FALLBACK_VERSION.name,
+        version: typeof parsed.version === 'string' ? parsed.version : FALLBACK_VERSION.version,
+      };
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+
+  return FALLBACK_VERSION;
+}
+
+export function getAppVersion(): AppVersion {
+  return readAppVersion();
+}

--- a/server/workers/hermes_sessions.py
+++ b/server/workers/hermes_sessions.py
@@ -1,0 +1,376 @@
+"""Project Hermes SessionDB rows into the shape Minions consumes.
+
+Owns transcript sanitization for replay-as-conversation, message projection
+for the chat UI, and session metadata projection for cost/token displays.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import Any
+
+from hermes_worker_utils import WorkerError, json_safe, string_or_none
+
+
+AGENT_HISTORY_KEYS = {
+    "role",
+    "content",
+    "tool_calls",
+    "tool_call_id",
+    "tool_name",
+    "finish_reason",
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+    "codex_message_items",
+}
+
+
+def _sanitize_agent_history(history: Any) -> list[dict[str, Any]]:
+    if not isinstance(history, list):
+        return []
+    safe: list[dict[str, Any]] = []
+    for item in history:
+        if not isinstance(item, dict):
+            continue
+        role = item.get("role")
+        if role not in {"user", "assistant", "system", "tool"}:
+            continue
+
+        safe_item = {
+            key: json_safe(value)
+            for key, value in item.items()
+            if key in AGENT_HISTORY_KEYS and value is not None
+        }
+        if not safe_item.get("content") and not safe_item.get("tool_calls") and not safe_item.get("tool_call_id"):
+            continue
+        safe_item["role"] = role
+        safe.append(safe_item)
+    return safe
+
+
+COMPACTION_REFERENCE_PREFIX = "[CONTEXT COMPACTION"
+COMPACTION_MARKER_TEXT = "Context compacted. Earlier conversation was summarized so the agent could continue."
+
+
+def open_session(session_id: str, *, resolve_live: bool = True) -> tuple[Any, str]:
+    """Return (session_db, resolved_session_id) for the given session.
+
+    Resolves Hermes compression aliases so chat runs continue from the live
+    session tip instead of replaying an old root session.
+    """
+    # Lazy import so this module has no top-level dependency on hermes_worker.
+    # `hermes_worker` aliases itself into sys.modules at startup (see top of
+    # `hermes_worker.py`), so this returns the same module instance even when
+    # the worker is invoked as a script.
+    import hermes_worker
+
+    hermes_worker._ensure_imports()
+    if hermes_worker._SessionDB is None:
+        raise WorkerError(
+            "Hermes session database is unavailable.",
+            code="session_db_unavailable",
+        )
+    db = hermes_worker._SessionDB()
+    if not resolve_live:
+        return db, session_id
+    return db, _resolve_live_session_id(db, session_id)
+
+
+def _resolve_live_session_id(session_db: Any, session_id: str) -> str:
+    compression_tip = getattr(session_db, "get_compression_tip", None)
+    if callable(compression_tip):
+        try:
+            return compression_tip(session_id) or session_id
+        except Exception:
+            pass
+
+    resolve = getattr(session_db, "resolve_resume_session_id", None)
+    if callable(resolve):
+        try:
+            return resolve(session_id) or session_id
+        except Exception:
+            return session_id
+    return session_id
+
+
+def _session_lineage_ids(session_db: Any, root_session_id: str) -> list[str]:
+    """Return root plus compression child sessions in chronological order."""
+    session_ids = [root_session_id]
+    db_path = getattr(session_db, "db_path", None)
+    if db_path:
+        try:
+            with sqlite3.connect(str(db_path)) as conn:
+                rows = conn.execute(
+                    """
+                    WITH RECURSIVE lineage(id, started_at, depth) AS (
+                      SELECT id, started_at, 0
+                      FROM sessions
+                      WHERE id = ?
+                      UNION ALL
+                      SELECT child.id, child.started_at, lineage.depth + 1
+                      FROM sessions child
+                      JOIN lineage ON child.parent_session_id = lineage.id
+                      JOIN sessions parent ON parent.id = lineage.id
+                      WHERE lineage.depth < 100
+                        AND parent.end_reason = 'compression'
+                    )
+                    SELECT id
+                    FROM lineage
+                    ORDER BY started_at, id
+                    """,
+                    (root_session_id,),
+                ).fetchall()
+            queried_ids = [str(row[0]) for row in rows if row and row[0]]
+            if queried_ids:
+                session_ids = queried_ids
+        except Exception:
+            pass
+
+    # Fallback: if CTE failed or db_path unavailable, resolve via Hermes API
+    if len(session_ids) == 1:
+        live_session_id = _resolve_live_session_id(session_db, root_session_id)
+        if live_session_id != root_session_id:
+            session_ids.append(live_session_id)
+    return session_ids
+
+
+def load_agent_history(session_db: Any, session_id: str) -> list[dict[str, Any]]:
+    if not session_id:
+        return []
+    try:
+        get_session = getattr(session_db, "get_session", None)
+        if callable(get_session) and not get_session(session_id):
+            return []
+        history = session_db.get_messages_as_conversation(session_id)
+    except Exception as exc:
+        raise WorkerError(f"Could not load Hermes session history: {exc}", code="session_load_error") from exc
+    return _sanitize_agent_history(history)
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                if item:
+                    parts.append(item)
+                continue
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+                    continue
+                item_type = string_or_none(item.get("type"))
+                if item_type:
+                    parts.append(f"[{item_type}]")
+        return "\n".join(parts) if parts else "[non-text content]"
+    if isinstance(content, dict):
+        text = content.get("text") or content.get("content")
+        if isinstance(text, str):
+            return text
+        return "[non-text content]"
+    return str(content)
+
+
+def _strip_minions_user_scaffold(content: str) -> str:
+    stripped = content.lstrip()
+    if stripped.startswith("[TASK AGENT]"):
+        marker = "[TASK DESCRIPTION]"
+        marker_index = stripped.find(marker)
+        if marker_index >= 0:
+            return stripped[marker_index + len(marker):].lstrip("\r\n ")
+
+    if stripped.startswith("<task_agent>"):
+        marker = "</task_agent>"
+        marker_index = stripped.find(marker)
+        if marker_index >= 0:
+            remainder = stripped[marker_index + len(marker):].lstrip()
+            if remainder.startswith("<task_description>"):
+                end_marker = "</task_description>"
+                end_index = remainder.find(end_marker)
+                if end_index >= 0:
+                    return remainder[len("<task_description>"):end_index].strip()
+            return remainder
+
+    return content
+
+
+def _is_compaction_reference(content: str) -> bool:
+    stripped = content.lstrip()
+    return (
+        stripped.startswith(COMPACTION_REFERENCE_PREFIX)
+        and "REFERENCE ONLY" in stripped[:200]
+    )
+
+
+def _timestamp_to_ms(timestamp: Any) -> int:
+    try:
+        value = float(timestamp)
+    except (TypeError, ValueError):
+        return int(time.time() * 1000)
+    if value < 10_000_000_000:
+        value *= 1000
+    return int(value)
+
+
+def _thinking_to_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:
+        return str(value)
+
+
+def project_session_messages(session_id: Any, task_id: Any = None) -> dict[str, Any]:
+    session_id = string_or_none(session_id)
+    if not session_id:
+        raise WorkerError("Session ID is required.", code="bad_request")
+
+    session_db, root_session_id = open_session(session_id, resolve_live=False)
+    projected: list[dict[str, Any]] = []
+    projected_task_id = string_or_none(task_id) or session_id
+
+    for lineage_index, lineage_session_id in enumerate(_session_lineage_ids(session_db, root_session_id)):
+        try:
+            rows = session_db.get_messages(lineage_session_id)
+        except Exception as exc:
+            raise WorkerError(f"Could not load Hermes session messages: {exc}", code="session_load_error") from exc
+
+        is_root_session = lineage_index == 0
+        compaction_seen = is_root_session
+        child_user_seen = is_root_session
+
+        for row in rows:
+            if not isinstance(row, dict):
+                row = dict(row)
+            role = row.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+
+            content = _content_to_text(row.get("content"))
+            if role == "user":
+                content = _strip_minions_user_scaffold(content)
+                if _is_compaction_reference(content):
+                    projected.append({
+                        "id": f"hermes:{lineage_session_id}:compaction:{row.get('id')}",
+                        "task_id": projected_task_id,
+                        "role": "system",
+                        "content": COMPACTION_MARKER_TEXT,
+                        "created_at": _timestamp_to_ms(row.get("timestamp")),
+                    })
+                    compaction_seen = True
+                    child_user_seen = False
+                    continue
+                if not compaction_seen:
+                    continue
+                child_user_seen = True
+            elif not compaction_seen or not child_user_seen:
+                continue
+
+            if role == "assistant" and not content.strip() and row.get("tool_calls"):
+                continue
+            if not content.strip():
+                continue
+
+            message = {
+                "id": f"hermes:{lineage_session_id}:{row.get('id')}",
+                "task_id": projected_task_id,
+                "role": role,
+                "content": content,
+                "created_at": _timestamp_to_ms(row.get("timestamp")),
+            }
+            if role == "assistant":
+                thinking = (
+                    _thinking_to_text(row.get("reasoning_content"))
+                    or _thinking_to_text(row.get("reasoning"))
+                    or _thinking_to_text(row.get("reasoning_details"))
+                    or _thinking_to_text(row.get("codex_reasoning_items"))
+                )
+                if thinking:
+                    message["thinking"] = thinking
+            projected.append(message)
+
+    return {"messages": projected}
+
+
+def _int_field(row: dict[str, Any], key: str) -> int:
+    try:
+        return int(row.get(key) or 0)
+    except Exception:
+        return 0
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def project_session_metadata(session_id: Any) -> dict[str, Any]:
+    session_id = string_or_none(session_id)
+    if not session_id:
+        raise WorkerError("Session ID is required.", code="bad_request")
+
+    session_db, live_session_id = open_session(session_id)
+    try:
+        row = session_db.get_session(live_session_id)
+    except Exception as exc:
+        raise WorkerError(f"Could not load Hermes session metadata: {exc}", code="session_load_error") from exc
+
+    if not row:
+        return {"session": None}
+
+    return {
+        "session": {
+            "id": str(row.get("id") or live_session_id),
+            "input_tokens": _int_field(row, "input_tokens"),
+            "output_tokens": _int_field(row, "output_tokens"),
+            "cache_read_tokens": _int_field(row, "cache_read_tokens"),
+            "cache_write_tokens": _int_field(row, "cache_write_tokens"),
+            "reasoning_tokens": _int_field(row, "reasoning_tokens"),
+            "estimated_cost_usd": _float_or_none(row.get("estimated_cost_usd")),
+            "cost_status": string_or_none(row.get("cost_status")) or "unknown",
+            "model": string_or_none(row.get("model")),
+        }
+    }
+
+
+def delete_session(session_id: Any) -> dict[str, Any]:
+    """Best-effort delete of a Hermes session and its compression lineage.
+
+    The gateway owns its own session index (SQLite); this removes the underlying
+    Hermes transcript when the SessionDB exposes a delete method. A missing
+    session, or a SessionDB build without a delete method, resolves to
+    ``{"deleted": False}`` rather than raising, so DELETE stays idempotent.
+    """
+    session_id = string_or_none(session_id)
+    if not session_id:
+        raise WorkerError("Session ID is required.", code="bad_request")
+
+    session_db, root_session_id = open_session(session_id, resolve_live=False)
+    deleted_any = False
+    for lineage_session_id in _session_lineage_ids(session_db, root_session_id):
+        for method_name in ("delete_session", "delete", "remove_session"):
+            method = getattr(session_db, method_name, None)
+            if callable(method):
+                try:
+                    method(lineage_session_id)
+                    deleted_any = True
+                except Exception:
+                    pass
+                break
+    return {"deleted": deleted_any}

--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -1,0 +1,1530 @@
+#!/usr/bin/env python3
+"""JSONL bridge between the Agent37 Gateway and the Hermes AIAgent.
+
+Spawned as a subprocess by the Node adapter (`server/adapters/hermes-worker.ts`).
+Speaks one JSON object per line over stdin/stdout. Imports Hermes `AIAgent`
+directly — no Hermes HTTP gateway is involved — so the gateway gets structured
+streaming, per-turn model/reasoning control, and direct SessionDB access for
+history and replay.
+
+Lifted from the Minions worker, trimmed to the surface the gateway needs:
+chat, session reads/delete, models, settings, and goal primitives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import inspect
+import json
+import os
+import sys
+import threading
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from pathlib import Path
+from typing import Any, Callable
+
+# Alias so submodules importing `hermes_worker` see this module even when run as `__main__`.
+sys.modules.setdefault("hermes_worker", sys.modules[__name__])
+
+from hermes_worker_utils import (
+    WorkerError,
+    string_or_none,
+)
+from hermes_sessions import (
+    delete_session,
+    load_agent_history,
+    open_session,
+    project_session_messages,
+    project_session_metadata,
+)
+
+PROTOCOL_OUT = sys.stdout
+PROTOCOL_LOCK = threading.Lock()
+# Keep in sync with GOAL_MAX_TURNS in shared/types.ts.
+GOAL_MAX_TURNS = 20
+
+# Cap on concurrent AIAgent.run_conversation calls.
+AGENT_RUN_LIMIT = int(os.environ.get("HERMES_AGENT_RUN_LIMIT", "10"))
+AGENT_SEMAPHORE = threading.BoundedSemaphore(AGENT_RUN_LIMIT)
+ACTIVE_TASKS: dict[str, str] = {}
+ACTIVE_AGENTS: dict[str, Any] = {}
+PENDING_INTERRUPTS: dict[str, str] = {}
+ACTIVE_TASKS_LOCK = threading.Lock()
+DEFAULT_INTERRUPT_REASON = "Stopped by user"
+
+ALLOWED_REASONING = {"none", "minimal", "low", "medium", "high", "xhigh"}
+KNOWN_PROVIDER_PREFIXES = {
+    "anthropic",
+    "openai",
+    "openai-codex",
+    "copilot",
+    "deepseek",
+    "gemini",
+    "google",
+    "kimi",
+    "kimi-coding",
+    "minimax",
+    "minimax-cn",
+    "mistral",
+    "mistralai",
+    "moonshotai",
+    "nous",
+    "nvidia",
+    "ollama",
+    "ollama-cloud",
+    "opencode-go",
+    "opencode-zen",
+    "openrouter",
+    "qwen",
+    "x-ai",
+    "xai",
+    "xiaomi",
+    "z-ai",
+    "zai",
+}
+PORTAL_PROVIDERS = {"nous", "opencode-zen", "opencode-go", "nvidia"}
+LOCAL_SERVER_PROVIDERS = {
+    "lmstudio",
+    "lm-studio",
+    "ollama",
+    "llamacpp",
+    "llama-cpp",
+    "vllm",
+    "tabby",
+    "tabbyapi",
+    "koboldcpp",
+    "textgen",
+    "localai",
+}
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+RUNTIME_MANAGED_PROVIDER_PREFIXES = {
+    "copilot",
+    "copilot-acp",
+    "google-gemini-cli",
+    "minimax-oauth",
+    "nous",
+    "openai-codex",
+    "qwen-oauth",
+}
+MODEL_RUNTIME_OVERRIDE_KEYS = ("base_url", "api_key", "api", "api_mode")
+
+_AGENT_DIR: Path | None = None
+_IMPORTS_READY = False
+_IMPORTS_LOCK = threading.Lock()
+_AIAgent: Any = None
+_AIAgent_PARAMS: set[str] = set()
+_SessionDB: Any = None
+_CONFIG_CACHE: dict[str, Any] | None = None
+_CONFIG_MTIME: float = 0.0
+_MODEL_EXECUTOR = ThreadPoolExecutor(max_workers=1)
+try:
+    _MODEL_LIST_CACHE_TTL_SECONDS = max(0.0, float(os.environ.get("GATEWAY_MODEL_LIST_CACHE_TTL_SECONDS", "60")))
+except ValueError:
+    _MODEL_LIST_CACHE_TTL_SECONDS = 60.0
+
+
+@dataclasses.dataclass
+class _ModelListCache:
+    data: dict[str, Any]
+    config_mtime: float
+    expires_at: float
+
+
+_MODEL_LIST_CACHE: _ModelListCache | None = None
+_MODEL_LIST_CACHE_LOCK = threading.Lock()
+
+
+def _send(payload: dict[str, Any]) -> None:
+    with PROTOCOL_LOCK:
+        PROTOCOL_OUT.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n")
+        PROTOCOL_OUT.flush()
+
+
+def _result(request_id: str, data: dict[str, Any]) -> None:
+    _send({"id": request_id, "type": "result", "data": data})
+
+
+def _error_payload(exc: BaseException) -> dict[str, str]:
+    if isinstance(exc, WorkerError):
+        payload = {"message": str(exc), "code": exc.code}
+        if exc.hint:
+            payload["hint"] = exc.hint
+        return payload
+
+    message = str(exc) or exc.__class__.__name__
+    lower = message.lower()
+    code = "worker_error"
+    hint = None
+
+    if isinstance(exc, ImportError) or "no module named" in lower:
+        code = "import_error"
+        hint = "Use HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python."
+    elif "unauthorized" in lower or "authentication" in lower or "401" in lower or "api key" in lower:
+        code = "auth_error"
+        hint = "Run hermes model or update ~/.hermes/config.yaml credentials."
+    elif "rate limit" in lower or "429" in lower:
+        code = "rate_limit"
+        hint = "Retry later or switch provider/model."
+    elif "quota" in lower or "credit" in lower or "insufficient" in lower:
+        code = "quota_exhausted"
+        hint = "Top up provider account or switch provider/model."
+    elif "model" in lower and ("not found" in lower or "rejected" in lower or "invalid" in lower):
+        code = "model_error"
+        hint = "Pick another model from the model menu."
+
+    payload = {"message": message, "code": code}
+    if hint:
+        payload["hint"] = hint
+    return payload
+
+
+def _send_error(request_id: str, exc: BaseException) -> None:
+    _send({"id": request_id, "type": "error", "error": _error_payload(exc)})
+
+
+def _resolve_agent_dir_from_hermes_cli() -> Path | None:
+    import shutil
+
+    hermes_bin = shutil.which("hermes")
+    if not hermes_bin:
+        return None
+    try:
+        real = Path(hermes_bin).resolve()
+        # Typical layout: <agent-dir>/venv/bin/hermes
+        candidate = real.parent.parent.parent
+        if (candidate / "run_agent.py").exists():
+            return candidate
+    except OSError:
+        pass
+    return None
+
+
+def _discover_agent_dir() -> Path:
+    candidates: list[Path] = []
+
+    env_dir = os.environ.get("HERMES_AGENT_DIR", "").strip()
+    if env_dir:
+        candidates.append(Path(env_dir).expanduser())
+
+    hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+    candidates.append(hermes_home / "hermes-agent")
+    candidates.append(Path.home() / ".hermes" / "hermes-agent")
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        if (resolved / "run_agent.py").exists():
+            return resolved
+
+    cli_dir = _resolve_agent_dir_from_hermes_cli()
+    if cli_dir:
+        return cli_dir
+
+    raise WorkerError(
+        "Hermes agent source not found.",
+        code="hermes_not_found",
+        hint="Set HERMES_AGENT_DIR or install Hermes into ~/.hermes/hermes-agent.",
+    )
+
+
+def _ensure_imports() -> None:
+    if _IMPORTS_READY:
+        return
+    with _IMPORTS_LOCK:
+        if _IMPORTS_READY:
+            return
+        _ensure_imports_unlocked()
+
+
+def _ensure_imports_unlocked() -> None:
+    global _AGENT_DIR, _IMPORTS_READY, _AIAgent, _AIAgent_PARAMS, _SessionDB
+
+    _AGENT_DIR = _discover_agent_dir()
+    agent_dir_str = str(_AGENT_DIR)
+    if agent_dir_str not in sys.path:
+        sys.path.append(agent_dir_str)
+
+    try:
+        from run_agent import AIAgent
+    except ImportError as exc:
+        raise WorkerError(
+            f"Could not import Hermes AIAgent: {exc}",
+            code="import_error",
+            hint="Use HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python.",
+        ) from exc
+
+    _AIAgent = AIAgent
+    _AIAgent_PARAMS = set(inspect.signature(AIAgent.__init__).parameters)
+    try:
+        from hermes_state import SessionDB
+        _SessionDB = SessionDB
+    except Exception:
+        _SessionDB = None
+
+    _IMPORTS_READY = True
+
+
+def _load_config() -> dict[str, Any]:
+    global _CONFIG_CACHE, _CONFIG_MTIME
+    _ensure_imports()
+
+    config_path = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "config.yaml"
+    try:
+        mtime = config_path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+
+    if _CONFIG_CACHE is not None and mtime == _CONFIG_MTIME:
+        return _CONFIG_CACHE
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        result = cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        result = {}
+
+    _CONFIG_CACHE = result
+    _CONFIG_MTIME = mtime
+    return result
+
+
+def _clear_model_list_cache() -> None:
+    global _MODEL_LIST_CACHE
+    with _MODEL_LIST_CACHE_LOCK:
+        _MODEL_LIST_CACHE = None
+
+
+def _model_section(cfg: dict[str, Any]) -> dict[str, Any]:
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        data = dict(model_cfg)
+        if not data.get("default") and data.get("model"):
+            data["default"] = data.get("model")
+        return data
+    if isinstance(model_cfg, str) and model_cfg.strip():
+        return {"default": model_cfg.strip()}
+    return {}
+
+
+def _normalize_reasoning(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if normalized in ALLOWED_REASONING else None
+
+
+def _default_reasoning(cfg: dict[str, Any]) -> str | None:
+    agent_cfg = cfg.get("agent")
+    raw = agent_cfg.get("reasoning_effort") if isinstance(agent_cfg, dict) else None
+    return _normalize_reasoning(raw) or "medium"
+
+
+def _set_defaults(request: dict[str, Any]) -> dict[str, Any]:
+    global _CONFIG_CACHE
+    _ensure_imports()
+    from hermes_cli.config import load_config as _load_full_config, save_config
+
+    cfg = _load_full_config()
+
+    if not isinstance(cfg.get("model"), dict):
+        cfg["model"] = {}
+
+    provider_present = "provider" in request
+    requested_provider = string_or_none(request.get("provider")) if provider_present else None
+    if requested_provider and not _provider_hint_is_selectable(requested_provider, cfg):
+        _raise_invalid_provider(requested_provider)
+
+    if "model" in request:
+        raw_model = request["model"]
+        if isinstance(raw_model, str) and raw_model.strip():
+            model_val = raw_model.strip()
+            parsed = _parse_provider_model(model_val)
+            previous_provider = string_or_none(cfg["model"].get("provider"))
+            if parsed:
+                parsed_provider, bare_model = parsed
+                provider_hint = requested_provider or parsed_provider
+                if provider_hint and not _provider_hint_is_selectable(provider_hint, cfg):
+                    _raise_invalid_provider(provider_hint)
+                cfg["model"]["default"] = bare_model
+                if provider_hint:
+                    cfg["model"]["provider"] = provider_hint
+                if (
+                    provider_hint != previous_provider
+                    or provider_hint in RUNTIME_MANAGED_PROVIDER_PREFIXES
+                ):
+                    _clear_model_runtime_overrides(cfg["model"])
+            else:
+                if requested_provider:
+                    resolved_model, resolved_provider = model_val, requested_provider
+                else:
+                    resolved_model, resolved_provider, _ = _resolve_model_provider(model_val, cfg)
+                if resolved_provider and not _provider_hint_is_selectable(resolved_provider, cfg):
+                    _raise_invalid_provider(resolved_provider)
+                cfg["model"]["default"] = resolved_model
+                if resolved_provider:
+                    cfg["model"]["provider"] = resolved_provider
+                else:
+                    cfg["model"].pop("provider", None)
+                if (
+                    resolved_provider != previous_provider
+                    or resolved_provider in RUNTIME_MANAGED_PROVIDER_PREFIXES
+                ):
+                    _clear_model_runtime_overrides(cfg["model"])
+    elif provider_present:
+        previous_provider = string_or_none(cfg["model"].get("provider"))
+        if requested_provider:
+            cfg["model"]["provider"] = requested_provider
+        else:
+            cfg["model"].pop("provider", None)
+        if requested_provider != previous_provider:
+            _clear_model_runtime_overrides(cfg["model"])
+
+    if "reasoningEffort" in request:
+        normalized = _normalize_reasoning(request["reasoningEffort"])
+        if normalized:
+            if not isinstance(cfg.get("agent"), dict):
+                cfg["agent"] = {}
+            cfg["agent"]["reasoning_effort"] = normalized
+
+    save_config(cfg)
+    _CONFIG_CACHE = None
+    _clear_model_list_cache()
+
+    return _defaults_from_config(cfg)
+
+
+def _clear_model_runtime_overrides(model_cfg: dict[str, Any]) -> None:
+    for key in MODEL_RUNTIME_OVERRIDE_KEYS:
+        model_cfg.pop(key, None)
+
+
+def _defaults_from_config(cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+    cfg = cfg if cfg is not None else _load_config()
+    model_cfg = _model_section(cfg)
+    display_cfg = cfg.get("display")
+
+    return {
+        "provider": string_or_none(model_cfg.get("provider")),
+        "model": string_or_none(model_cfg.get("default")),
+        "baseUrl": string_or_none(model_cfg.get("base_url")),
+        "apiMode": string_or_none(model_cfg.get("api_mode")),
+        "reasoningEffort": _default_reasoning(cfg),
+        "showReasoning": bool(display_cfg.get("show_reasoning")) if isinstance(display_cfg, dict) and isinstance(display_cfg.get("show_reasoning"), bool) else True,
+    }
+
+
+def _task_key_for(request: dict[str, Any]) -> str:
+    return (
+        string_or_none(request.get("taskId"))
+        or string_or_none(request.get("sessionId"))
+        or str(request.get("id"))
+    )
+
+
+def _try_mark_task_active(task_key: str, request_id: str) -> bool:
+    with ACTIVE_TASKS_LOCK:
+        if task_key in ACTIVE_TASKS:
+            return False
+        ACTIVE_TASKS[task_key] = request_id
+        return True
+
+
+def _try_interrupt_agent(agent: Any, reason: str) -> bool:
+    if agent is not None and hasattr(agent, "interrupt"):
+        agent.interrupt(reason)
+        return True
+    return False
+
+
+def _register_active_agent(task_key: str, request_id: str, agent: Any) -> None:
+    pending_reason = None
+    with ACTIVE_TASKS_LOCK:
+        if ACTIVE_TASKS.get(task_key) != request_id:
+            return
+        ACTIVE_AGENTS[task_key] = agent
+        pending_reason = PENDING_INTERRUPTS.pop(task_key, None)
+
+    # An interrupt that arrived before this agent was constructed was parked in
+    # PENDING_INTERRUPTS; apply it now that the agent exists.
+    if pending_reason:
+        _try_interrupt_agent(agent, pending_reason)
+
+
+def _clear_task_active(task_key: str, request_id: str) -> None:
+    with ACTIVE_TASKS_LOCK:
+        if ACTIVE_TASKS.get(task_key) == request_id:
+            ACTIVE_TASKS.pop(task_key, None)
+            ACTIVE_AGENTS.pop(task_key, None)
+            PENDING_INTERRUPTS.pop(task_key, None)
+
+
+def _interrupt_active_chat(request: dict[str, Any]) -> dict[str, bool]:
+    task_key = _task_key_for(request)
+    reason = string_or_none(request.get("reason")) or DEFAULT_INTERRUPT_REASON
+
+    with ACTIVE_TASKS_LOCK:
+        if task_key not in ACTIVE_TASKS:
+            return {"interrupted": False}
+
+        agent = ACTIVE_AGENTS.get(task_key)
+        if agent is None:
+            # The run is active but its agent isn't registered yet. Park the reason
+            # so _register_active_agent applies it the moment the agent is created.
+            PENDING_INTERRUPTS[task_key] = reason
+            return {"interrupted": True}
+
+    return {"interrupted": _try_interrupt_agent(agent, reason)}
+
+
+def _custom_providers(cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        providers = get_compatible_custom_providers(cfg)
+        return providers if isinstance(providers, list) else []
+    except Exception:
+        raw = cfg.get("custom_providers")
+        return raw if isinstance(raw, list) else []
+
+
+def _custom_provider_models(entry: dict[str, Any]) -> list[str]:
+    models: list[str] = []
+    for key in ("model", "default_model"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            models.append(value.strip())
+
+    raw_models = entry.get("models")
+    if isinstance(raw_models, dict):
+        models.extend(str(k).strip() for k in raw_models.keys() if str(k).strip())
+    elif isinstance(raw_models, list):
+        for item in raw_models:
+            if isinstance(item, str) and item.strip():
+                models.append(item.strip())
+            elif isinstance(item, dict):
+                mid = item.get("id") or item.get("model") or item.get("name")
+                if isinstance(mid, str) and mid.strip():
+                    models.append(mid.strip())
+
+    return _dedupe(models)
+
+
+def _parse_provider_model(raw: str) -> tuple[str, str] | None:
+    if raw.startswith("@") and ":" in raw:
+        inner = raw[1:]
+        provider, model = inner.rsplit(":", 1)
+        if provider.startswith("custom:") and provider.count(":") >= 2:
+            slug_rest = provider[len("custom:"):]
+            if not _custom_slug_rest_looks_like_host_port(slug_rest):
+                provider, extra = provider.rsplit(":", 1)
+                model = f"{extra}:{model}"
+        elif provider not in KNOWN_PROVIDER_PREFIXES and not provider.startswith("custom:"):
+            provider, model = inner.split(":", 1)
+        return provider, model
+    return None
+
+
+def _custom_slug_rest_looks_like_host_port(rest: str) -> bool:
+    rest = str(rest or "").strip()
+    if ":" not in rest:
+        return False
+    host, port_s = rest.rsplit(":", 1)
+    if not host or ":" in host or not port_s.isdigit():
+        return False
+    if not (1 <= int(port_s) <= 65535):
+        return False
+    try:
+        import ipaddress
+
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        pass
+    host_l = host.lower()
+    return host_l == "localhost" or "." in host
+
+
+def _provider_hint_is_available(provider: str) -> bool:
+    if provider.startswith("custom:"):
+        return True
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider  # type: ignore
+
+        resolve_runtime_provider(requested=provider)
+        return True
+    except ImportError:
+        return True
+    except Exception:
+        return False
+
+
+def _provider_hint_is_selectable(provider: str, cfg: dict[str, Any]) -> bool:
+    if _provider_hint_is_available(provider):
+        return True
+
+    provider_l = provider.strip().lower()
+    groups = _list_authenticated_model_groups(cfg, _defaults_from_config(cfg)) or {}
+    return any(
+        (string_or_none(model.get("provider")) or "").lower() == provider_l
+        for models in groups.values()
+        for model in models
+    )
+
+
+def _raise_invalid_provider(provider: str) -> None:
+    raise WorkerError(
+        f"Provider '{provider}' is not configured for this Hermes install.",
+        code="invalid_provider",
+        hint="Choose a configured provider, or configure this provider in Hermes first.",
+    )
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
+def _add_model(
+    groups: dict[str, list[dict[str, Any]]],
+    provider: str,
+    model_id: str,
+    source: str,
+    default_model: str | None,
+    label: str | None = None,
+    provider_id: str | None = None,
+) -> None:
+    if not model_id:
+        return
+    bucket = groups.setdefault(provider or "configured", [])
+    if any(item["id"] == model_id for item in bucket):
+        return
+    bucket.append({
+        "id": model_id,
+        "label": label or model_id,
+        "source": source,
+        "provider": provider_id,
+        "isCurrentDefault": bool(default_model and model_id == default_model),
+    })
+
+
+def _provider_model_ids_with_timeout(provider: str, timeout: float = 4.0) -> list[str]:
+    try:
+        future = _MODEL_EXECUTOR.submit(_provider_model_ids, provider)
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        return []
+    except Exception:
+        return []
+
+
+def _provider_model_ids(provider: str) -> list[str]:
+    from hermes_cli.models import provider_model_ids
+
+    models = provider_model_ids(provider)
+    return [str(model).strip() for model in models or [] if str(model).strip()]
+
+
+def _groups_have_model(groups: dict[str, list[dict[str, Any]]], model_id: str) -> bool:
+    return any(
+        item.get("id") == model_id
+        for models in groups.values()
+        for item in models
+    )
+
+
+def _is_local_server_provider(provider: str | None) -> bool:
+    provider_l = str(provider or "").strip().lower()
+    if provider_l in LOCAL_SERVER_PROVIDERS:
+        return True
+    if provider_l.startswith("custom:"):
+        return provider_l.removeprefix("custom:") in LOCAL_SERVER_PROVIDERS
+    return False
+
+
+def _base_url_points_at_local_server(base_url: str | None) -> bool:
+    if not base_url:
+        return False
+    try:
+        import ipaddress
+        from urllib.parse import urlparse
+
+        host = (urlparse(base_url).hostname or "").lower()
+        if host in {"localhost", "ip6-localhost", "ip6-loopback"}:
+            return True
+        if not host:
+            return False
+        try:
+            addr = ipaddress.ip_address(host)
+        except ValueError:
+            return False
+        return addr.is_loopback or addr.is_private or addr.is_link_local
+    except Exception:
+        return False
+
+
+def _model_option_id(provider: str | None, model_id: str, active_provider: str | None) -> str:
+    if not provider or provider == active_provider:
+        return model_id
+    if provider.startswith("custom:"):
+        return model_id
+    return f"@{provider}:{model_id}"
+
+
+def _list_authenticated_model_groups(
+    cfg: dict[str, Any],
+    defaults: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]] | None:
+    try:
+        from hermes_cli.model_switch import list_authenticated_providers
+    except Exception:
+        return None
+
+    providers_cfg = cfg.get("providers")
+    user_providers = providers_cfg if isinstance(providers_cfg, dict) else {}
+    custom_providers = _custom_providers(cfg)
+    active_provider = defaults["provider"]
+    default_model = defaults["model"]
+    groups: dict[str, list[dict[str, Any]]] = {}
+
+    try:
+        providers = list_authenticated_providers(
+            current_provider=active_provider or "",
+            current_base_url=defaults.get("baseUrl") or "",
+            current_model=default_model or "",
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+            max_models=500,
+        )
+    except Exception:
+        return None
+
+    for provider_info in providers:
+        if not isinstance(provider_info, dict):
+            continue
+        slug = string_or_none(provider_info.get("slug"))
+        group_name = string_or_none(provider_info.get("name")) or slug or "configured"
+        is_user_defined = bool(provider_info.get("is_user_defined"))
+        # Inventory view — runtime validation happens in _create_agent().
+        source = "custom" if is_user_defined else "catalog"
+        models = provider_info.get("models")
+        if not isinstance(models, list):
+            continue
+        for raw_model in models:
+            model_id = string_or_none(raw_model)
+            if not model_id:
+                continue
+            option_id = model_id if is_user_defined else _model_option_id(slug, model_id, active_provider)
+            _add_model(groups, group_name, option_id, source, default_model, label=model_id, provider_id=slug)
+
+    return groups
+
+
+def _list_models() -> dict[str, Any]:
+    global _MODEL_LIST_CACHE
+
+    cfg = _load_config()
+    config_mtime = _CONFIG_MTIME
+    now = time.monotonic()
+    with _MODEL_LIST_CACHE_LOCK:
+        cached = _MODEL_LIST_CACHE
+        if cached is not None and cached.config_mtime == config_mtime and now < cached.expires_at:
+            return cached.data
+
+    defaults = _defaults_from_config(cfg)
+    default_model = defaults["model"]
+    active_provider = defaults["provider"]
+    authenticated_groups = _list_authenticated_model_groups(cfg, defaults)
+    groups = authenticated_groups or {}
+
+    if default_model and not _groups_have_model(groups, default_model):
+        _add_model(groups, active_provider or "current", default_model, "current", default_model, provider_id=active_provider)
+
+    if active_provider and authenticated_groups is None:
+        for model_id in _provider_model_ids_with_timeout(active_provider):
+            _add_model(groups, active_provider, model_id, "catalog", default_model, provider_id=active_provider)
+
+    aliases = cfg.get("model_aliases")
+    if isinstance(aliases, dict):
+        for alias, target in aliases.items():
+            if isinstance(alias, str) and alias.strip():
+                label = f"{alias.strip()} -> {target}" if target else alias.strip()
+                bucket = groups.setdefault("aliases", [])
+                if not any(item["id"] == alias.strip() for item in bucket):
+                    bucket.append({
+                        "id": alias.strip(),
+                        "label": label,
+                        "source": "alias",
+                        "isCurrentDefault": bool(default_model and alias.strip() == default_model),
+                    })
+
+    result = {
+        "defaultModel": default_model,
+        "activeProvider": active_provider,
+        "groups": [{"provider": provider, "models": models} for provider, models in groups.items()],
+    }
+
+    with _MODEL_LIST_CACHE_LOCK:
+        _MODEL_LIST_CACHE = _ModelListCache(
+            data=result,
+            config_mtime=config_mtime,
+            expires_at=time.monotonic() + _MODEL_LIST_CACHE_TTL_SECONDS,
+        )
+
+    return result
+
+
+def _resolve_model_provider(
+    requested_model: str | None,
+    cfg: dict[str, Any] | None = None,
+    requested_provider: str | None = None,
+) -> tuple[str, str | None, str | None]:
+    cfg = cfg if cfg is not None else _load_config()
+    model_cfg = _model_section(cfg)
+    config_provider = string_or_none(requested_provider) or string_or_none(model_cfg.get("provider"))
+    config_base_url = string_or_none(model_cfg.get("base_url"))
+    if requested_provider and string_or_none(requested_provider) != string_or_none(model_cfg.get("provider")):
+        config_base_url = None
+    config_provider_l = (config_provider or "").lower()
+    default_model = string_or_none(model_cfg.get("default"))
+    model_id = (requested_model or default_model or "").strip()
+
+    if not model_id:
+        return model_id, config_provider, config_base_url
+
+    for entry in _custom_providers(cfg):
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            continue
+        if model_id in _custom_provider_models(entry):
+            return model_id, f"custom:{name.lower().replace(' ', '-')}", string_or_none(entry.get("base_url"))
+
+    parsed = _parse_provider_model(model_id)
+    if parsed:
+        provider_hint, bare_model = parsed
+        return bare_model, provider_hint or config_provider, None
+
+    if "/" in model_id:
+        prefix, bare = model_id.split("/", 1)
+        prefix_normalized = prefix.lower()
+        if config_provider_l == "openrouter":
+            return model_id, "openrouter", config_base_url
+        if config_provider_l in PORTAL_PROVIDERS:
+            return model_id, config_provider, config_base_url
+        if config_provider and prefix_normalized == config_provider_l:
+            return bare, config_provider, config_base_url
+        if (
+            config_provider_l == "openai-codex"
+            and (config_base_url or "").rstrip("/") == CODEX_BASE_URL
+            and prefix_normalized in KNOWN_PROVIDER_PREFIXES
+            and prefix_normalized != config_provider_l
+        ):
+            return model_id, "openrouter", None
+        if config_base_url:
+            if _is_local_server_provider(config_provider) or _base_url_points_at_local_server(config_base_url):
+                return model_id, config_provider, config_base_url
+            if prefix_normalized in KNOWN_PROVIDER_PREFIXES:
+                return bare, config_provider, config_base_url
+            return model_id, config_provider, config_base_url
+        if prefix_normalized in KNOWN_PROVIDER_PREFIXES and prefix_normalized != config_provider_l:
+            return model_id, "openrouter", None
+
+    return model_id, config_provider, config_base_url
+
+
+def _resolve_toolsets(cfg: dict[str, Any]) -> list[str] | None:
+    try:
+        from hermes_cli.tools_config import _get_platform_tools
+
+        toolsets = _get_platform_tools(cfg, "cli")
+        return list(toolsets) if toolsets else None
+    except Exception:
+        platform_toolsets = cfg.get("platform_toolsets")
+        if isinstance(platform_toolsets, dict) and isinstance(platform_toolsets.get("cli"), list):
+            return list(platform_toolsets["cli"])
+    return None
+
+
+def _normalize_fallback_entry(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    model = string_or_none(raw.get("model"))
+    if not model:
+        return None
+    return {
+        "model": model,
+        "provider": string_or_none(raw.get("provider")),
+        "base_url": string_or_none(raw.get("base_url")),
+    }
+
+
+def _fallback_model(cfg: dict[str, Any]) -> dict[str, Any] | list[dict[str, Any]] | None:
+    raw_chain = cfg.get("fallback_providers")
+    if isinstance(raw_chain, list):
+        chain = [
+            entry
+            for item in raw_chain
+            if (entry := _normalize_fallback_entry(item)) is not None
+        ]
+        if chain:
+            return chain
+
+    return _normalize_fallback_entry(cfg.get("fallback_model"))
+
+
+def _parse_reasoning(effort: str | None) -> dict[str, Any] | None:
+    if not effort:
+        return None
+    try:
+        from hermes_constants import parse_reasoning_effort
+
+        return parse_reasoning_effort(effort)
+    except Exception:
+        if effort == "none":
+            return {"enabled": False}
+        if effort in ALLOWED_REASONING:
+            return {"enabled": True, "effort": effort}
+    return None
+
+
+def _create_agent(
+    *,
+    session_id: str,
+    requested_model: str | None,
+    reasoning_effort: str | None,
+    requested_provider: str | None = None,
+    callbacks: dict[str, Any] | None = None,
+) -> Any:
+    _ensure_imports()
+    cfg = _load_config()
+    defaults = _defaults_from_config(cfg)
+    resolved_reasoning_effort = reasoning_effort or defaults.get("reasoningEffort")
+    resolved_model, resolved_provider, resolved_base_url = _resolve_model_provider(
+        requested_model, cfg, requested_provider=requested_provider,
+    )
+
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider  # type: ignore
+
+        runtime = resolve_runtime_provider(
+            requested=resolved_provider,
+            explicit_base_url=(
+                resolved_base_url
+                if (resolved_provider or "").startswith("custom:")
+                else None
+            ),
+            target_model=resolved_model,
+        )
+    except Exception as exc:
+        err = _error_payload(exc)
+        raise WorkerError(str(exc), code=err.get("code", "worker_error"), hint=err.get("hint")) from exc
+
+    if not resolved_provider:
+        resolved_provider = string_or_none(runtime.get("provider"))
+    if not resolved_base_url:
+        resolved_base_url = string_or_none(runtime.get("base_url"))
+
+    def clarify_callback(question: Any, choices: Any = None) -> str:
+        return (
+            "The user is not available for an interactive clarification right now. "
+            "Make a reasonable assumption, proceed, and call out the assumption in the response if it matters."
+        )
+
+    session_db = None
+    if _SessionDB is not None:
+        try:
+            session_db = _SessionDB()
+        except Exception:
+            session_db = None
+
+    agent_params = _AIAgent_PARAMS
+    agent_kwargs: dict[str, Any] = {
+        "model": resolved_model,
+        "provider": resolved_provider,
+        "base_url": resolved_base_url,
+        "api_key": runtime.get("api_key"),
+        "quiet_mode": True,
+        "verbose_logging": False,
+        "platform": "agent37-gateway",
+        "session_id": session_id,
+        "session_db": session_db,
+        "enabled_toolsets": _resolve_toolsets(cfg),
+        "fallback_model": _fallback_model(cfg),
+        "clarify_callback": clarify_callback,
+    }
+    if callbacks:
+        agent_kwargs.update(callbacks)
+
+    reasoning_config = _parse_reasoning(resolved_reasoning_effort)
+    if "reasoning_config" in agent_params and reasoning_config is not None:
+        agent_kwargs["reasoning_config"] = reasoning_config
+    if "api_mode" in agent_params:
+        agent_kwargs["api_mode"] = runtime.get("api_mode")
+    if "acp_command" in agent_params:
+        agent_kwargs["acp_command"] = runtime.get("command")
+    elif "command" in agent_params:
+        agent_kwargs["command"] = runtime.get("command")
+    if "acp_args" in agent_params:
+        agent_kwargs["acp_args"] = list(runtime.get("args") or [])
+    elif "args" in agent_params:
+        agent_kwargs["args"] = list(runtime.get("args") or [])
+    if "credential_pool" in agent_params:
+        agent_kwargs["credential_pool"] = runtime.get("credential_pool")
+    if "gateway_session_key" in agent_params:
+        agent_kwargs["gateway_session_key"] = session_id
+
+    filtered_kwargs = {
+        key: value
+        for key, value in agent_kwargs.items()
+        if key in agent_params and value is not None
+    }
+
+    return _AIAgent(**filtered_kwargs)
+
+
+def _agent_failure_message(text: str) -> str | None:
+    clean = str(text or "").strip()
+    if not clean:
+        return None
+
+    failure_prefixes = (
+        "API call failed after",
+        "Rate limited after",
+        "Non-retryable client error",
+    )
+    if clean.startswith(failure_prefixes):
+        return clean
+
+    return None
+
+
+def _sync_session_identity(agent: Any, session_id: str) -> None:
+    """Refresh persisted Hermes session metadata when the gateway switches models."""
+    session_db = getattr(agent, "_session_db", None)
+    model = string_or_none(getattr(agent, "model", None))
+    if not session_db or not session_id or not model:
+        return
+
+    try:
+        session_row = session_db.get_session(session_id)
+    except Exception:
+        return
+    if not session_row:
+        return
+
+    model_config = getattr(agent, "_session_init_model_config", None)
+    stored_model = string_or_none(session_row.get("model"))
+    if stored_model == model:
+        return
+
+    model_config_json = None
+    if model_config:
+        try:
+            model_config_json = json.dumps(model_config)
+        except Exception:
+            model_config_json = None
+
+    execute_write = getattr(session_db, "_execute_write", None)
+    if callable(execute_write):
+        def _do(conn: Any) -> None:
+            if model_config_json is None:
+                conn.execute(
+                    "UPDATE sessions SET model = ?, system_prompt = NULL WHERE id = ?",
+                    (model, session_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE sessions SET model = ?, model_config = ?, system_prompt = NULL WHERE id = ?",
+                    (model, model_config_json, session_id),
+                )
+
+        try:
+            execute_write(_do)
+        except Exception:
+            return
+    else:
+        try:
+            session_db.update_system_prompt(session_id, None)
+        except Exception:
+            return
+
+    try:
+        setattr(agent, "_cached_system_prompt", None)
+    except Exception:
+        pass
+
+
+def _warm_agent() -> None:
+    _load_config()
+
+
+def _goal_manager(session_id: str) -> Any:
+    _ensure_imports()
+    if not session_id:
+        raise WorkerError("Session ID is required.", code="bad_request")
+    from hermes_cli.goals import GoalManager
+
+    return GoalManager(session_id=session_id, default_max_turns=GOAL_MAX_TURNS)
+
+
+def _project_goal_state(state: Any) -> dict[str, Any] | None:
+    if not state:
+        return None
+    return {
+        "goal": str(getattr(state, "goal", "") or ""),
+        "status": str(getattr(state, "status", "") or "active"),
+        "turnsUsed": int(getattr(state, "turns_used", 0) or 0),
+        "maxTurns": int(getattr(state, "max_turns", 0) or 0),
+        "lastReason": string_or_none(getattr(state, "last_reason", None)),
+        "pausedReason": string_or_none(getattr(state, "paused_reason", None)),
+    }
+
+
+def _project_goal_decision(decision: dict[str, Any], state: Any) -> dict[str, Any]:
+    return {
+        "status": string_or_none(decision.get("status")),
+        "shouldContinue": bool(decision.get("should_continue")),
+        "continuationPrompt": string_or_none(decision.get("continuation_prompt")),
+        "verdict": string_or_none(decision.get("verdict")) or "inactive",
+        "reason": string_or_none(decision.get("reason")) or "",
+        "message": string_or_none(decision.get("message")) or "",
+        "state": _project_goal_state(state),
+    }
+
+
+def _goal_mgr_from_request(request: dict[str, Any]) -> Any:
+    return _goal_manager(string_or_none(request.get("sessionId")) or "")
+
+
+def _goal_status(request: dict[str, Any]) -> dict[str, Any]:
+    mgr = _goal_mgr_from_request(request)
+    return {"goal": _project_goal_state(mgr.state)}
+
+
+def _goal_set(request: dict[str, Any]) -> dict[str, Any]:
+    goal = string_or_none(request.get("goal")) or ""
+    if not goal.strip():
+        raise WorkerError("Goal text is required.", code="bad_request")
+
+    mgr = _goal_mgr_from_request(request)
+    raw_max_turns = request.get("maxTurns")
+    if raw_max_turns is None:
+        state = mgr.set(goal)
+    else:
+        try:
+            max_turns = int(raw_max_turns)
+        except (TypeError, ValueError) as exc:
+            raise WorkerError("maxTurns must be a positive integer.", code="bad_request") from exc
+        if max_turns <= 0:
+            raise WorkerError("maxTurns must be a positive integer.", code="bad_request")
+        state = mgr.set(goal, max_turns=max_turns)
+    return {"goal": _project_goal_state(state)}
+
+
+def _goal_pause(request: dict[str, Any]) -> dict[str, Any]:
+    reason = string_or_none(request.get("reason")) or "user-paused"
+    mgr = _goal_mgr_from_request(request)
+    return {"goal": _project_goal_state(mgr.pause(reason))}
+
+
+def _goal_resume(request: dict[str, Any]) -> dict[str, Any]:
+    mgr = _goal_mgr_from_request(request)
+    return {"goal": _project_goal_state(mgr.resume())}
+
+
+def _goal_clear(request: dict[str, Any]) -> dict[str, Any]:
+    mgr = _goal_mgr_from_request(request)
+    had_goal = bool(mgr.has_goal())
+    mgr.clear()
+    return {"cleared": had_goal}
+
+
+def _goal_evaluate(request: dict[str, Any]) -> dict[str, Any]:
+    response_text = string_or_none(request.get("responseText")) or ""
+    mgr = _goal_mgr_from_request(request)
+    decision = mgr.evaluate_after_turn(response_text)
+    return _project_goal_decision(decision, mgr.state)
+
+
+def _usage_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Extract per-turn token/cost usage from an AIAgent.run_conversation result."""
+    usage: dict[str, Any] = {
+        "input_tokens": int(result.get("input_tokens") or 0),
+        "output_tokens": int(result.get("output_tokens") or 0),
+    }
+    cost = result.get("cost_usd")
+    if cost is None:
+        cost = result.get("cost")
+    if cost is None:
+        cost = result.get("estimated_cost_usd")
+    if cost is not None:
+        try:
+            usage["cost_usd"] = float(cost)
+        except (TypeError, ValueError):
+            pass
+    return usage
+
+
+def _run_chat(request_id: str, request: dict[str, Any]) -> None:
+    settings = request.get("settings") if isinstance(request.get("settings"), dict) else {}
+    requested_model = string_or_none(settings.get("model"))
+    requested_provider = string_or_none(settings.get("provider"))
+    requested_effort = _normalize_reasoning(settings.get("reasoningEffort"))
+
+    session_id = string_or_none(request.get("sessionId")) or request_id
+    message = request.get("message")
+    if not isinstance(message, str) or not message.strip():
+        raise WorkerError("Chat request message is required.", code="bad_request")
+
+    session_db, session_id = open_session(session_id)
+    history = load_agent_history(session_db, session_id)
+    system_message = request.get("systemMessage")
+    if not isinstance(system_message, str):
+        system_message = None
+
+    state = {"text": "", "thinking": ""}
+
+    def on_text_delta(text: Any) -> None:
+        if text is None:
+            return
+        chunk = str(text)
+        state["text"] += chunk
+        _send({"id": request_id, "type": "text_delta", "content": chunk})
+
+    def on_reasoning_delta(text: Any) -> None:
+        if text is None:
+            return
+        chunk = str(text)
+        if not chunk:
+            return
+        state["thinking"] += chunk
+        _send({"id": request_id, "type": "thinking_delta", "content": chunk})
+
+    def on_tool_progress(*args: Any, **kwargs: Any) -> None:
+        event_type = None
+        name = None
+        preview = None
+        tool_args = None
+
+        if len(args) >= 4:
+            event_type, name, preview, tool_args = args[:4]
+        elif len(args) == 3:
+            name, preview, tool_args = args
+            event_type = "tool.started"
+        elif len(args) == 2:
+            event_type, name = args
+        elif len(args) == 1:
+            name = args[0]
+            event_type = "tool.started"
+
+        tool_name = str(name or "tool")
+        if event_type in {None, "tool.started"}:
+            _send({
+                "id": request_id,
+                "type": "tool_progress",
+                "tool": tool_name,
+                "status": "running",
+                "label": str(preview) if preview else None,
+            })
+            return
+
+        if event_type == "tool.completed":
+            _send({
+                "id": request_id,
+                "type": "tool_progress",
+                "tool": tool_name,
+                "status": "error" if kwargs.get("is_error") else "completed",
+                "duration": kwargs.get("duration"),
+                "label": str(preview) if preview else None,
+            })
+
+    agent = _create_agent(
+        session_id=session_id,
+        requested_model=requested_model,
+        requested_provider=requested_provider,
+        reasoning_effort=requested_effort,
+        callbacks={
+            "stream_delta_callback": on_text_delta,
+            "reasoning_callback": on_reasoning_delta,
+            "tool_progress_callback": on_tool_progress,
+        },
+    )
+    _register_active_agent(_task_key_for(request), request_id, agent)
+    _sync_session_identity(agent, session_id)
+    task_id = string_or_none(request.get("taskId")) or session_id
+    task_title = string_or_none(request.get("taskTitle")) or task_id
+    session_tokens = None
+    clear_session_vars = None
+    try:
+        from gateway.session_context import set_session_vars, clear_session_vars as _clear_session_vars
+
+        clear_session_vars = _clear_session_vars
+        session_tokens = set_session_vars(
+            chat_id=task_id,
+            chat_name=task_title,
+            session_key=session_id,
+        )
+    except Exception:
+        session_tokens = None
+
+    try:
+        result = agent.run_conversation(
+            user_message=message,
+            system_message=system_message,
+            conversation_history=history,
+            task_id=session_id,
+        )
+    finally:
+        if session_tokens is not None and clear_session_vars is not None:
+            try:
+                clear_session_vars(session_tokens)
+            except Exception:
+                pass
+
+    if result.get("interrupted"):
+        # User-initiated stop: end the turn cleanly (the partial reply is already
+        # streamed and persisted by run_conversation) rather than as an error.
+        _send({
+            "id": request_id,
+            "type": "done",
+            "sessionId": getattr(agent, "session_id", None) or session_id,
+            "interrupted": True,
+            "usage": _usage_from_result(result),
+        })
+        return
+
+    final_text = str(result.get("final_response") or "")
+    failure_message = _agent_failure_message(final_text)
+    if failure_message:
+        raise WorkerError(failure_message, code="provider_error")
+
+    if final_text and not state["text"]:
+        _send({"id": request_id, "type": "text_delta", "content": final_text})
+    if result.get("last_reasoning") and not state["thinking"]:
+        _send({"id": request_id, "type": "thinking_delta", "content": str(result["last_reasoning"])})
+
+    context_engine = getattr(agent, "context_compressor", None)
+    context_used = int(result.get("last_prompt_tokens") or 0)
+    context_window = int(getattr(context_engine, "context_length", 0) or 0)
+    context = None
+    if context_used > 0 and context_window > 0:
+        context = {
+            "used_tokens": context_used,
+            "window_tokens": context_window,
+        }
+    _send({"id": request_id, "type": "done", "sessionId": getattr(agent, "session_id", None) or session_id, "context": context, "usage": _usage_from_result(result)})
+
+
+def _run_chat_thread(request_id: str, request: dict[str, Any], task_key: str) -> None:
+    done_sent = False
+    acquired = False
+    try:
+        AGENT_SEMAPHORE.acquire()
+        acquired = True
+        _run_chat(request_id, request)
+        done_sent = True
+    except Exception as exc:
+        _send_error(request_id, exc)
+    finally:
+        if not done_sent:
+            _send({
+                "id": request_id,
+                "type": "done",
+                "sessionId": string_or_none(request.get("sessionId")) or request_id,
+            })
+        if acquired:
+            AGENT_SEMAPHORE.release()
+        _clear_task_active(task_key, request_id)
+
+
+def _submit_background_agent_request(
+    request_id: str,
+    request: dict[str, Any],
+    *,
+    name_prefix: str,
+    handler: Callable[[dict[str, Any]], dict[str, Any]],
+    task_key: str | None = None,
+) -> None:
+    if task_key and not _try_mark_task_active(task_key, request_id):
+        _send_error(
+            request_id,
+            WorkerError(
+                "This task is already running. Wait for the current operation to finish, then retry.",
+                code="task_busy",
+            ),
+        )
+        return
+
+    def runner() -> None:
+        acquired = False
+        try:
+            AGENT_SEMAPHORE.acquire()
+            acquired = True
+            _result(request_id, handler(request))
+        except Exception as exc:
+            _send_error(request_id, exc)
+        finally:
+            if acquired:
+                AGENT_SEMAPHORE.release()
+            if task_key:
+                _clear_task_active(task_key, request_id)
+
+    threading.Thread(
+        target=runner,
+        daemon=True,
+        name=f"{name_prefix}-{request_id[:8]}",
+    ).start()
+
+
+def _submit_chat_request(request_id: str, request: dict[str, Any]) -> None:
+    task_key = _task_key_for(request)
+    if not _try_mark_task_active(task_key, request_id):
+        _send_error(
+            request_id,
+            WorkerError(
+                "This task is already running. Wait for the current turn to finish, then retry.",
+                code="task_busy",
+            ),
+        )
+        _send({
+            "id": request_id,
+            "type": "done",
+            "sessionId": string_or_none(request.get("sessionId")) or request_id,
+        })
+        return
+
+    thread = threading.Thread(
+        target=_run_chat_thread,
+        args=(request_id, request, task_key),
+        daemon=True,
+        name=f"agent-{request_id[:8]}",
+    )
+    thread.start()
+
+
+def _handle_request(request: dict[str, Any]) -> None:
+    request_id = str(request.get("id") or "")
+    if not request_id:
+        return
+
+    request_type = request.get("type")
+    try:
+        if request_type == "health":
+            _warm_agent()
+            _result(request_id, {
+                "ok": True,
+                "agentDir": str(_AGENT_DIR) if _AGENT_DIR else None,
+                "python": sys.executable,
+            })
+        elif request_type == "settings.get":
+            _result(request_id, _defaults_from_config())
+        elif request_type == "settings.set":
+            _result(request_id, _set_defaults(request))
+        elif request_type == "models.list":
+            _result(request_id, _list_models())
+        elif request_type == "session.messages.get":
+            _result(request_id, project_session_messages(request.get("sessionId"), request.get("taskId")))
+        elif request_type == "session.get":
+            _result(request_id, project_session_metadata(request.get("sessionId")))
+        elif request_type == "session.delete":
+            _result(request_id, delete_session(request.get("sessionId")))
+        elif request_type == "goal.status":
+            _result(request_id, _goal_status(request))
+        elif request_type == "goal.set":
+            _result(request_id, _goal_set(request))
+        elif request_type == "goal.pause":
+            _result(request_id, _goal_pause(request))
+        elif request_type == "goal.resume":
+            _result(request_id, _goal_resume(request))
+        elif request_type == "goal.clear":
+            _result(request_id, _goal_clear(request))
+        elif request_type == "goal.evaluate":
+            _submit_background_agent_request(request_id, request, name_prefix="goal", handler=_goal_evaluate)
+        elif request_type == "chat.interrupt":
+            _result(request_id, _interrupt_active_chat(request))
+        elif request_type == "chat":
+            _submit_chat_request(request_id, request)
+        else:
+            raise WorkerError(f"Unknown request type: {request_type}", code="bad_request")
+    except Exception as exc:
+        _send_error(request_id, exc)
+        if request_type == "chat":
+            _send({
+                "id": request_id,
+                "type": "done",
+                "sessionId": string_or_none(request.get("sessionId")) or request_id,
+            })
+
+
+def _run_loop() -> None:
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+            if not isinstance(request, dict):
+                continue
+            _handle_request(request)
+        except Exception as exc:
+            print(f"[hermes-worker] failed to handle request: {exc}", file=sys.stderr, flush=True)
+            traceback.print_exc(file=sys.stderr)
+
+
+def _self_test() -> int:
+    try:
+        _ensure_imports()
+        cfg = _load_config()
+        payload = {
+            "ok": True,
+            "agentDir": str(_AGENT_DIR) if _AGENT_DIR else None,
+            "python": sys.executable,
+            "defaults": _defaults_from_config(cfg),
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": _error_payload(exc)}, ensure_ascii=False, indent=2))
+        return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    os.environ.setdefault("HERMES_QUIET", "1")
+    os.environ.setdefault("HERMES_YOLO_MODE", "1")
+
+    if args.self_test:
+        return _self_test()
+
+    sys.stdout = sys.stderr
+    try:
+        _run_loop()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/workers/hermes_worker_utils.py
+++ b/server/workers/hermes_worker_utils.py
@@ -1,0 +1,33 @@
+"""Shared utilities for the Hermes worker and its submodules.
+
+Kept intentionally small: just the error type and pure helpers that are used
+across `hermes_worker.py` and `hermes_sessions.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class WorkerError(Exception):
+    def __init__(self, message: str, code: str = "worker_error", hint: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.hint = hint
+
+
+def string_or_none(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [json_safe(item) for item in value]
+    return str(value)

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,227 @@
+// Types shared by the gateway server and (eventually) any TypeScript client.
+//
+// Two families live here:
+//   1. The public API surface — Response / Session objects, streaming events,
+//      and the error body — modelled on docs/agents-api.
+//   2. The worker DTOs — the shapes the Hermes worker returns over JSONL, used
+//      by the adapter layer.
+
+// ---------------------------------------------------------------------------
+// Shared scalars
+// ---------------------------------------------------------------------------
+
+export const REASONING_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+/** Response modes. `chat` runs one turn; `goal` is reserved for a fast-follow. */
+export const RESPONSE_MODES = ['chat', 'goal'] as const;
+export type ResponseMode = (typeof RESPONSE_MODES)[number];
+
+/** The only agent this build routes to. */
+export const SUPPORTED_AGENTS = ['hermes'] as const;
+export type AgentName = (typeof SUPPORTED_AGENTS)[number];
+export const DEFAULT_AGENT: AgentName = 'hermes';
+
+/** Safety cap for goal mode. Keep in sync with GOAL_MAX_TURNS in hermes_worker.py. */
+export const GOAL_MAX_TURNS = 20;
+
+export interface AppVersion {
+  name: string;
+  version: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: errors
+// ---------------------------------------------------------------------------
+
+/** The stable, machine-readable error body. Branch on `code`, show `message`. */
+export interface ApiError {
+  code: string;
+  message: string;
+  param?: string;
+  hint?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: usage
+// ---------------------------------------------------------------------------
+
+export interface TurnUsage {
+  input_tokens: number;
+  output_tokens: number;
+  /** Null when the provider/model did not report a cost for the turn. */
+  cost_usd?: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: responses
+// ---------------------------------------------------------------------------
+
+export const RESPONSE_STATUSES = ['in_progress', 'completed', 'failed', 'cancelled'] as const;
+export type ResponseStatus = (typeof RESPONSE_STATUSES)[number];
+
+/** One agentic turn: the input, the agent's work, and its reply. */
+export interface ResponseObject {
+  id: string;
+  session_id: string;
+  status: ResponseStatus;
+  agent: AgentName;
+  model: string | null;
+  provider: string | null;
+  output_text: string;
+  usage: TurnUsage | null;
+  error: ApiError | null;
+  metadata: Record<string, unknown> | null;
+  created: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: sessions
+// ---------------------------------------------------------------------------
+
+/** One conversation. The gateway holds the index; Hermes owns the transcript. */
+export interface SessionObject {
+  id: string;
+  agent: AgentName;
+  model: string | null;
+  provider: string | null;
+  created: number;
+  last_response_at: number | null;
+}
+
+/** A message in a session's history, projected from Hermes SessionDB. */
+export interface SessionMessage {
+  id: string;
+  session_id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  thinking?: string;
+  created_at: number;
+}
+
+export interface SessionWithHistory extends SessionObject {
+  history: SessionMessage[];
+}
+
+// ---------------------------------------------------------------------------
+// Public API: streaming events (Server-Sent Events)
+// ---------------------------------------------------------------------------
+
+export type ResponseStreamEvent =
+  | { event: 'response.created'; data: { id: string; session_id: string } }
+  | { event: 'response.reasoning.delta'; data: { text: string } }
+  | { event: 'response.output_text.delta'; data: { text: string } }
+  | { event: 'response.tool_call.started'; data: { tool: string; label?: string } }
+  | { event: 'response.tool_call.completed'; data: { tool: string; duration_ms?: number } }
+  | { event: 'response.tool_call.failed'; data: { tool: string; error?: string } }
+  | { event: 'response.completed'; data: { output_text: string; usage: TurnUsage | null } }
+  | { event: 'response.failed'; data: { error: ApiError } };
+
+export type ResponseStreamEventName = ResponseStreamEvent['event'];
+
+// ---------------------------------------------------------------------------
+// Worker DTOs (returned by the Hermes worker over JSONL)
+// ---------------------------------------------------------------------------
+
+/** Per-turn run dials passed through to the Hermes worker. */
+export interface AgentRunSettings {
+  model?: string | null;
+  provider?: string | null;
+  reasoningEffort?: ReasoningEffort | null;
+}
+
+export interface ContextUsage {
+  used_tokens: number;
+  window_tokens: number;
+}
+
+/** A raw message row projected by the worker's `session.messages.get`. */
+export interface HermesMessage {
+  id: string;
+  task_id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  thinking?: string;
+  created_at: number;
+}
+
+/** The worker's `session.get` projection. */
+export interface SessionMetadata {
+  id: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  estimated_cost_usd: number | null;
+  cost_status: string | null;
+  model: string | null;
+}
+
+export interface AgentDefaults {
+  provider: string | null;
+  model: string | null;
+  baseUrl: string | null;
+  apiMode: string | null;
+  reasoningEffort: ReasoningEffort | null;
+  showReasoning: boolean;
+}
+
+export interface AgentModelOption {
+  id: string;
+  label: string;
+  source: 'current' | 'catalog' | 'custom' | 'alias';
+  provider?: string | null;
+  isCurrentDefault?: boolean;
+}
+
+export interface AgentModelGroup {
+  provider: string;
+  models: AgentModelOption[];
+}
+
+export interface AgentModelsResponse {
+  defaultModel: string | null;
+  activeProvider: string | null;
+  groups: AgentModelGroup[];
+}
+
+// ---------------------------------------------------------------------------
+// Goal primitives (reserved for the goal-mode fast-follow)
+// ---------------------------------------------------------------------------
+
+export interface GoalStateSnapshot {
+  goal: string;
+  status: 'active' | 'paused' | 'done' | 'cleared';
+  turnsUsed: number;
+  maxTurns: number;
+  lastReason?: string | null;
+  pausedReason?: string | null;
+}
+
+export interface GoalDecision {
+  status: GoalStateSnapshot['status'] | null;
+  shouldContinue: boolean;
+  continuationPrompt?: string | null;
+  verdict: 'done' | 'continue' | 'skipped' | 'inactive';
+  reason: string;
+  message: string;
+  state?: GoalStateSnapshot | null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: GET /v1/models response
+// ---------------------------------------------------------------------------
+
+export interface ModelInfo {
+  id: string;
+  label: string;
+  provider: string | null;
+  is_default: boolean;
+}
+
+export interface ModelsListResponse {
+  default_model: string | null;
+  default_provider: string | null;
+  data: ModelInfo[];
+}

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -1,0 +1,176 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+interface ResponseBody {
+  id: string;
+  session_id: string;
+  status: string;
+  agent: string;
+  output_text: string;
+  usage: unknown;
+  metadata: Record<string, unknown> | null;
+}
+
+async function jsonOk<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  assert.equal(res.status, 200, JSON.stringify(body));
+  return body as T;
+}
+
+function assertCompleted(body: ResponseBody): void {
+  assert.match(body.id, /^resp_/);
+  assert.match(body.session_id, /^sess_/);
+  assert.equal(body.status, 'completed');
+  assert.equal(body.agent, 'hermes');
+  assert.ok(body.output_text.trim().length > 0);
+  assert.ok(body.usage);
+}
+
+async function waitForTerminalResponse(responseId: string): Promise<ResponseBody> {
+  for (let i = 0; i < 120; i += 1) {
+    const body = await jsonOk<ResponseBody>(await fetch(`${base}/v1/responses/${responseId}`));
+    if (body.status !== 'in_progress') return body;
+    await delay(500);
+  }
+  throw new Error(`response ${responseId} stayed in_progress`);
+}
+
+test('health, version, and models endpoints answer from the real gateway', async () => {
+  assert.deepEqual(await jsonOk(await fetch(`${base}/v1/health`)), { ok: true, hermes: true });
+
+  const version = await jsonOk<{ name: string; version: string }>(await fetch(`${base}/v1/version`));
+  assert.equal(version.name, 'agent37-gateway');
+  assert.ok(version.version.length > 0);
+
+  const models = await jsonOk<{ data: unknown[] }>(await fetch(`${base}/v1/models`));
+  assert.ok(Array.isArray(models.data));
+});
+
+test('responses and sessions work end-to-end through the local LLM', async () => {
+  const marker = `gateway-integration-${Date.now()}`;
+  const created = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      input: `Reply with one short sentence. Include this marker: ${marker}`,
+      reasoning_effort: 'low',
+      metadata: { marker },
+    }),
+  );
+  assertCompleted(created);
+  assert.equal(created.metadata?.marker, marker);
+
+  const fetched = await jsonOk<ResponseBody>(await fetch(`${base}/v1/responses/${created.id}`));
+  assert.equal(fetched.output_text, created.output_text);
+
+  const sessions = await jsonOk<{ data: Array<{ id: string }> }>(await fetch(`${base}/v1/sessions`));
+  assert.ok(sessions.data.some((session) => session.id === created.session_id));
+
+  const session = await jsonOk<{
+    id: string;
+    history: Array<{ role: string; content: string }>;
+  }>(await fetch(`${base}/v1/sessions/${created.session_id}`));
+  assert.equal(session.id, created.session_id);
+  assert.ok(session.history.some((message) => message.role === 'user' && message.content.includes(marker)));
+  assert.ok(session.history.some((message) => message.role === 'assistant' && message.content.trim()));
+
+  const continued = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      session_id: created.session_id,
+      input: 'Reply with one short follow-up sentence.',
+      reasoning_effort: 'low',
+    }),
+  );
+  assertCompleted(continued);
+  assert.equal(continued.session_id, created.session_id);
+
+  const deleted = await jsonOk<{ id: string; deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}`, { method: 'DELETE' }),
+  );
+  assert.deepEqual(deleted, { id: created.session_id, deleted: true });
+  assert.equal((await fetch(`${base}/v1/sessions/${created.session_id}`)).status, 404);
+  assert.equal((await fetch(`${base}/v1/responses/${created.id}`)).status, 404);
+});
+
+test('streaming responses can be replayed', async () => {
+  const res = await postJson(base, {
+    input: 'Reply with one short sentence for a streaming integration test.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') ?? '', /text\/event-stream/);
+
+  const events = await new SseReader(res).drain();
+  assert.equal(events[0]?.event, 'response.created');
+  assert.equal(events.at(-1)?.event, 'response.completed');
+  assert.ok(events.some((event) => event.event === 'response.output_text.delta'));
+
+  const responseId = events[0].data.id as string;
+  assertCompleted(await jsonOk<ResponseBody>(await fetch(`${base}/v1/responses/${responseId}`)));
+
+  const replay = await fetch(`${base}/v1/responses/${responseId}/stream`);
+  assert.equal(replay.status, 200);
+  const replayEvents = await new SseReader(replay).drain();
+  assert.equal(replayEvents[0]?.event, 'response.created');
+  assert.equal(replayEvents.at(-1)?.event, 'response.completed');
+});
+
+test('an in-flight response blocks another turn and can be cancelled', async () => {
+  const slow = await postJson(base, {
+    input: 'Count from 1 to 2000, one number per line. Do not summarize.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(slow.status, 200);
+
+  const reader = new SseReader(slow);
+  const opening = await reader.until((event) => event.event === 'response.created');
+  const created = opening.find((event) => event.event === 'response.created');
+  assert.ok(created);
+  const responseId = created.data.id as string;
+  const sessionId = created.data.session_id as string;
+
+  const busy = await postJson(base, { session_id: sessionId, input: 'start another turn' });
+  assert.equal(busy.status, 409);
+  assert.equal((await busy.json()).error.code, 'session_busy');
+
+  const cancel = await fetch(`${base}/v1/responses/${responseId}/cancel`, { method: 'POST' });
+  assert.equal(cancel.status, 200);
+  await reader.drain();
+  assert.equal((await waitForTerminalResponse(responseId)).status, 'cancelled');
+});
+
+test('validation and not-found errors stay stable', async () => {
+  const noInput = await postJson(base, {});
+  assert.equal(noInput.status, 400);
+  assert.equal((await noInput.json()).error.param, 'input');
+
+  const goal = await postJson(base, { input: 'x', mode: 'goal' });
+  assert.equal(goal.status, 400);
+  assert.equal((await goal.json()).error.param, 'mode');
+
+  const response = await fetch(`${base}/v1/responses/resp_missing`);
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error.code, 'response_not_found');
+
+  const session = await fetch(`${base}/v1/sessions/sess_missing`);
+  assert.equal(session.status, 404);
+  assert.equal((await session.json()).error.code, 'session_not_found');
+
+  const route = await fetch(`${base}/v1/nope`);
+  assert.equal(route.status, 404);
+  assert.equal((await route.json()).error.code, 'not_found');
+});

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface TestServer {
+  base: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Boot the real Express app on an ephemeral port against a throwaway state dir.
+ * Sets the gateway home BEFORE importing the app (the SQLite db opens at import).
+ */
+export async function startTestServer(): Promise<TestServer> {
+  process.env.AGENT37_GATEWAY_HOME = mkdtempSync(join(tmpdir(), 'a37gw-test-'));
+  process.env.NODE_ENV = 'test';
+
+  const { default: app } = await import('../server/app.js');
+  const { adapter } = await import('../server/agent.js');
+  const { shutdownLiveRuns } = await import('../server/live-runs.js');
+
+  const server: Server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    base: `http://127.0.0.1:${port}`,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      shutdownLiveRuns();
+      await adapter.stop?.();
+    },
+  };
+}
+
+export interface SseEvent {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+/** A pull-based reader over an SSE fetch Response body. */
+export class SseReader {
+  private reader: ReadableStreamDefaultReader<Uint8Array>;
+  private decoder = new TextDecoder();
+  private buffer = '';
+  private queue: SseEvent[] = [];
+  private done = false;
+
+  constructor(res: Response) {
+    if (!res.body) throw new Error('response has no body');
+    this.reader = res.body.getReader();
+  }
+
+  /** Resolve the next SSE event, or null when the stream ends. */
+  async next(): Promise<SseEvent | null> {
+    while (this.queue.length === 0 && !this.done) {
+      const { value, done } = await this.reader.read();
+      if (done) {
+        this.done = true;
+        break;
+      }
+      this.buffer += this.decoder.decode(value, { stream: true });
+      const frames = this.buffer.split('\n\n');
+      this.buffer = frames.pop() ?? '';
+      for (const frame of frames) {
+        const event = frame.match(/^event: (.+)$/m)?.[1];
+        if (!event) continue; // skip comments / keepalives
+        const dataLine = frame.match(/^data: (.+)$/m)?.[1];
+        this.queue.push({ event, data: dataLine ? JSON.parse(dataLine) : {} });
+      }
+    }
+    return this.queue.shift() ?? null;
+  }
+
+  /** Read until an event matches the predicate (inclusive). Returns all read so far. */
+  async until(predicate: (e: SseEvent) => boolean): Promise<SseEvent[]> {
+    const collected: SseEvent[] = [];
+    for (;;) {
+      const event = await this.next();
+      if (!event) return collected;
+      collected.push(event);
+      if (predicate(event)) return collected;
+    }
+  }
+
+  /** Drain the rest of the stream. */
+  async drain(): Promise<SseEvent[]> {
+    const rest: SseEvent[] = [];
+    for (;;) {
+      const event = await this.next();
+      if (!event) return rest;
+      rest.push(event);
+    }
+  }
+
+  async cancel(): Promise<void> {
+    try {
+      await this.reader.cancel();
+    } catch {
+      // already closed
+    }
+  }
+}
+
+export async function postJson(
+  base: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["server", "shared", "test"]
+}


### PR DESCRIPTION
## What

Introduces the **Agent37 Gateway** — a small, Responses-style HTTP API that runs inside an instance and routes turns to the instance's agent. v1 routes to **Hermes**; the adapter seam leaves room for OpenClaw / Claude Code next.

```
HTTP / SSE client
  ↕  HTTP + Server-Sent Events
Agent37 Gateway  (Express, :3737)
  ↕  JSONL over stdin/stdout
Python worker    (hermes_worker.py)
  ↕  direct Python import
Hermes AIAgent
```

## Surface

- `POST /v1/responses` — run a turn (start or continue a session), streaming (SSE) or not, with reconnect/replay and one-active-turn-per-session.
- `GET /v1/responses/:id`, `GET /:id/stream`, `POST /:id/cancel`.
- `/v1/sessions` (list / get-with-history / delete), `/v1/models`, health + version.
- SQLite holds the session/response index; an in-memory live-run registry buffers stream events for replay. The durable transcript stays in Hermes' SessionDB.
- Bruno collection under `bruno/`, `.env.example`, and an end-to-end test suite.

## /simplify pass

Folded in a quality pass over the changed code:

- One `optionalEnum` helper replaces three near-identical request-body validators (agent / mode / reasoning_effort).
- A single `WORKER_CODE_MAP` table replaces the two parallel switch/if-ladders that mapped worker error codes → HTTP status + API code.
- A `stringifyJson` helper mirrors the existing `parseJson` for the nullable JSON columns.

## Test plan

- `npm run typecheck` — clean.
- `npm test` — passes 5/5. The suite is end-to-end and exercises a live Hermes worker + local LLM, so it needs a working Hermes install to run.
