### PR TITLE
Bare ids + strict PORT binding (v0.1.0 prep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Non-streaming returns the finished response object:
 
 ```jsonc
 {
-  "id": "resp_…",
-  "session_id": "sess_…",
+  "id": "…",
+  "session_id": "…",
   "status": "completed",          // in_progress | completed | failed | cancelled
   "agent": "hermes",
   "model": null,
@@ -179,7 +179,7 @@ error bodies.
 A [Bruno](https://www.usebruno.com/) collection lives in [`bruno/`](bruno/) —
 open that folder in Bruno, pick the **local** environment (`baseUrl`
 `http://localhost:3737`), and run the requests top to bottom. *Create Response*
-saves the `session_id` and `resp_` id into the environment, so *Continue
+saves the `session_id` and response id into the environment, so *Continue
 Session*, *Get Response*, *Cancel*, and *Delete Session* just work.
 
 ## Configuration

--- a/bruno/gateway/04 Create Response.bru
+++ b/bruno/gateway/04 Create Response.bru
@@ -44,7 +44,7 @@ tests {
 docs {
   Start a new conversation: send `input` with no `session_id`. The reply returns
   a `session_id` (saved to the env) you reuse to continue the thread, and a
-  `resp_` id (also saved) for Get Response / Cancel.
+  response id (also saved) for Get Response / Cancel.
 
   Other optional fields: `model`, `provider`, `reasoning_effort`
   (none|minimal|low|medium|high|xhigh), `metadata` (<=16 keys), `stream`.

--- a/server/ids.ts
+++ b/server/ids.ts
@@ -7,18 +7,10 @@ function compactUuid(): string {
 /** Mint a session id. Used verbatim as the Hermes session id (the worker
  *  resolves Hermes resume/compression chains internally). */
 export function newSessionId(): string {
-  return `sess_${compactUuid()}`;
+  return compactUuid();
 }
 
 /** Mint a response id for a single turn. */
 export function newResponseId(): string {
-  return `resp_${compactUuid()}`;
-}
-
-export function isSessionId(value: unknown): value is string {
-  return typeof value === 'string' && value.startsWith('sess_');
-}
-
-export function isResponseId(value: unknown): value is string {
-  return typeof value === 'string' && value.startsWith('resp_');
+  return compactUuid();
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,9 @@ import { shutdownLiveRuns } from './live-runs.js';
 
 const PORT = parseInt(process.env.PORT || '3737', 10);
 const HOST = process.env.HOST || '0.0.0.0';
-const PORT_FALLBACK_ATTEMPTS = 20;
+// An explicit PORT must bind exactly: behind the platform edge the route points
+// at one port, so silently falling back would strand the instance URL.
+const PORT_FALLBACK_ATTEMPTS = process.env.PORT ? 1 : 20;
 
 const httpServer = createServer(app);
 let shuttingDown = false;

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -32,8 +32,8 @@ async function jsonOk<T>(res: Response): Promise<T> {
 }
 
 function assertCompleted(body: ResponseBody): void {
-  assert.match(body.id, /^resp_/);
-  assert.match(body.session_id, /^sess_/);
+  assert.match(body.id, /^[a-f0-9]{32}$/);
+  assert.match(body.session_id, /^[a-f0-9]{32}$/);
   assert.equal(body.status, 'completed');
   assert.equal(body.agent, 'hermes');
   assert.ok(body.output_text.trim().length > 0);
@@ -162,11 +162,11 @@ test('validation and not-found errors stay stable', async () => {
   assert.equal(goal.status, 400);
   assert.equal((await goal.json()).error.param, 'mode');
 
-  const response = await fetch(`${base}/v1/responses/resp_missing`);
+  const response = await fetch(`${base}/v1/responses/missing`);
   assert.equal(response.status, 404);
   assert.equal((await response.json()).error.code, 'response_not_found');
 
-  const session = await fetch(`${base}/v1/sessions/sess_missing`);
+  const session = await fetch(`${base}/v1/sessions/missing`);
   assert.equal(session.status, 404);
   assert.equal((await session.json()).error.code, 'session_not_found');
 


### PR DESCRIPTION
Two small changes ahead of cutting the first tag:

- **Bare ids**: drop the `sess_`/`resp_` prefixes — ids are bare compact uuids, matching the platform-wide no-id-prefix convention.
- **Strict PORT binding**: when `PORT` is explicitly set, bind exactly that port or exit non-zero. Behind the platform edge the route points at one port, so the old silent +1..20 fallback would strand the instance URL. The fallback remains for local dev when `PORT` is unset.

`npm run typecheck` and `npm test` (live Hermes + LLM) both pass locally: 5/5.