### PR TITLE
Settle provider-refused turns as failed instead of empty completed

### DIFF
--- a/server/adapters/hermes-worker.ts
+++ b/server/adapters/hermes-worker.ts
@@ -95,6 +95,11 @@ function formatWorkerError(error: string | WorkerErrorPayload | undefined): stri
   return `${code}${error.message}${hint}`;
 }
 
+function workerErrorMessage(error: string | WorkerErrorPayload | undefined): string {
+  if (!error) return 'Hermes worker error';
+  return typeof error === 'string' ? error : error.message;
+}
+
 function workerErrorCode(error: string | WorkerErrorPayload | undefined): string | undefined {
   return typeof error === 'object' ? error.code : undefined;
 }
@@ -442,7 +447,7 @@ export class HermesWorkerAdapter implements AgentAdapter, GoalCapableAdapter {
         case 'error':
           yield {
             type: 'error',
-            error: formatWorkerError(event.error),
+            error: workerErrorMessage(event.error),
             code: workerErrorCode(event.error),
             hint: workerErrorHint(event.error),
           };

--- a/server/responses.ts
+++ b/server/responses.ts
@@ -150,9 +150,13 @@ export async function driveResponse(begun: BegunResponse, input: string): Promis
           emitToolProgress(responseId, event);
           break;
         case 'done':
+          // The worker closes every turn with a trailing `done`, including
+          // after an `error` event — a reported failure must stay failed.
           sawTerminal = true;
-          usage = event.usage ?? null;
-          status = event.interrupted ? 'cancelled' : 'completed';
+          if (status !== 'failed') {
+            usage = event.usage ?? null;
+            status = event.interrupted ? 'cancelled' : 'completed';
+          }
           break;
         case 'error':
           sawTerminal = true;

--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -168,6 +168,9 @@ def _error_payload(exc: BaseException) -> dict[str, str]:
     elif "rate limit" in lower or "429" in lower:
         code = "rate_limit"
         hint = "Retry later or switch provider/model."
+    elif "instance_budget_exhausted" in lower or "insufficient_balance" in lower:
+        code = "quota_exhausted"
+        hint = "Raise the instance budget or top up the workspace balance."
     elif "quota" in lower or "credit" in lower or "insufficient" in lower:
         code = "quota_exhausted"
         hint = "Top up provider account or switch provider/model."
@@ -1313,6 +1316,14 @@ def _run_chat(request_id: str, request: dict[str, Any]) -> None:
         return
 
     final_text = str(result.get("final_response") or "")
+    if result.get("failed") and not final_text:
+        # The agent's run loop aborted (e.g. every provider call was refused)
+        # without producing a reply. Surface it as an error instead of letting
+        # the turn settle as an empty success.
+        error_text = str(result.get("error") or "") or "The agent run failed without producing a response."
+        payload = _error_payload(RuntimeError(error_text))
+        raise WorkerError(error_text, code=payload["code"], hint=payload.get("hint"))
+
     failure_message = _agent_failure_message(final_text)
     if failure_message:
         raise WorkerError(failure_message, code="provider_error")

--- a/test/provider-failure.integration.test.ts
+++ b/test/provider-failure.integration.test.ts
@@ -1,0 +1,111 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+// Refuses every LLM call the way the Agent37 starter proxy does when the
+// managed budget is exhausted: HTTP 402 with an OpenAI-style error body.
+function startBudgetExhaustedProvider(): Promise<{ server: Server; port: number }> {
+  const provider = createServer((req, res) => {
+    if (req.method === 'GET') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ data: [] }));
+      return;
+    }
+    res.writeHead(402, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error: {
+          type: 'instance_budget_exhausted',
+          message: 'Instance budget exhausted. Raise the monthly cap or top up this instance to continue.',
+        },
+      }),
+    );
+  });
+  return new Promise((resolve) => {
+    provider.listen(0, '127.0.0.1', () => {
+      resolve({ server: provider, port: (provider.address() as AddressInfo).port });
+    });
+  });
+}
+
+let provider: Server;
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  const started = await startBudgetExhaustedProvider();
+  provider = started.server;
+
+  // A throwaway HERMES_HOME whose only provider is the refusing mock, so the
+  // real worker and the real Hermes agent run the turn against it.
+  const hermesHome = mkdtempSync(join(tmpdir(), 'a37gw-hermes-402-'));
+  writeFileSync(
+    join(hermesHome, 'config.yaml'),
+    [
+      'model:',
+      '  default: mock-model',
+      '  provider: custom:budget-mock',
+      'custom_providers:',
+      '  - name: budget-mock',
+      `    base_url: http://127.0.0.1:${started.port}/v1`,
+      '    api_key: test-key',
+      '    model: mock-model',
+      '',
+    ].join('\n'),
+  );
+  process.env.HERMES_HOME = hermesHome;
+  // Pointing HERMES_HOME away from the real install hides the venv from the
+  // adapter's auto-detection; pin it unless the developer already overrides.
+  if (!process.env.HERMES_PYTHON && !process.env.HERMES_AGENT_DIR) {
+    process.env.HERMES_PYTHON = join(homedir(), '.hermes/hermes-agent/venv/bin/python');
+  }
+
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+  await new Promise<void>((resolve) => provider.close(() => resolve()));
+});
+
+test('a turn whose provider calls are all refused settles as failed with a structured error', async () => {
+  const res = await postJson(base, { input: 'Reply with the single word: ok' });
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as {
+    id: string;
+    status: string;
+    output_text: string;
+    error: { code: string; message: string; hint?: string } | null;
+  };
+  assert.equal(body.status, 'failed', JSON.stringify(body));
+  assert.ok(body.error);
+  assert.equal(body.error.code, 'quota_exhausted');
+  assert.match(body.error.message, /instance_budget_exhausted|budget exhausted/i);
+  assert.match(body.error.hint ?? '', /instance budget|workspace balance/i);
+  assert.equal(body.output_text, '');
+
+  const fetched = (await (await fetch(`${base}/v1/responses/${body.id}`)).json()) as typeof body;
+  assert.equal(fetched.status, 'failed');
+  assert.equal(fetched.error?.code, 'quota_exhausted');
+});
+
+test('a streaming turn whose provider calls are all refused ends with response.failed', async () => {
+  const res = await postJson(base, { input: 'Reply with the single word: ok', stream: true });
+  assert.equal(res.status, 200);
+
+  const events = await new SseReader(res).drain();
+  assert.equal(events[0]?.event, 'response.created');
+  assert.ok(!events.some((event) => event.event === 'response.completed'), JSON.stringify(events));
+
+  const failed = events.at(-1);
+  assert.equal(failed?.event, 'response.failed');
+  const error = (failed?.data as { error: { code: string; message: string; hint?: string } }).error;
+  assert.equal(error.code, 'quota_exhausted');
+  assert.match(error.hint ?? '', /instance budget|workspace balance/i);
+});


### PR DESCRIPTION
Fixes #4

## Bug

When the instance's managed LLM call is refused upstream (the Agent37 starter proxy returns HTTP 402 with `error.type` `instance_budget_exhausted` or `insufficient_balance`), the gateway settled the turn as `status: "completed"` with empty `output_text`, `error: null`, and zero usage — on both the non-streaming and streaming paths. A chat client could not tell "the agent said nothing" from "every LLM call was refused".

## Root cause

Two layers, both needed:

1. **Worker swallows the agent-reported failure** (`server/workers/hermes_worker.py`, `_run_chat`). On a non-retryable provider error (402 billing included, once Hermes' credential-rotation/fallback recovery paths are exhausted), hermes-agent's run loop returns `{"final_response": None, "failed": True, "error": str(api_error)}` — it does not raise. The worker only inspected `final_response` text prefixes (`_agent_failure_message`), so an empty `final_response` produced a clean `done` event with zero usage and the gateway completed the turn.
2. **Gateway lets the trailing `done` mask errors** (`server/responses.ts`, `driveResponse`). The worker protocol always closes a turn with a trailing `done` event, including after an `error` event. The `done` case unconditionally reset `status` to `completed`, so even when the worker *did* report an error, the turn settled as completed. This masked the entire existing worker error vocabulary on the turn path.

## Fix

- **Worker**: after `run_conversation`, if the result is `failed` and produced no `final_response`, raise a `WorkerError` built from the agent's error string, classified through the existing `_error_payload` vocabulary. A new classification branch maps the starter-proxy refusal types (`instance_budget_exhausted`, `insufficient_balance`) to `quota_exhausted` with the hint "Raise the instance budget or top up the workspace balance." Turns where the agent crafted a reply despite failing (e.g. content-policy blocks, billing message after max retries) keep their current behavior, so legitimately non-empty turns are not flipped.
- **Gateway**: in `driveResponse`, the trailing `done` no longer overrides an already-recorded failure, so the turn persists as `failed` and emits the `response.failed` terminal SSE event on both paths.
- **Adapter**: the `error` stream event now carries the bare worker message; the code and hint already travel in their own fields, so `error.message` no longer duplicates them (`[code] message hint`).

## Testing

- New integration test `test/provider-failure.integration.test.ts`: boots the real gateway + real Hermes worker against a throwaway `HERMES_HOME` whose only configured provider is a local mock that refuses every LLM call exactly like the starter proxy (HTTP 402, OpenAI-style `instance_budget_exhausted` body). Asserts the non-streaming turn returns `status: "failed"` with `error: {code: "quota_exhausted", message, hint}` and empty `output_text` (and persists that via `GET /v1/responses/{id}`), and the streaming turn emits `response.created` → `response.failed` with no `response.completed`.
- `npm run typecheck && npm test` — green locally (7/7, including the pre-existing suite against the real local Hermes worker/LLM).

## Shipping note

This changes gateway server code and the bundled Python worker, so shipping requires a gateway version bump and a hermes image rebuild. Not bumped here, per repo convention of dedicated version-prep commits.