### PR TITLE
Non-stream turns: first-byte heartbeat so long turns survive the edge

### DIFF
--- a/server/routes/responses.ts
+++ b/server/routes/responses.ts
@@ -8,7 +8,7 @@ import {
 import { isRecord, responseNotFound, validationError } from '../errors.js';
 import { initSSE, writeStreamEvent } from '../sse.js';
 import { attach, hasRun } from '../live-runs.js';
-import { getResponse } from '../db/queries.js';
+import { getResponse, setResponseStatus } from '../db/queries.js';
 import {
   beginResponse,
   cancelResponse,
@@ -18,6 +18,17 @@ import {
 } from '../responses.js';
 
 export const responsesRouter = Router();
+
+// A non-streaming turn sends its response headers only when the turn finishes, and every
+// hop to the client caps how long it will wait for headers (~100s at Cloudflare's edge,
+// not configurable) — which used to kill stream:false turns longer than that. So the
+// route commits its headers immediately and ticks a whitespace heartbeat while the turn
+// runs: leading whitespace before a JSON document is valid JSON (RFC 8259), so clients
+// parse the body unchanged. Env override exists so tests can tighten the cadence; the
+// 50ms floor keeps a typo'd value from becoming a whitespace flood (Node clamps NaN/0
+// intervals to 1ms).
+const heartbeatEnv = parseInt(process.env.GATEWAY_NONSTREAM_HEARTBEAT_MS || '', 10);
+const NONSTREAM_HEARTBEAT_MS = Number.isFinite(heartbeatEnv) && heartbeatEnv >= 50 ? heartbeatEnv : 25_000;
 
 function optionalString(value: unknown, field: string): string | null {
   if (value === undefined || value === null) return null;
@@ -121,11 +132,52 @@ responsesRouter.post('/', async (req, res, next) => {
     return;
   }
 
+  // Non-streaming: commit 200 before driving the turn — beginResponse has succeeded, and
+  // from here on agent failures are encoded as status:"failed" in the body by contract.
+  // Once headers are flushed, res.json() would throw and the app-level error handler can
+  // only defer, so the body is written manually and errors are settled right here.
+  res.status(200);
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+  const heartbeat = setInterval(() => {
+    if (!res.writableEnded && !res.destroyed) res.write(' ');
+  }, NONSTREAM_HEARTBEAT_MS);
+  heartbeat.unref();
+  res.on('close', () => clearInterval(heartbeat));
   try {
     const response = await driveResponse(begun, request.input);
-    res.status(200).json(response);
+    if (!res.writableEnded && !res.destroyed) res.end(JSON.stringify(response));
   } catch (error) {
-    next(error);
+    // driveResponse never rejects by contract (agent failures resolve as failed
+    // responses); this is the same last resort the stream branch has. Settle the stored
+    // row too, so a later GET /v1/responses/:id agrees with the body written below.
+    console.error('driveResponse crashed:', error);
+    try {
+      setResponseStatus(begun.responseId, 'failed');
+    } catch {
+      // the row may be unreachable for the same reason driveResponse crashed
+    }
+    if (!res.writableEnded && !res.destroyed) {
+      res.end(
+        JSON.stringify({
+          id: begun.responseId,
+          session_id: begun.sessionId,
+          status: 'failed',
+          agent: request.agent,
+          model: begun.model,
+          provider: begun.provider,
+          output_text: '',
+          usage: null,
+          error: { code: 'internal_error', message: 'Something went wrong.' },
+          metadata: null,
+          created: Date.now(),
+        }),
+      );
+    }
+  } finally {
+    clearInterval(heartbeat);
   }
 });
 

--- a/test/nonstream-heartbeat.integration.test.ts
+++ b/test/nonstream-heartbeat.integration.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { startTestServer, postJson } from './test-helpers.js';
+
+// The non-streaming branch must send its headers immediately and tick a whitespace
+// heartbeat while the turn runs — Cloudflare's edge kills connections that stay
+// header-silent for ~100s, which used to 502 every stream:false turn longer than that.
+// The final body must still parse as the normal response JSON despite the padding.
+// Uses a fake adapter (setAdapter), so this file needs no live Hermes worker or LLM.
+test('non-stream turns send first bytes immediately and stay valid JSON', async () => {
+  process.env.GATEWAY_NONSTREAM_HEARTBEAT_MS = '300'; // read at route-module load, before startTestServer imports it
+  const server = await startTestServer();
+  const { setAdapter } = await import('../server/agent.js');
+  setAdapter({
+    // eslint-disable-next-line require-yield
+    async *chatStream() {
+      yield { type: 'text_delta', content: 'hello from the fake adapter' };
+      await new Promise((resolve) => setTimeout(resolve, 1400));
+      yield { type: 'done', sessionId: 'fake', usage: { input_tokens: 1, output_tokens: 2, cost_usd: 0 } };
+    },
+  } as never);
+
+  try {
+    const started = Date.now();
+    const res = await postJson(server.base, { input: 'hi', stream: false });
+    const headersAfterMs = Date.now() - started;
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+    // Headers must arrive while the turn is still running, not when it finishes.
+    assert.ok(headersAfterMs < 900, `headers took ${headersAfterMs}ms`);
+
+    const text = await res.text();
+    assert.ok(Date.now() - started >= 1400, 'body should settle only when the turn ends');
+    const padding = text.match(/^ */)?.[0] ?? '';
+    assert.ok(padding.length >= 2, `expected >=2 heartbeat spaces before the JSON, got ${padding.length}`);
+    const body = JSON.parse(text);
+    assert.equal(body.status, 'completed');
+    assert.equal(body.output_text, 'hello from the fake adapter');
+    assert.ok(body.usage, 'usage from the done event should persist');
+
+    // A client that aborts mid-turn must not crash the route; the turn still finalizes
+    // server-side and releases the one-turn-per-session lock.
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 300);
+    await fetch(`${server.base}/v1/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ input: 'aborted turn', stream: false, session_id: body.session_id }),
+      signal: controller.signal,
+    })
+      .then((r) => r.text())
+      .catch(() => null);
+    await new Promise((resolve) => setTimeout(resolve, 1700)); // the aborted turn finishes server-side
+    const after = await postJson(server.base, { input: 'still alive?', stream: false, session_id: body.session_id });
+    assert.equal(after.status, 200);
+    assert.equal(JSON.parse(await after.text()).status, 'completed');
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Why

`stream:false` turns sent response headers only at turn end. Cloudflare's edge (the Worker's mesh fetch) kills any connection that stays header-silent ~100s — not configurable on any plan — so non-streaming turns longer than that died with an opaque error while the turn kept running. Reproduced live before/after.

## What

The non-stream branch of `POST /v1/responses` commits `200` + headers immediately after `beginResponse` succeeds and ticks a single-space heartbeat every 25s until the turn settles, then writes the JSON body. Leading whitespace before a JSON document is valid JSON (RFC 8259) — `fetch().json()`, Python `requests.json()`, and Go's decoder all parse it unchanged. Committing 200 up front is safe: every documented 4xx throws before the flush, and agent failures were already `200` + `status:"failed"` by contract.

Reviewed adversarially: post-flush errors settle in-route (the app error handler can only defer once headers are sent) with the stored row marked `failed` for POST/GET parity; heartbeat interval is env-clamped (≥50ms) so a typo'd value can't become a whitespace flood; `X-Accel-Buffering: no` for proxy parity with the SSE path; client aborts mid-turn neither crash the route nor strand the session lock.

## Verification

- `npm run typecheck` clean; full suite **8/8** including the live-worker tests (AGENTS.md gate).
- New `test/nonstream-heartbeat.integration.test.ts` uses `setAdapter()` with a deterministic fake — pins early headers (<900ms while the turn runs 1.4s), ≥2 heartbeat spaces, JSON-with-padding parses, and abort-mid-turn still finalizes the turn and frees the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)