### PR TITLE
Filter GET /v1/sessions by agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ With `stream: true` the body is a Server-Sent Events stream of named events:
 
 | Action | Endpoint |
 | --- | --- |
-| List | `GET /v1/sessions` → `{ data: [...] }` |
+| List | `GET /v1/sessions` → `{ data: [...] }` (optional `?agent=hermes` filters to one agent) |
 | Retrieve, with history | `GET /v1/sessions/{id}` |
 | Delete | `DELETE /v1/sessions/{id}` |
 

--- a/server/db/queries.ts
+++ b/server/db/queries.ts
@@ -82,6 +82,9 @@ const stmtInsertSession = db.prepare(`
 `);
 const stmtGetSession = db.prepare('SELECT * FROM sessions WHERE id = ?');
 const stmtListSessions = db.prepare('SELECT * FROM sessions ORDER BY created DESC');
+const stmtListSessionsByAgent = db.prepare(
+  'SELECT * FROM sessions WHERE agent = ? ORDER BY created DESC',
+);
 const stmtSetSessionModel = db.prepare('UPDATE sessions SET model = @model, provider = @provider WHERE id = @id');
 const stmtMarkSessionResponded = db.prepare('UPDATE sessions SET last_response_at = @at WHERE id = @id');
 const stmtDeleteSession = db.prepare('DELETE FROM sessions WHERE id = ?');
@@ -109,8 +112,9 @@ export function getSession(id: string): SessionObject | undefined {
   return row ? rowToSession(row) : undefined;
 }
 
-export function listSessions(): SessionObject[] {
-  return (stmtListSessions.all() as SessionRow[]).map(rowToSession);
+export function listSessions(agent?: AgentType | null): SessionObject[] {
+  const rows = (agent ? stmtListSessionsByAgent.all(agent) : stmtListSessions.all()) as SessionRow[];
+  return rows.map(rowToSession);
 }
 
 export function setSessionModel(id: string, model: string | null, provider: string | null): void {

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -37,6 +37,23 @@ export function validationError(message: string, param?: string, hint?: string):
   return new GatewayError(400, 'validation_error', message, { param, hint });
 }
 
+/** An optional field constrained to a fixed set: absent → `fallback`, present →
+ *  validated against `allowed` (throws `validationError` otherwise). */
+export function optionalEnum<T extends string>(value: unknown, field: string, allowed: readonly T[], fallback: T): T;
+export function optionalEnum<T extends string>(value: unknown, field: string, allowed: readonly T[], fallback: null): T | null;
+export function optionalEnum<T extends string>(
+  value: unknown,
+  field: string,
+  allowed: readonly T[],
+  fallback: T | null,
+): T | null {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw validationError(`${field} must be one of: ${allowed.join(', ')}.`, field);
+  }
+  return value as T;
+}
+
 export function sessionNotFound(id: string): GatewayError {
   return new GatewayError(404, 'session_not_found', `No session with id '${id}'.`);
 }

--- a/server/routes/responses.ts
+++ b/server/routes/responses.ts
@@ -6,7 +6,7 @@ import {
   RESPONSE_MODES,
   SUPPORTED_AGENTS,
 } from '../../shared/types.js';
-import { isRecord, responseNotFound, validationError } from '../errors.js';
+import { isRecord, optionalEnum, responseNotFound, validationError } from '../errors.js';
 import { resolveHomeAwarePath } from '../paths.js';
 import { initSSE, writeStreamEvent } from '../sse.js';
 import { attach, hasRun } from '../live-runs.js';
@@ -34,23 +34,6 @@ function optionalString(value: unknown, field: string): string | null {
     throw validationError(`${field} must be a non-empty string.`, field);
   }
   return value;
-}
-
-/** An optional field constrained to a fixed set: absent → `fallback`, present →
- *  validated against `allowed` (throws otherwise). */
-function optionalEnum<T extends string>(value: unknown, field: string, allowed: readonly T[], fallback: T): T;
-function optionalEnum<T extends string>(value: unknown, field: string, allowed: readonly T[], fallback: null): T | null;
-function optionalEnum<T extends string>(
-  value: unknown,
-  field: string,
-  allowed: readonly T[],
-  fallback: T | null,
-): T | null {
-  if (value === undefined || value === null) return fallback;
-  if (typeof value !== 'string' || !allowed.includes(value as T)) {
-    throw validationError(`${field} must be one of: ${allowed.join(', ')}.`, field);
-  }
-  return value as T;
 }
 
 /** Validate `files` attachment paths: each must name an existing regular file

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import type { SessionMessage } from '../../shared/types.js';
+import { SUPPORTED_AGENTS } from '../../shared/types.js';
 import { getAdapter } from '../agent.js';
-import { gatewayErrorFromWorker, sessionNotFound } from '../errors.js';
+import { gatewayErrorFromWorker, optionalEnum, sessionNotFound } from '../errors.js';
 import {
   deleteResponsesForSession,
   deleteSession,
@@ -11,9 +12,16 @@ import {
 
 export const sessionsRouter = Router();
 
-// GET /v1/sessions — list the sessions on this instance.
-sessionsRouter.get('/', (_req, res) => {
-  res.json({ data: listSessions() });
+// GET /v1/sessions — list the sessions on this instance, optionally filtered by agent.
+sessionsRouter.get('/', (req, res, next) => {
+  try {
+    // `?agent=` (empty) is treated as absent → all sessions; an unknown agent is a 400.
+    const raw = req.query.agent === '' ? undefined : req.query.agent;
+    const agent = optionalEnum(raw, 'agent', SUPPORTED_AGENTS, null);
+    res.json({ data: listSessions(agent) });
+  } catch (error) {
+    next(error);
+  }
 });
 
 // GET /v1/sessions/:id — the session with its full transcript history.

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -94,6 +94,19 @@ test('responses and sessions work end-to-end through the local LLM', async () =>
   const sessions = await jsonOk<{ data: Array<{ id: string }> }>(await fetch(`${base}/v1/sessions`));
   assert.ok(sessions.data.some((session) => session.id === created.session_id));
 
+  // The optional ?agent= filter narrows the list to one agent; an unknown agent is a 400.
+  const hermesSessions = await jsonOk<{ data: Array<{ id: string; agent: string }> }>(
+    await fetch(`${base}/v1/sessions?agent=hermes`),
+  );
+  assert.ok(hermesSessions.data.some((session) => session.id === created.session_id));
+  assert.ok(hermesSessions.data.every((session) => session.agent === 'hermes'));
+
+  const badFilter = await fetch(`${base}/v1/sessions?agent=bogus`);
+  assert.equal(badFilter.status, 400);
+  const badBody = (await badFilter.json()) as { error: { code: string; param: string } };
+  assert.equal(badBody.error.code, 'validation_error');
+  assert.equal(badBody.error.param, 'agent');
+
   const session = await jsonOk<{
     id: string;
     history: Array<{ role: string; content: string }>;


### PR DESCRIPTION
## What

Adds an optional `?agent=` query param to `GET /v1/sessions` that narrows the list to one agent. Absent (or empty) → all sessions, as before; an unknown agent → `400 validation_error` (`param: "agent"`).

```
GET /v1/sessions            → all sessions
GET /v1/sessions?agent=hermes → hermes sessions only
GET /v1/sessions?agent=bogus  → 400 validation_error
```

## How

- `server/db/queries.ts` — `listSessions(agent?)` picks a prepared `WHERE agent = ?` statement when filtering, falls back to the existing list-all statement otherwise.
- `server/routes/sessions.ts` — validates the param via the shared `optionalEnum` helper against `SUPPORTED_AGENTS`.
- `server/errors.ts` — `optionalEnum` lifted here from `routes/responses.ts` so both routes reuse it (no behavior change for responses).
- `README.md` — documents the new filter on the sessions list endpoint.
- `test/gateway.integration.test.ts` — covers the filtered list and the unknown-agent 400.

## Testing

- `npm run typecheck` — passes.
- `npm test` — 11/12 pass, including the end-to-end Hermes test carrying the new `?agent=` filter assertions. The one failure is the OpenClaw turn-completion test, which fails on an environmental `HTTP 402: Instance budget exhausted` from the local OpenClaw instance — unrelated to this change (the diff doesn't touch OpenClaw).