### PR TITLE
Add file-browser API on /v1/files (remove multipart upload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ behind the host, which handles and forwards authentication.
 | `input` | string, required | The message or task. |
 | `agent` | string | `hermes` or `openclaw`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
 | `session_id` | string | Continue a conversation. Omit to start a new one. |
-| `files` | string[] | Absolute paths of files to attach (from `POST /v1/files`). Appended to the message as an `[Attached files: …]` block; the agent reads them from disk. |
+| `files` | string[] | Absolute paths of files to attach (write them first with `PUT /v1/files/content`). Appended to the message as an `[Attached files: …]` block; the agent reads them from disk. |
 | `stream` | boolean | `true` for Server-Sent Events; default `false`. |
 | `model` / `provider` | string | The LLM to run on. List options at `GET /v1/models`. |
 | `reasoning_effort` | string | `none` … `xhigh`. |
@@ -199,32 +199,65 @@ With `stream: true` the body is a Server-Sent Events stream of named events:
 
 ### Files
 
-Files live on the instance's disk, in the agent's workspace
-(`<home>/workspace`) — the worker's working directory. A path is the file's
-identity; there are no file ids.
+Files live on the instance's disk — the `sk_live_` key is the instance root, so
+a path can name anything on it (there's no jail). A path (resolved, absolute) is
+the file's identity; there are no file ids. The listing defaults to the agent's
+workspace (`<home>/workspace`, the worker's working directory), so files written
+there are the files the agent reads from disk.
+
+Every entry — in a listing and returned by every write — is a `FileEntry`:
+
+```jsonc
+{
+  "name": "leads.csv",            // basename
+  "path": "/home/user/leads.csv", // resolved absolute path (the identity)
+  "type": "file",                 // file | directory | symlink | other
+  "size": 1024,                   // bytes; null for directories
+  "modified": 1719500000123,      // mtime, epoch milliseconds
+  "hidden": false                 // name starts with "."
+}
+```
 
 | Action | Endpoint |
 | --- | --- |
-| Upload (multipart, one file in a `file` field) | `POST /v1/files` → `{ path, filename, bytes }` |
-| Download (e.g. a file the agent produced) | `GET /v1/files/content?path=…` |
+| List one directory level | `GET /v1/files?path=<dir>` (defaults to the workspace) |
+| Read / preview / download | `GET /v1/files/content?path=<file>&disposition=inline\|attachment` |
+| Write raw bytes (create/overwrite/edit/upload) | `PUT /v1/files/content?path=<file>&overwrite=true\|false` |
+| Delete (recursive, force) | `DELETE /v1/files?path=<path>` → `{ ok: true }` |
+| Rename / move | `PATCH /v1/files` body `{ from, to }` |
+| Create a directory (mkdir -p) | `POST /v1/files/dir?path=<dir>` |
 
-The chat loop: upload, pass the returned `path` in `files` on
-`POST /v1/responses`, and when the agent replies that it wrote a file, fetch
-that path from `/v1/files/content`.
+`GET /v1/files` returns `{ path, parentPath, entries, truncated }` — one level,
+directories first then name (case-insensitive), capped at 1000 entries
+(`truncated: true` past that). `parentPath` is null at the filesystem root.
+
+`GET /v1/files/content` sets `Content-Type` from the extension and streams at any
+size; `disposition` defaults to `attachment` (download), `inline` lets a browser
+render it.
+
+`PUT /v1/files/content` writes the **raw request body** (not multipart) to the
+path, creating parent directories as needed, and returns the new `FileEntry`.
+`overwrite` defaults to true; with `overwrite=false` an existing file is a
+`409 file_exists`. Pass an `X-Expected-Mtime` header (epoch ms) for optimistic
+concurrency — if the file changed since you read it, the write is a `412 modified`.
+
+The chat loop: write a file with `PUT /v1/files/content`, pass its `path` in
+`files` on `POST /v1/responses`, and when the agent replies that it wrote a file,
+fetch it from `GET /v1/files/content`.
 
 ```bash
-curl -F "file=@leads.csv" http://localhost:3737/v1/files
-# → { "path": "/home/user/.agent37-gateway/workspace/uploads/3f2a1b9c-leads.csv", … }
+curl -X PUT --data-binary @leads.csv \
+  'http://localhost:3737/v1/files/content?path=/home/user/leads.csv'
+# → { "path": "/home/user/leads.csv", "type": "file", "size": 1024, … }
 
 curl http://localhost:3737/v1/responses -H 'content-type: application/json' -d '{
   "input": "Summarize the attached spreadsheet.",
-  "files": ["/home/user/.agent37-gateway/workspace/uploads/3f2a1b9c-leads.csv"]
+  "files": ["/home/user/leads.csv"]
 }'
 ```
 
-Uploads are kept until you delete them from the workspace yourself (there is no
-garbage collection), and stored paths assume the instance's home directory
-stays stable.
+Files are kept until you delete them yourself (there is no garbage collection),
+and stored paths assume the instance's home directory stays stable.
 
 ### Models & health
 
@@ -277,11 +310,14 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 | Code | HTTP | When |
 | --- | --- | --- |
 | `validation_error` | 400 | A request field was invalid (see `param`). |
+| `not_a_directory` | 400 | `GET /v1/files` was given a path that isn't a directory. |
 | `response_not_found` | 404 | No response with that id. |
 | `file_not_found` | 404 | No file at that path. |
 | `not_found` | 404 | Unknown route. |
 | `session_busy` | 409 | A response is already running on the session. |
 | `title_conflict` | 409 | The requested session title is already in use by another session. |
+| `file_exists` | 409 | `PUT /v1/files/content?overwrite=false` and the file already exists. |
+| `modified` | 412 | `PUT /v1/files/content`'s `X-Expected-Mtime` no longer matches the file. |
 | `rename_unsupported` | 405 | The targeted harness can't rename sessions (no native editable title). |
 | `payload_too_large` | 413 | Request body exceeded the size limit. |
 | `rate_limited` | 429 | The upstream agent/provider was rate-limited. |
@@ -313,7 +349,7 @@ open that folder in Bruno, pick the **local** environment (`baseUrl`
 saves the `session_id` and response id into the environment, so *Continue
 Session*, *Cancel*, and *Delete Session* just work. The
 *(openclaw)* requests do the same for OpenClaw (start `openclaw` locally first).
-For *Upload File*, pick any local file first; it saves the uploaded path for
+*Upload File* writes a file via `PUT /v1/files/content` and saves its path for
 *Download File*.
 
 ## Configuration

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -10,8 +10,8 @@ API requests for poking the gateway locally, using [Bruno](https://www.usebruno.
 4. Run the requests in order. They chain through env vars:
    - **04 Create Response** saves `session_id` and `responseId`.
    - **05 Continue Session**, **10 Get Session**, **11 Cancel**, **12 Delete**, **15 Rename Session** reuse them.
-   - **13 Upload File** saves `uploadedFilePath` (pick any local file for its
-     `file` field first), which **14 Download File** reuses.
+   - **13 Upload File** writes a file via `PUT /v1/files/content` (raw body) and
+     saves `uploadedFilePath`, which **14 Download File** reuses.
 
 There's no auth — the gateway is a localhost service (the host/Docker handles
 auth in production), so every request uses `auth: none`.

--- a/bruno/gateway/13 Upload File.bru
+++ b/bruno/gateway/13 Upload File.bru
@@ -4,14 +4,18 @@ meta {
   seq: 13
 }
 
-post {
-  url: {{baseUrl}}/v1/files
-  body: multipartForm
+put {
+  url: {{baseUrl}}/v1/files/content?path=~/.agent37-gateway/workspace/bruno-upload.txt
+  body: text
   auth: none
 }
 
-body:multipart-form {
-  file: @file()
+params:query {
+  path: ~/.agent37-gateway/workspace/bruno-upload.txt
+}
+
+body:text {
+  Hello from Bruno. The secret marker is 4242.
 }
 
 script:post-response {
@@ -25,16 +29,18 @@ tests {
     expect(res.status).to.equal(200);
   });
 
-  test("returns the workspace path", function () {
+  test("returns the written FileEntry", function () {
     expect(res.body.path).to.be.a("string");
-    expect(res.body.filename).to.be.a("string");
-    expect(res.body.bytes).to.be.a("number");
+    expect(res.body.type).to.equal("file");
+    expect(res.body.size).to.be.a("number");
   });
 }
 
 docs {
-  Pick any local file for the `file` field, then run. The returned `path`
-  (saved to the env as `uploadedFilePath`) is the file's identity — attach it
-  to a turn by adding `"files": ["{{uploadedFilePath}}"]` to Create Response,
-  or download it back with 14 Download File.
+  Writes the raw request body to `path` (not multipart) and returns the written
+  file's `FileEntry`. The returned `path` (saved to the env as
+  `uploadedFilePath`) is the file's identity — attach it to a turn by adding
+  `"files": ["{{uploadedFilePath}}"]` to Create Response, or read it back with
+  14 Download File. Edit the body or `path` to write anything; `overwrite`
+  defaults to true.
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "agent37-gateway",
-  "version": "0.1.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent37-gateway",
-      "version": "0.1.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
-        "express": "^4.21.2",
-        "multer": "^2.1.1"
+        "express": "^4.21.2"
       },
       "bin": {
         "agent37-gateway": "bin/agent37-gateway.mjs"
@@ -20,7 +19,6 @@
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
-        "@types/multer": "^2.1.0",
         "@types/node": "^24.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3"
@@ -534,16 +532,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/multer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
-      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "24.13.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
@@ -602,12 +590,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/append-field": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
-      "license": "MIT"
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -636,23 +618,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -691,21 +656,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "engines": [
-        "node >= 6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -1218,25 +1168,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
-      "license": "MIT",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.6.0",
-        "concat-stream": "^2.0.0",
-        "type-is": "^1.6.18"
-      },
-      "engines": {
-        "node": ">= 10.16.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1344,20 +1275,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/safe-buffer": {
@@ -1518,23 +1435,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1576,12 +1476,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1611,12 +1505,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",
@@ -32,13 +32,11 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
-    "express": "^4.21.2",
-    "multer": "^2.1.1"
+    "express": "^4.21.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
-    "@types/multer": "^2.1.0",
     "@types/node": "^24.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3"

--- a/server/app.ts
+++ b/server/app.ts
@@ -14,7 +14,15 @@ const app = express();
 app.use(cors());
 // A turn request is small (input text + a few fields). Keep the limit modest so
 // an oversized body can't be a memory vector; oversize → 413 payload_too_large.
-app.use(express.json({ limit: '2mb' }));
+// PUT /v1/files/content is the one exception: it carries raw file bytes of any
+// size, so it opts out of JSON parsing and the limit — the files route streams
+// that body straight to disk.
+app.use(
+  express.json({
+    limit: '2mb',
+    type: (req) => (req as Request).path !== '/v1/files/content' && Boolean((req as Request).is('application/json')),
+  }),
+);
 
 app.get('/v1/health', async (req, res, next) => {
   try {

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -68,6 +68,22 @@ export function fileNotFound(path: string): GatewayError {
   return new GatewayError(404, 'file_not_found', `No file at '${path}'.`);
 }
 
+export function notADirectory(path: string): GatewayError {
+  return new GatewayError(400, 'not_a_directory', `'${path}' is not a directory.`, { param: 'path' });
+}
+
+export function fileExists(path: string): GatewayError {
+  return new GatewayError(409, 'file_exists', `A file already exists at '${path}'.`, {
+    hint: 'Pass overwrite=true to replace it.',
+  });
+}
+
+export function fileModified(path: string): GatewayError {
+  return new GatewayError(412, 'modified', `'${path}' was modified since it was last read.`, {
+    hint: 'Re-read the file to get its current X-Expected-Mtime, then retry.',
+  });
+}
+
 export function sessionBusy(): GatewayError {
   return new GatewayError(409, 'session_busy', 'A response is already running on this session.', {
     hint: 'Cancel the running response, or start another session.',

--- a/server/paths.ts
+++ b/server/paths.ts
@@ -34,11 +34,6 @@ export function resolveWorkspaceDir(): string {
   return resolveHomeAwarePath(configured || join(resolveGatewayHome(), 'workspace'));
 }
 
-/** Where POST /v1/files lands uploads, inside the agent's workspace. */
-export function resolveUploadsDir(): string {
-  return join(resolveWorkspaceDir(), 'uploads');
-}
-
 export function ensureGatewayStateDirs(): void {
   mkdirSync(resolveGatewayLogsDir(), { recursive: true });
   mkdirSync(resolveWorkspaceDir(), { recursive: true });

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -1,66 +1,141 @@
-// File attachments for chat: upload a file into the agent's workspace, and
-// download a file the agent produced. Identity is the absolute path — the
-// worker runs with cwd = workspace, so the agent reads attachments from disk.
+// The agent's filesystem over HTTP. The sk_live_ key is the instance root —
+// there is no jail; `path` (resolved, absolute) is the identity for every call.
+// The worker runs with cwd = the workspace, so files written here are the files
+// the agent reads from disk, and files the agent produces are read back here.
 
-import { mkdir } from 'node:fs';
-import { stat } from 'node:fs/promises';
-import { basename } from 'node:path';
-import { randomUUID } from 'node:crypto';
-import multer from 'multer';
+import { createWriteStream } from 'node:fs';
+import { lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import { Router } from 'express';
-import type { FileUploadResult } from '../../shared/types.js';
-import { fileNotFound, validationError } from '../errors.js';
-import { resolveHomeAwarePath, resolveUploadsDir } from '../paths.js';
+import type { FileEntry, FileListResponse } from '../../shared/types.js';
+import {
+  fileExists,
+  fileModified,
+  fileNotFound,
+  isRecord,
+  notADirectory,
+  optionalEnum,
+  queryParam,
+  toErrorMessage,
+  validationError,
+} from '../errors.js';
+import { resolveHomeAwarePath, resolveWorkspaceDir } from '../paths.js';
 
 export const filesRouter = Router();
 
-// Uploads stream straight to their final location in <workspace>/uploads/
-// under a collision-proof name; no staging dir or rename step needed. The dir
-// is (re)created per upload: it sits in the agent-owned workspace, which the
-// agent may wipe at runtime, so boot-time creation can't hold the invariant.
-const upload = multer({
-  // Multipart filenames arrive as UTF-8 bytes; multer's default decodes latin1.
-  defParamCharset: 'utf8',
-  storage: multer.diskStorage({
-    destination: (_req, _file, callback) => {
-      const dir = resolveUploadsDir();
-      mkdir(dir, { recursive: true }, (error) => callback(error, dir));
-    },
-    filename: (_req, file, callback) => {
-      callback(null, `${randomUUID().slice(0, 8)}-${basename(file.originalname)}`);
-    },
-  }),
-});
+// A directory listing returns at most this many entries; past it the list is
+// clipped and `truncated` is set, so one pathological directory can't blow up a
+// response (or the client rendering it).
+const LIST_CAP = 1000;
 
-// POST /v1/files — multipart upload (one file per request, field name `file`).
-// Returns the absolute workspace path to attach via `files` on POST /v1/responses.
-filesRouter.post('/', (req, res, next) => {
-  upload.single('file')(req, res, (error: unknown) => {
-    if (error instanceof multer.MulterError) {
-      return next(validationError(error.message, 'file'));
-    }
-    if (error) return next(error);
-    const file = req.file;
-    if (!file) {
-      return next(validationError('A multipart "file" field with one file is required.', 'file'));
-    }
-    const result: FileUploadResult = {
-      path: file.path,
-      filename: basename(file.originalname),
-      bytes: file.size,
-    };
-    res.json(result);
-  });
-});
+const DISPOSITIONS = ['inline', 'attachment'] as const;
 
-// GET /v1/files/content?path=… — download a file (e.g. one the agent produced).
-filesRouter.get('/content', async (req, res, next) => {
+/** A required `path` query param: missing/empty → 400; otherwise resolved abs. */
+function requirePathParam(raw: unknown, field = 'path'): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw validationError(`${field} query parameter is required.`, field);
+  }
+  return resolveHomeAwarePath(raw);
+}
+
+/** A required path in a JSON body (rename's from/to): missing/empty → 400. */
+function requireBodyPath(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw validationError(`${field} must be a non-empty string.`, field);
+  }
+  return resolveHomeAwarePath(value);
+}
+
+/** An optional boolean query flag (`true`/`false`); absent → fallback. */
+function boolFlag(value: unknown, field: string, fallback: boolean): boolean {
+  if (value === undefined || value === null || value === '') return fallback;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw validationError(`${field} must be 'true' or 'false'.`, field);
+}
+
+/** Parse the optional X-Expected-Mtime header (epoch ms). Absent → null. */
+function expectedMtime(value: string | string[] | undefined): number | null {
+  if (value === undefined) return null;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (!raw.trim()) return null;
+  const ms = Number(raw);
+  if (!Number.isFinite(ms)) {
+    throw validationError('X-Expected-Mtime must be epoch milliseconds.', 'X-Expected-Mtime');
+  }
+  return ms;
+}
+
+/** Build the FileEntry for an absolute path. `lstat` (not `stat`) so a symlink
+ *  reports as a symlink rather than its target. */
+async function toFileEntry(path: string): Promise<FileEntry> {
+  const stats = await lstat(path);
+  const type: FileEntry['type'] = stats.isDirectory()
+    ? 'directory'
+    : stats.isFile()
+      ? 'file'
+      : stats.isSymbolicLink()
+        ? 'symlink'
+        : 'other';
+  const name = basename(path);
+  return {
+    name,
+    path,
+    type,
+    size: type === 'directory' ? null : stats.size,
+    modified: stats.mtimeMs,
+    hidden: name.startsWith('.'),
+  };
+}
+
+// GET /v1/files?path=<dir> — list one directory level. `path` is optional and
+// defaults to the agent workspace dir. Directories sort first, then by name.
+filesRouter.get('/', async (req, res, next) => {
   try {
     const raw = req.query.path;
-    if (typeof raw !== 'string' || !raw.trim()) {
-      throw validationError('path query parameter is required.', 'path');
+    const dir = typeof raw === 'string' && raw.trim() ? resolveHomeAwarePath(raw) : resolveWorkspaceDir();
+
+    let stats;
+    try {
+      stats = await stat(dir);
+    } catch {
+      throw fileNotFound(dir);
     }
-    const path = resolveHomeAwarePath(raw);
+    if (!stats.isDirectory()) throw notADirectory(dir);
+
+    const dirents = await readdir(dir, { withFileTypes: true });
+    dirents.sort((a, b) => {
+      const aDir = a.isDirectory();
+      const bDir = b.isDirectory();
+      if (aDir !== bDir) return aDir ? -1 : 1;
+      return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    });
+
+    const truncated = dirents.length > LIST_CAP;
+    const capped = truncated ? dirents.slice(0, LIST_CAP) : dirents;
+    const entries = await Promise.all(capped.map((d) => toFileEntry(join(dir, d.name))));
+
+    const parent = dirname(dir);
+    const body: FileListResponse = {
+      path: dir,
+      parentPath: parent === dir ? null : parent,
+      entries,
+      truncated,
+    };
+    res.json(body);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /v1/files/content?path=<file>&disposition=inline|attachment — read/preview
+// /download a file. `send` (under sendFile/download) sets Content-Type from the
+// extension and streams at any size; dotfiles:'allow' so agent-produced dotfiles
+// download too. disposition defaults to attachment; inline lets a browser render.
+filesRouter.get('/content', async (req, res, next) => {
+  try {
+    const path = requirePathParam(req.query.path);
 
     let stats;
     try {
@@ -68,15 +143,99 @@ filesRouter.get('/content', async (req, res, next) => {
     } catch {
       throw fileNotFound(path);
     }
-    if (!stats.isFile()) {
-      throw validationError(`'${path}' is not a downloadable file.`, 'path');
+    if (!stats.isFile()) throw validationError(`'${path}' is not a downloadable file.`, 'path');
+
+    const disposition = optionalEnum(queryParam(req.query.disposition), 'disposition', DISPOSITIONS, 'attachment');
+    const onDone = (error: unknown) => {
+      if (error) next(error);
+    };
+    if (disposition === 'inline') {
+      res.sendFile(path, { dotfiles: 'allow', headers: { 'Content-Disposition': 'inline' } }, onDone);
+    } else {
+      res.download(path, basename(path), { dotfiles: 'allow' }, onDone);
+    }
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PUT /v1/files/content?path=<file>&overwrite=true|false — write the raw request
+// body to the path (create/overwrite/edit/upload). The parent dir is created as
+// needed. The global JSON parser skips this route (see app.ts), so the body is
+// the untouched byte stream — piped straight to disk at any size.
+filesRouter.put('/content', async (req, res, next) => {
+  try {
+    const path = requirePathParam(req.query.path);
+    const overwrite = boolFlag(queryParam(req.query.overwrite), 'overwrite', true);
+    const expected = expectedMtime(req.headers['x-expected-mtime']);
+
+    let existing;
+    try {
+      existing = await stat(path);
+    } catch {
+      existing = null;
+    }
+    if (existing) {
+      if (!overwrite) throw fileExists(path);
+      if (expected !== null && existing.mtimeMs !== expected) throw fileModified(path);
     }
 
-    // dotfiles: 'allow' — express hides dot-basenames by default, but agents
-    // legitimately produce files like .gitignore.
-    res.download(path, basename(path), { dotfiles: 'allow' }, (error) => {
-      if (error) next(error);
-    });
+    await mkdir(dirname(path), { recursive: true });
+    await pipeline(req, createWriteStream(path));
+
+    res.json(await toFileEntry(path));
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /v1/files?path=<path> — recursive force delete (rm -rf), no guards. A
+// symlink is removed itself, not followed; deleting a missing path is a no-op.
+filesRouter.delete('/', async (req, res, next) => {
+  try {
+    const path = requirePathParam(req.query.path);
+    await rm(path, { recursive: true, force: true });
+    res.json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PATCH /v1/files  { from, to } — rename/move via fs.rename; the OS decides the
+// overwrite/dir rules. Returns the FileEntry of the new path.
+filesRouter.patch('/', async (req, res, next) => {
+  try {
+    const body: unknown = req.body;
+    if (!isRecord(body)) throw validationError('Request body must be a JSON object with from and to.', 'body');
+    const from = requireBodyPath(body.from, 'from');
+    const to = requireBodyPath(body.to, 'to');
+
+    try {
+      await stat(from);
+    } catch {
+      throw fileNotFound(from);
+    }
+    try {
+      await rename(from, to);
+    } catch (error) {
+      // fs.rename decides the overwrite/dir rules; surface its complaint (e.g.
+      // the destination's parent doesn't exist, or a cross-device move) as a 400
+      // rather than a generic 500. The source is known to exist by here.
+      throw validationError(toErrorMessage(error, 'Could not move the file.'), 'to');
+    }
+
+    res.json(await toFileEntry(to));
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /v1/files/dir?path=<dir> — mkdir -p (recursive, idempotent).
+filesRouter.post('/dir', async (req, res, next) => {
+  try {
+    const path = requirePathParam(req.query.path);
+    await mkdir(path, { recursive: true });
+    res.json(await toFileEntry(path));
   } catch (error) {
     next(error);
   }

--- a/server/routes/responses.ts
+++ b/server/routes/responses.ts
@@ -49,7 +49,7 @@ function parseFiles(value: unknown): string[] {
     try {
       stats = statSync(path);
     } catch {
-      throw validationError(`files entry '${p}' does not exist on this instance.`, 'files', 'Upload it first via POST /v1/files.');
+      throw validationError(`files entry '${p}' does not exist on this instance.`, 'files', 'Upload it first via PUT /v1/files/content.');
     }
     if (!stats.isFile()) throw validationError(`files entry '${p}' is not a file.`, 'files');
     return path;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -105,13 +105,32 @@ export interface SessionMessage {
 // Public API: files
 // ---------------------------------------------------------------------------
 
-/** The result of POST /v1/files. `path` is the file's absolute location in the
- *  agent's workspace — pass it back in `files` on POST /v1/responses, or to
- *  GET /v1/files/content to download it. */
-export interface FileUploadResult {
+/** One entry in the agent's filesystem. `path` (resolved, absolute) is the
+ *  identity used by every other /v1/files call. Returned by the directory
+ *  listing and echoed back by every write (PUT/PATCH/mkdir). */
+export interface FileEntry {
+  /** Basename. */
+  name: string;
+  /** Resolved absolute path — the identity for all other /v1/files calls. */
   path: string;
-  filename: string;
-  bytes: number;
+  type: 'file' | 'directory' | 'symlink' | 'other';
+  /** Bytes; null for directories. */
+  size: number | null;
+  /** mtimeMs — epoch milliseconds. */
+  modified: number;
+  /** Name starts with ".". */
+  hidden: boolean;
+}
+
+/** The result of GET /v1/files: one directory level. */
+export interface FileListResponse {
+  /** The resolved absolute directory that was listed. */
+  path: string;
+  /** The parent directory, or null at the filesystem root. */
+  parentPath: string | null;
+  entries: FileEntry[];
+  /** True when the directory held more than the cap and the list was clipped. */
+  truncated: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/files.integration.test.ts
+++ b/test/files.integration.test.ts
@@ -1,0 +1,291 @@
+// The /v1/files surface is pure filesystem — it never touches a harness — so
+// this suite boots the real Express app but needs no live Hermes/LLM. Run it
+// alone with: node --import tsx --test test/files.integration.test.ts
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { startTestServer, type TestServer } from './test-helpers.js';
+import { resolveWorkspaceDir } from '../server/paths.js';
+import type { FileEntry, FileListResponse as ListBody } from '../shared/types.js';
+
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+async function jsonOk<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  assert.equal(res.status, 200, JSON.stringify(body));
+  return body as T;
+}
+
+function freshDir(): string {
+  return mkdtempSync(join(tmpdir(), 'a37gw-files-'));
+}
+
+const filesUrl = (path: string) => `${base}/v1/files?path=${encodeURIComponent(path)}`;
+const contentUrl = (path: string, query = '') =>
+  `${base}/v1/files/content?path=${encodeURIComponent(path)}${query}`;
+
+test('GET /v1/files lists one level: dirs first, then case-insensitive name', async () => {
+  const dir = freshDir();
+  mkdirSync(join(dir, 'alpha-dir'));
+  writeFileSync(join(dir, 'Zebra.txt'), 'z');
+  writeFileSync(join(dir, 'apple.txt'), 'apple');
+  writeFileSync(join(dir, '.hidden'), 'h');
+  symlinkSync(join(dir, 'apple.txt'), join(dir, 'link'));
+
+  const body = await jsonOk<ListBody>(await fetch(filesUrl(dir)));
+  assert.equal(body.path, dir);
+  assert.equal(body.parentPath, dirname(dir));
+  assert.equal(body.truncated, false);
+  assert.equal(body.entries.length, 5);
+
+  // Same ordering rule the route applies — directories first, then name (ci).
+  const expected = [...body.entries].sort((a, b) => {
+    const ad = a.type === 'directory';
+    const bd = b.type === 'directory';
+    if (ad !== bd) return ad ? -1 : 1;
+    return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+  });
+  assert.deepEqual(body.entries.map((e) => e.name), expected.map((e) => e.name));
+  assert.equal(body.entries[0].name, 'alpha-dir');
+
+  const byName = Object.fromEntries(body.entries.map((e) => [e.name, e]));
+  assert.equal(byName['alpha-dir'].type, 'directory');
+  assert.equal(byName['alpha-dir'].size, null);
+  assert.equal(byName['apple.txt'].type, 'file');
+  assert.equal(byName['apple.txt'].size, 5);
+  assert.equal(byName['link'].type, 'symlink');
+  assert.equal(byName['.hidden'].hidden, true);
+  assert.equal(byName['apple.txt'].hidden, false);
+  for (const entry of body.entries) {
+    assert.equal(entry.path, join(dir, entry.name));
+    assert.equal(typeof entry.modified, 'number');
+  }
+});
+
+test('GET /v1/files defaults to the workspace dir and roots parentPath at /', async () => {
+  // Production creates the workspace at boot (ensureGatewayStateDirs); the test
+  // boots the app directly, so create it here before listing the default.
+  mkdirSync(resolveWorkspaceDir(), { recursive: true });
+  const dflt = await jsonOk<ListBody>(await fetch(`${base}/v1/files`));
+  assert.equal(dflt.path, resolveWorkspaceDir());
+  assert.ok(Array.isArray(dflt.entries));
+
+  const root = await jsonOk<ListBody>(await fetch(filesUrl('/')));
+  assert.equal(root.path, '/');
+  assert.equal(root.parentPath, null);
+});
+
+test('GET /v1/files errors: not-a-directory and missing path', async () => {
+  const dir = freshDir();
+  const file = join(dir, 'a.txt');
+  writeFileSync(file, 'x');
+
+  const notDir = await fetch(filesUrl(file));
+  assert.equal(notDir.status, 400);
+  assert.equal((await notDir.json()).error.code, 'not_a_directory');
+
+  const missing = await fetch(filesUrl(join(dir, 'nope')));
+  assert.equal(missing.status, 404);
+  assert.equal((await missing.json()).error.code, 'file_not_found');
+});
+
+test('GET /v1/files/content reads, previews, and downloads', async () => {
+  const dir = freshDir();
+  const file = join(dir, 'note.txt');
+  writeFileSync(file, 'hello world');
+
+  const dl = await fetch(contentUrl(file));
+  assert.equal(dl.status, 200);
+  assert.equal(await dl.text(), 'hello world');
+  assert.match(dl.headers.get('content-type') ?? '', /text\/plain/);
+  assert.match(dl.headers.get('content-disposition') ?? '', /^attachment/);
+
+  const inline = await fetch(contentUrl(file, '&disposition=inline'));
+  assert.equal(inline.status, 200);
+  assert.equal(inline.headers.get('content-disposition'), 'inline');
+  assert.equal(await inline.text(), 'hello world');
+
+  // Agents produce dotfiles too; express must not hide them.
+  const dot = join(dir, '.env');
+  writeFileSync(dot, 'SECRET=1');
+  const dotRes = await fetch(contentUrl(dot));
+  assert.equal(dotRes.status, 200);
+  assert.equal(await dotRes.text(), 'SECRET=1');
+});
+
+test('GET /v1/files/content errors stay stable', async () => {
+  const dir = freshDir();
+
+  const noPath = await fetch(`${base}/v1/files/content`);
+  assert.equal(noPath.status, 400);
+  assert.equal((await noPath.json()).error.param, 'path');
+
+  const missing = await fetch(contentUrl(join(dir, 'nope.txt')));
+  assert.equal(missing.status, 404);
+  assert.equal((await missing.json()).error.code, 'file_not_found');
+
+  const notFile = await fetch(contentUrl(dir));
+  assert.equal(notFile.status, 400);
+  assert.equal((await notFile.json()).error.code, 'validation_error');
+});
+
+test('PUT /v1/files/content writes raw bytes, mkdir -p parent, returns the entry', async () => {
+  const dir = freshDir();
+  const file = join(dir, 'nested/deep/file.txt');
+
+  const created = await jsonOk<FileEntry>(
+    await fetch(contentUrl(file), { method: 'PUT', body: 'first' }),
+  );
+  assert.equal(created.path, file);
+  assert.equal(created.name, 'file.txt');
+  assert.equal(created.type, 'file');
+  assert.equal(created.size, 5);
+  assert.equal(existsSync(file), true);
+  assert.equal(statSync(file).size, 5);
+
+  // Overwrite is the default.
+  const updated = await jsonOk<FileEntry>(
+    await fetch(contentUrl(file), { method: 'PUT', body: 'second-longer' }),
+  );
+  assert.equal(updated.size, 'second-longer'.length);
+
+  const noPath = await fetch(`${base}/v1/files/content`, { method: 'PUT', body: 'x' });
+  assert.equal(noPath.status, 400);
+  assert.equal((await noPath.json()).error.param, 'path');
+});
+
+test('PUT /v1/files/content honors overwrite=false and X-Expected-Mtime', async () => {
+  const dir = freshDir();
+  const file = join(dir, 'guarded.txt');
+
+  // overwrite=false on an absent file creates it.
+  await jsonOk<FileEntry>(
+    await fetch(contentUrl(file, '&overwrite=false'), { method: 'PUT', body: 'v1' }),
+  );
+  // overwrite=false on an existing file is a 409.
+  const conflict = await fetch(contentUrl(file, '&overwrite=false'), { method: 'PUT', body: 'v2' });
+  assert.equal(conflict.status, 409);
+  assert.equal((await conflict.json()).error.code, 'file_exists');
+
+  // A stale X-Expected-Mtime is a 412.
+  const stale = await fetch(contentUrl(file), {
+    method: 'PUT',
+    headers: { 'X-Expected-Mtime': '1' },
+    body: 'v3',
+  });
+  assert.equal(stale.status, 412);
+  assert.equal((await stale.json()).error.code, 'modified');
+
+  // The current mtime is accepted.
+  const fresh = await fetch(contentUrl(file), {
+    method: 'PUT',
+    headers: { 'X-Expected-Mtime': String(statSync(file).mtimeMs) },
+    body: 'v4',
+  });
+  assert.equal(fresh.status, 200);
+});
+
+test('DELETE /v1/files removes files, dirs (recursive), and symlinks; no guards', async () => {
+  const dir = freshDir();
+  const file = join(dir, 'gone.txt');
+  writeFileSync(file, 'x');
+  const del = await jsonOk<{ ok: boolean }>(await fetch(filesUrl(file), { method: 'DELETE' }));
+  assert.deepEqual(del, { ok: true });
+  assert.equal(existsSync(file), false);
+
+  // Recursive: a populated directory.
+  const sub = join(dir, 'sub');
+  mkdirSync(sub);
+  writeFileSync(join(sub, 'child.txt'), 'x');
+  await jsonOk(await fetch(filesUrl(sub), { method: 'DELETE' }));
+  assert.equal(existsSync(sub), false);
+
+  // A symlink is removed itself, the target survives.
+  const target = join(dir, 'target.txt');
+  const link = join(dir, 'link');
+  writeFileSync(target, 'keep');
+  symlinkSync(target, link);
+  await jsonOk(await fetch(filesUrl(link), { method: 'DELETE' }));
+  assert.equal(existsSync(link), false);
+  assert.equal(existsSync(target), true);
+
+  // Deleting a missing path is a no-op success (no guards).
+  const noop = await jsonOk<{ ok: boolean }>(
+    await fetch(filesUrl(join(dir, 'never')), { method: 'DELETE' }),
+  );
+  assert.deepEqual(noop, { ok: true });
+
+  const noPath = await fetch(`${base}/v1/files`, { method: 'DELETE' });
+  assert.equal(noPath.status, 400);
+  assert.equal((await noPath.json()).error.param, 'path');
+});
+
+test('PATCH /v1/files renames/moves and returns the new entry', async () => {
+  const dir = freshDir();
+  const from = join(dir, 'before.txt');
+  const to = join(dir, 'after.txt');
+  writeFileSync(from, 'payload');
+
+  const moved = await jsonOk<FileEntry>(
+    await fetch(`${base}/v1/files`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ from, to }),
+    }),
+  );
+  assert.equal(moved.path, to);
+  assert.equal(moved.type, 'file');
+  assert.equal(existsSync(from), false);
+  assert.equal(statSync(to).size, 'payload'.length);
+
+  const badBody = await fetch(`${base}/v1/files`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ to }),
+  });
+  assert.equal(badBody.status, 400);
+  assert.equal((await badBody.json()).error.param, 'from');
+
+  const missingSrc = await fetch(`${base}/v1/files`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ from: join(dir, 'nope'), to: join(dir, 'x') }),
+  });
+  assert.equal(missingSrc.status, 404);
+  assert.equal((await missingSrc.json()).error.code, 'file_not_found');
+});
+
+test('POST /v1/files/dir is mkdir -p and idempotent', async () => {
+  const dir = freshDir();
+  const target = join(dir, 'a/b/c');
+
+  const made = await jsonOk<FileEntry>(
+    await fetch(`${base}/v1/files/dir?path=${encodeURIComponent(target)}`, { method: 'POST' }),
+  );
+  assert.equal(made.path, target);
+  assert.equal(made.type, 'directory');
+  assert.equal(made.size, null);
+  assert.equal(existsSync(target), true);
+
+  // Idempotent: a second call on an existing dir succeeds.
+  const again = await jsonOk<FileEntry>(
+    await fetch(`${base}/v1/files/dir?path=${encodeURIComponent(target)}`, { method: 'POST' }),
+  );
+  assert.equal(again.type, 'directory');
+
+  const noPath = await fetch(`${base}/v1/files/dir`, { method: 'POST' });
+  assert.equal(noPath.status, 400);
+  assert.equal((await noPath.json()).error.param, 'path');
+});

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -1,7 +1,8 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { parse } from 'dotenv';
 import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
 import { DEFAULT_BASE_URL } from '../server/adapters/openclaw-adapter.js';
@@ -239,22 +240,24 @@ test('an in-flight response blocks another turn and can be cancelled', async () 
   assert.equal(next.status, 200);
 });
 
-test('a file can be uploaded, attached to a turn, and downloaded back', async () => {
+test('a file written via PUT can be attached to a turn and downloaded back', async () => {
   const marker = `attachment-marker-${Date.now()}`;
-  const form = new FormData();
-  form.set('file', new File([`The secret marker is: ${marker}\n`], 'attachment tëst.txt'));
-  const uploaded = await jsonOk<{ path: string; filename: string; bytes: number }>(
-    await fetch(`${base}/v1/files`, { method: 'POST', body: form }),
+  const filePath = join(tmpdir(), `a37gw-attach-${Date.now()}.txt`);
+  const written = await jsonOk<{ path: string; type: string; size: number }>(
+    await fetch(`${base}/v1/files/content?path=${encodeURIComponent(filePath)}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: `The secret marker is: ${marker}\n`,
+    }),
   );
-  assert.equal(uploaded.filename, 'attachment tëst.txt'); // UTF-8 name survives multipart
-  assert.match(uploaded.path, /\/workspace\/uploads\/[a-f0-9]{8}-attachment tëst\.txt$/);
-  assert.ok(uploaded.bytes > 0);
-  assert.ok(existsSync(uploaded.path));
+  assert.equal(written.path, filePath);
+  assert.equal(written.type, 'file');
+  assert.ok(written.size > 0);
 
   const turn = await jsonOk<ResponseBody>(
     await postJson(base, {
       input: 'Read the attached file and reply with the exact secret marker it contains.',
-      files: [uploaded.path],
+      files: [written.path],
       reasoning_effort: 'low',
     }),
   );
@@ -267,27 +270,16 @@ test('a file can be uploaded, attached to a turn, and downloaded back', async ()
   );
   assert.ok(
     session.history.some(
-      (message) => message.role === 'user' && message.content.includes(`[Attached files:\n- ${uploaded.path}]`),
+      (message) => message.role === 'user' && message.content.includes(`[Attached files:\n- ${written.path}]`),
     ),
   );
 
-  const download = await fetch(`${base}/v1/files/content?path=${encodeURIComponent(uploaded.path)}`);
+  const download = await fetch(`${base}/v1/files/content?path=${encodeURIComponent(written.path)}`);
   assert.equal(download.status, 200);
   assert.equal(await download.text(), `The secret marker is: ${marker}\n`);
-
-  // Agents produce dotfiles too; express must not hide them.
-  const dotfilePath = join(dirname(uploaded.path), '.dotfile-download-test');
-  writeFileSync(dotfilePath, 'dot');
-  const dotfile = await fetch(`${base}/v1/files/content?path=${encodeURIComponent(dotfilePath)}`);
-  assert.equal(dotfile.status, 200);
-  assert.equal(await dotfile.text(), 'dot');
 });
 
-test('file validation and not-found errors stay stable', async () => {
-  const noFile = await fetch(`${base}/v1/files`, { method: 'POST', body: new FormData() });
-  assert.equal(noFile.status, 400);
-  assert.equal((await noFile.json()).error.param, 'file');
-
+test('responses files[] validation stays stable', async () => {
   const badFiles = await postJson(base, { input: 'x', files: 'not-an-array' });
   assert.equal(badFiles.status, 400);
   assert.equal((await badFiles.json()).error.param, 'files');
@@ -297,14 +289,6 @@ test('file validation and not-found errors stay stable', async () => {
   const missingBody = await missingAttachment.json();
   assert.equal(missingBody.error.param, 'files');
   assert.ok(missingBody.error.message.includes('/nope/missing.txt'));
-
-  const noPath = await fetch(`${base}/v1/files/content`);
-  assert.equal(noPath.status, 400);
-  assert.equal((await noPath.json()).error.param, 'path');
-
-  const missingDownload = await fetch(`${base}/v1/files/content?path=${encodeURIComponent('/nope/missing.txt')}`);
-  assert.equal(missingDownload.status, 404);
-  assert.equal((await missingDownload.json()).error.code, 'file_not_found');
 });
 
 // --- OpenClaw adapter (needs a local OpenClaw gateway; skipped when it's down) ---


### PR DESCRIPTION
## Summary
Turns the minimal files API (multipart upload + download) into a full **file browser** on the Agent API (`/v1/files`), so customers can build their own file UI against an instance.

## Endpoints
| Verb | Path | Does |
|---|---|---|
| `GET` | `/v1/files?path=` | list a directory (dirs-first, 1000-cap + `truncated`) |
| `GET` | `/v1/files/content?path=&disposition=` | read / preview / download |
| `PUT` | `/v1/files/content?path=&overwrite=` | write (create/overwrite/edit/upload), raw body |
| `DELETE` | `/v1/files?path=` | recursive delete |
| `PATCH` | `/v1/files` `{from,to}` | rename / move |
| `POST` | `/v1/files/dir?path=` | mkdir -p |

- **No jail** — the `sk_live_` key is instance root.
- `PUT /v1/files/content` carries raw bytes (no multipart / `multer`); `app.ts` excludes it from the JSON parser so the body streams to disk. `overwrite=false` → `409 file_exists`; `X-Expected-Mtime` → `412 modified` (lost-update guard).
- `FileEntry { name, path, type, size, modified (epoch ms), hidden }`, returned by list and every write.
- The old multipart `POST /v1/files` is removed (folded into `PUT content`); the chat-attachment flow now PUTs bytes, then references the path.

## Tests
New LLM-free `test/files.integration.test.ts` covers all 6 endpoints. `npm run typecheck` + full `npm test` are green (**24/24**, including the live-LLM attachment round-trip).

## Deploy
Ships to instances via tag `v0.3.0` → bump `GATEWAY_VERSION` + the `b2b-hermes` tag in agent37-web → `publish-image.sh b2b-hermes` → `POST /v1/instances/{id}/update`. Docs + the-college-agent file browser ship alongside.

https://claude.ai/code/session_01H7n6UGCNTacwukoqcDtCY7
