### PR TITLE
Add GET /v1/files/archive: download a folder as a streamed .tar.gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Every entry — in a listing and returned by every write — is a `FileEntry`:
 | --- | --- |
 | List one directory level | `GET /v1/files?path=<dir>` (defaults to the workspace) |
 | Read / preview / download | `GET /v1/files/content?path=<file>&disposition=inline\|attachment` |
+| Download a folder as `.tar.gz` | `GET /v1/files/archive?path=<dir>` (defaults to the workspace) |
 | Write raw bytes (create/overwrite/edit/upload) | `PUT /v1/files/content?path=<file>&overwrite=true\|false` |
 | Delete (recursive, force) | `DELETE /v1/files?path=<path>` → `{ ok: true }` |
 | Rename / move | `PATCH /v1/files` body `{ from, to }` |
@@ -234,6 +235,13 @@ directories first then name (case-insensitive), capped at 1000 entries
 `GET /v1/files/content` sets `Content-Type` from the extension and streams at any
 size; `disposition` defaults to `attachment` (download), `inline` lets a browser
 render it.
+
+`GET /v1/files/archive` streams a directory as a gzipped tar (`.tar.gz`), produced
+by piping the system `tar` — any size, flat memory, and it unpacks to one
+top-level folder named after the directory (`application/gzip`,
+`Content-Disposition: attachment`). Symlinks are stored as links, not followed.
+There is no folder-upload counterpart — recreate a tree with per-file
+`PUT /v1/files/content` calls (each `mkdir -p`s its parents).
 
 `PUT /v1/files/content` writes the **raw request body** (not multipart) to the
 path, creating parent directories as needed, and returns the new `FileEntry`.
@@ -310,7 +318,7 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 | Code | HTTP | When |
 | --- | --- | --- |
 | `validation_error` | 400 | A request field was invalid (see `param`). |
-| `not_a_directory` | 400 | `GET /v1/files` was given a path that isn't a directory. |
+| `not_a_directory` | 400 | `GET /v1/files` or `GET /v1/files/archive` was given a path that isn't a directory. |
 | `response_not_found` | 404 | No response with that id. |
 | `file_not_found` | 404 | No file at that path. |
 | `not_found` | 404 | Unknown route. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -3,6 +3,7 @@
 // The worker runs with cwd = the workspace, so files written here are the files
 // the agent reads from disk, and files the agent produces are read back here.
 
+import { spawn } from 'node:child_process';
 import { createWriteStream } from 'node:fs';
 import { lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
@@ -89,6 +90,21 @@ async function toFileEntry(path: string): Promise<FileEntry> {
   };
 }
 
+/** A safe download filename for an archive of `dirName`: keep only filename-safe
+ *  characters (drops the CR/LF, quotes, and slashes that could break or escape
+ *  the header), fall back to `archive`, and always end `.tar.gz`. */
+function archiveFilename(dirName: string): string {
+  const cleaned = dirName.replace(/[^A-Za-z0-9._ -]/g, '').trim();
+  return `${cleaned || 'archive'}.tar.gz`;
+}
+
+/** A Content-Disposition value with an ASCII `filename=` fallback plus an RFC 5987
+ *  `filename*` for non-ASCII names. */
+function attachmentDisposition(filename: string): string {
+  const ascii = filename.replace(/[^\x20-\x7e]/g, '_');
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}
+
 // GET /v1/files?path=<dir> — list one directory level. `path` is optional and
 // defaults to the agent workspace dir. Directories sort first, then by name.
 filesRouter.get('/', async (req, res, next) => {
@@ -154,6 +170,72 @@ filesRouter.get('/content', async (req, res, next) => {
     } else {
       res.download(path, basename(path), { dotfiles: 'allow' }, onDone);
     }
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /v1/files/archive?path=<dir> — download a directory as a streamed .tar.gz.
+// `path` is optional and defaults to the workspace dir. The archive is produced
+// by piping the system `tar` straight to the response, so it streams at any size
+// with flat memory. tar.gz only — the image has gzip but no zip packer.
+filesRouter.get('/archive', async (req, res, next) => {
+  try {
+    const raw = req.query.path;
+    const dir = typeof raw === 'string' && raw.trim() ? resolveHomeAwarePath(raw) : resolveWorkspaceDir();
+
+    let stats;
+    try {
+      stats = await stat(dir);
+    } catch {
+      throw fileNotFound(dir);
+    }
+    if (!stats.isDirectory()) throw notADirectory(dir);
+
+    const name = basename(dir);
+    res.setHeader('Content-Type', 'application/gzip');
+    res.setHeader('Content-Disposition', attachmentDisposition(archiveFilename(name)));
+    // Send the headers before spawning tar. The mesh/host-proxy header timeout
+    // fires on the container's *response* headers, and Node holds them until the
+    // first body byte — a slow-first-byte tar (a huge first file or deep tree)
+    // would trip it. Flushing up front means only the looser inter-chunk gap
+    // timeout applies once bytes start flowing.
+    res.flushHeaders();
+
+    // `-C <parent> -- <name>`: archive the directory by name relative to its
+    // parent so the tarball unpacks to a single top-level folder. `--` ends
+    // options because `name` is agent-controlled — a directory literally named
+    // `--checkpoint-action=...` must be treated as a path, not a tar flag. No
+    // `-h`/`--dereference`: symlinks stay link entries, never their target bytes.
+    const child = spawn('tar', ['-czf', '-', '-C', dirname(dir), '--', name], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    // A client that disconnects mid-download must not orphan tar.
+    res.on('close', () => {
+      if (!child.killed) child.kill('SIGKILL');
+    });
+
+    // Manage end-of-response ourselves (end:false) so the exit code decides
+    // between a clean end and a torn connection.
+    child.stdout.pipe(res, { end: false });
+
+    child.on('error', () => {
+      // tar could not even spawn; headers are already out, so the only signal we
+      // can give the client is a torn connection.
+      if (!res.destroyed) res.destroy();
+    });
+    child.on('close', (code) => {
+      if (res.destroyed || res.writableEnded) return;
+      // Only a clean exit (0) or tar's "some files changed/vanished as we read
+      // them" warning (1, expected on a live workspace) is success. Anything else
+      // — a fatal code (>1) or signal death (code === null, e.g. the OOM-killer
+      // reaping tar mid-archive) — means the gzip stream was cut mid-write. The
+      // headers are already flushed, so tear the connection rather than res.end()
+      // a truncated archive into a clean EOF the client would trust.
+      if (code === 0 || code === 1) res.end();
+      else res.destroy();
+    });
   } catch (error) {
     next(error);
   }

--- a/test/files.integration.test.ts
+++ b/test/files.integration.test.ts
@@ -3,7 +3,8 @@
 // alone with: node --import tsx --test test/files.integration.test.ts
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, mkdtempSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { startTestServer, type TestServer } from './test-helpers.js';
@@ -35,6 +36,23 @@ function freshDir(): string {
 const filesUrl = (path: string) => `${base}/v1/files?path=${encodeURIComponent(path)}`;
 const contentUrl = (path: string, query = '') =>
   `${base}/v1/files/content?path=${encodeURIComponent(path)}${query}`;
+const archiveUrl = (path: string) => `${base}/v1/files/archive?path=${encodeURIComponent(path)}`;
+
+/** Extract a fetched .tar.gz response body into a fresh dir; returns that dir. */
+async function extractArchive(res: Response): Promise<string> {
+  const buf = Buffer.from(await res.arrayBuffer());
+  // gzip magic — proves we streamed a real gzip stream, not an error body.
+  assert.equal(buf[0], 0x1f);
+  assert.equal(buf[1], 0x8b);
+  const work = freshDir();
+  const tgz = join(work, 'archive.tar.gz');
+  writeFileSync(tgz, buf);
+  const out = join(work, 'out');
+  mkdirSync(out);
+  const r = spawnSync('tar', ['-xzf', tgz, '-C', out]);
+  assert.equal(r.status, 0, r.stderr?.toString());
+  return out;
+}
 
 test('GET /v1/files lists one level: dirs first, then case-insensitive name', async () => {
   const dir = freshDir();
@@ -288,4 +306,78 @@ test('POST /v1/files/dir is mkdir -p and idempotent', async () => {
   const noPath = await fetch(`${base}/v1/files/dir`, { method: 'POST' });
   assert.equal(noPath.status, 400);
   assert.equal((await noPath.json()).error.param, 'path');
+});
+
+test('GET /v1/files/archive streams a .tar.gz that unpacks to one top-level folder', async () => {
+  const dir = freshDir();
+  const proj = join(dir, 'proj');
+  mkdirSync(join(proj, 'nested/deep'), { recursive: true });
+  writeFileSync(join(proj, 'top.txt'), 'top');
+  writeFileSync(join(proj, 'nested/deep/file.txt'), 'deep');
+
+  const res = await fetch(archiveUrl(proj));
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('content-type'), 'application/gzip');
+  assert.match(res.headers.get('content-disposition') ?? '', /attachment; filename="proj\.tar\.gz"/);
+
+  // Round-trips: the tarball unpacks to a single `proj/` dir with the tree intact.
+  const out = await extractArchive(res);
+  assert.equal(readFileSync(join(out, 'proj/top.txt'), 'utf8'), 'top');
+  assert.equal(readFileSync(join(out, 'proj/nested/deep/file.txt'), 'utf8'), 'deep');
+});
+
+test('GET /v1/files/archive treats a dash-led directory name as a path, not a flag', async () => {
+  // Without `--` in the tar argv, `--weird` would be parsed as an option (RCE/arg
+  // injection vector). With it, the dir archives normally.
+  const dir = freshDir();
+  const weird = join(dir, '--weird');
+  mkdirSync(weird);
+  writeFileSync(join(weird, 'a.txt'), 'x');
+
+  const res = await fetch(archiveUrl(weird));
+  assert.equal(res.status, 200);
+  const out = await extractArchive(res);
+  assert.equal(readFileSync(join(out, '--weird/a.txt'), 'utf8'), 'x');
+});
+
+test('GET /v1/files/archive stores symlinks as links, never the target bytes', async () => {
+  // No `-h`/`--dereference`: a symlink must round-trip as a symlink, so the archive can't be used
+  // to exfiltrate a link target's contents as inlined file bytes.
+  const dir = freshDir();
+  const proj = join(dir, 'proj');
+  mkdirSync(proj);
+  writeFileSync(join(proj, 'secret.txt'), 'classified');
+  symlinkSync(join(proj, 'secret.txt'), join(proj, 'link'));
+
+  const out = await extractArchive(await fetch(archiveUrl(proj)));
+  assert.equal(lstatSync(join(out, 'proj/link')).isSymbolicLink(), true);
+});
+
+test('GET /v1/files/archive sanitizes the Content-Disposition filename', async () => {
+  // A directory name is agent-controlled and Linux allows almost anything in it; quotes (which would
+  // break out of the header) must be stripped, leaving a clean `*.tar.gz` download name.
+  const dir = freshDir();
+  const weird = join(dir, 'my "quoted" dir');
+  mkdirSync(weird);
+  writeFileSync(join(weird, 'a.txt'), 'x');
+
+  const res = await fetch(archiveUrl(weird));
+  assert.equal(res.status, 200);
+  const cd = res.headers.get('content-disposition') ?? '';
+  assert.match(cd, /filename="my quoted dir\.tar\.gz"/);
+  await res.arrayBuffer(); // drain the stream so the connection closes cleanly
+});
+
+test('GET /v1/files/archive errors before streaming: 404 missing, 400 not-a-directory', async () => {
+  const dir = freshDir();
+  const file = join(dir, 'a.txt');
+  writeFileSync(file, 'x');
+
+  const missing = await fetch(archiveUrl(join(dir, 'nope')));
+  assert.equal(missing.status, 404);
+  assert.equal((await missing.json()).error.code, 'file_not_found');
+
+  const notDir = await fetch(archiveUrl(file));
+  assert.equal(notDir.status, 400);
+  assert.equal((await notDir.json()).error.code, 'not_a_directory');
 });


### PR DESCRIPTION
## What

Adds `GET /v1/files/archive?path=<dir>` — download an instance folder as a streamed `.tar.gz`. `path` is optional and defaults to the workspace. This is the missing "pull a whole tree" primitive; the existing `/v1/files/content` is single-file only.

## How

Shells out to the system `tar` (`tar -czf - -C <parent> -- <name>`) and pipes stdout to the response — zero deps, flat memory, unbounded size. The transport/security gotchas are baked in:

- `res.flushHeaders()` **before** spawning tar — the mesh/host-proxy header timeout fires on the container's response headers, which Node holds until the first body byte.
- `--` end-of-options — the directory basename is agent-controlled, so a dir named `--checkpoint-action=…` must be a path, not a tar flag.
- No `-h`/`--dereference` — symlinks stay link entries, never their target bytes (no exfil).
- Sanitized `Content-Disposition` filename (strips path separators, control chars, quotes; falls back to `archive`).
- tar exit 1 (a "file changed as we read it" warning on a live tree) is success; any other code **or signal death** tears the connection so a truncated archive is never sent as a clean EOF.
- `res.on('close')` SIGKILLs tar so a cancelled download doesn't orphan it.

No edge/host-proxy change needed — both stream the response through unchanged.

## Tests

5 new archive integration tests (real `tar` round-trip to a single top-level folder, the `--` injection guard, symlink-stays-a-link, Content-Disposition sanitization, pre-stream 404/400 errors). Full suite green: `npm run typecheck` clean, `npm test` 29/29.

## Release

Bumps `package.json` to **0.4.0**; README documents the endpoint. Tag `v0.4.0` follows the merge.

https://claude.ai/code/session_01CvWdDnG3hRym325BauZmxp
