### PR TITLE
Honor configured custom: provider for vendor-prefixed model ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -830,6 +830,15 @@ def _resolve_model_provider(
         provider_hint, bare_model = parsed
         return bare_model, provider_hint or config_provider, None
 
+    if config_provider_l.startswith("custom:"):
+        slug = config_provider_l[len("custom:"):]
+        for entry in _custom_providers(cfg):
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "").strip()
+            if name and name.lower().replace(" ", "-") == slug:
+                return model_id, f"custom:{name.lower().replace(' ', '-')}", string_or_none(entry.get("base_url"))
+
     if "/" in model_id:
         prefix, bare = model_id.split("/", 1)
         prefix_normalized = prefix.lower()

--- a/test/resolve-model-provider.test.ts
+++ b/test/resolve-model-provider.test.ts
@@ -1,0 +1,13 @@
+// Regression gate for the Python worker's _resolve_model_provider: catalog
+// model ids must stay on a configured custom: provider (the managed starter
+// proxy) instead of being re-routed to the credential-less openrouter builtin.
+// Pure unit tests — no live Hermes/LLM needed. The real assertions live in
+// test/resolve_model_provider_test.py; this wrapper runs them under npm test.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+test('hermes worker _resolve_model_provider honors managed custom providers', () => {
+  const result = spawnSync('python3', ['test/resolve_model_provider_test.py'], { encoding: 'utf8' });
+  assert.equal(result.status, 0, `python unit tests failed:\n${result.stdout}\n${result.stderr}`);
+});

--- a/test/resolve_model_provider_test.py
+++ b/test/resolve_model_provider_test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Regression tests for _resolve_model_provider (managed custom-provider routing).
+
+Catalog model ids like "anthropic/claude-sonnet-5" must stay on a configured
+custom: provider (the managed Agent37 starter proxy) instead of being re-routed
+to the built-in openrouter provider, which holds no credentials on managed
+instances (HTTP 401 "User not found").
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "server" / "workers"))
+
+import hermes_worker
+
+PROXY_URL = "https://www.agent37.com/api/openclaw/starter-proxy/v1"
+
+MANAGED_CFG = {
+    "model": {"default": "default", "provider": "custom:agent37"},
+    "custom_providers": [
+        {
+            "name": "Agent37",
+            "base_url": PROXY_URL,
+            "api_key": "token",
+            "api_mode": "chat_completions",
+            "model": "default",
+        }
+    ],
+}
+
+
+class ResolveModelProviderTest(unittest.TestCase):
+    def test_explicit_custom_provider_honored_for_catalog_model(self):
+        result = hermes_worker._resolve_model_provider(
+            "anthropic/claude-sonnet-5", MANAGED_CFG, requested_provider="custom:agent37"
+        )
+        self.assertEqual(result, ("anthropic/claude-sonnet-5", "custom:agent37", PROXY_URL))
+
+    def test_config_custom_provider_honored_without_explicit_provider(self):
+        result = hermes_worker._resolve_model_provider("openai/gpt-4o-mini", MANAGED_CFG)
+        self.assertEqual(result, ("openai/gpt-4o-mini", "custom:agent37", PROXY_URL))
+
+    def test_default_model_unchanged(self):
+        result = hermes_worker._resolve_model_provider(
+            "default", MANAGED_CFG, requested_provider="custom:agent37"
+        )
+        self.assertEqual(result, ("default", "custom:agent37", PROXY_URL))
+
+    def test_explicit_openrouter_still_routes_to_openrouter(self):
+        model, provider, _ = hermes_worker._resolve_model_provider(
+            "anthropic/claude-sonnet-5", MANAGED_CFG, requested_provider="openrouter"
+        )
+        self.assertEqual((model, provider), ("anthropic/claude-sonnet-5", "openrouter"))
+
+    def test_at_provider_syntax_still_overrides_config_provider(self):
+        model, provider, _ = hermes_worker._resolve_model_provider(
+            "@openrouter:anthropic/claude-sonnet-5", MANAGED_CFG
+        )
+        self.assertEqual((model, provider), ("anthropic/claude-sonnet-5", "openrouter"))
+
+    def test_openrouter_config_provider_unchanged(self):
+        cfg = {"model": {"default": "anthropic/claude-sonnet-5", "provider": "openrouter"}}
+        model, provider, _ = hermes_worker._resolve_model_provider("anthropic/claude-sonnet-5", cfg)
+        self.assertEqual((model, provider), ("anthropic/claude-sonnet-5", "openrouter"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
On managed instances the Hermes config routes everything through the `custom:agent37` starter proxy, but `_resolve_model_provider` re-routed any vendor-prefixed catalog id (`anthropic/claude-sonnet-5`, `openai/gpt-4o-mini`, …) to the built-in `openrouter` provider — which holds no credentials there — so every non-default model pick died with `HTTP 401: User not found`, even when `custom:agent37` was explicitly requested.

Fix: resolve to the configured `custom:` provider (explicitly requested **or** the config default) before the `KNOWN_PROVIDER_PREFIXES → openrouter` fallthrough, keeping the full vendor-prefixed id the proxy expects. The config-default case also fixes Hermes' internal sub-agents (title generation, curator, background review), which resolve with no requested provider.

Unchanged: explicit `provider: openrouter`, `@provider:model` syntax, `openrouter`/portal config providers, and the `default` model path.

Tests: new pure-python regression suite (`test/resolve_model_provider_test.py`, red on the old code) wired into `npm test` via `test/resolve-model-provider.test.ts`. Full gate run locally: `npm run typecheck && npm test` → 30/30 pass.

Bumps version to 0.4.1 (tagged on merge; downstream images re-pin in agent37-platform/website).

https://claude.ai/code/session_01H4yTrV5VM917AaAksQ1x7g