### PR TITLE
Expose a session's running response: active_response_id + 409 response_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,31 @@ With `stream: true` the body is a Server-Sent Events stream of named events:
 | Reconnect a dropped stream | `GET /v1/responses/{id}/stream` (replays a snapshot, then resumes live) |
 | Cancel a running turn | `POST /v1/responses/{id}/cancel` |
 
+Lost the id (page reload, new device)? `GET /v1/sessions/{id}` returns the
+running response as `active_response_id`.
+
 ### Sessions
 
 | Action | Endpoint |
 | --- | --- |
 | List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw`; native backend fields pass through) |
-| Retrieve, with history | `GET /v1/sessions/{id}` (`?agent=` to pick the harness) |
+| Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history }` (`?agent=` to pick the harness) |
 | Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store. Hermes only (titles are length-capped and must be unique — a clash is `409 title_conflict`); harnesses without an editable title answer `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |
+
+`active_response_id` is the id of the `in_progress` response on the session, or
+null when it is idle. Harnesses persist a turn's messages at turn end, so while
+`active_response_id` is set the running turn is normally **not** in `history`
+yet — follow it live with `GET /v1/responses/{id}/stream`. This is how a client
+that lost its state (page reload, new device) rediscovers and reattaches to a
+running turn. Two timing edges to code for: right at turn end, one read can
+briefly show the finished turn in `history` **and** its id still in
+`active_response_id` — reattaching is still correct, the finished run's replay
+just ends immediately. And once it reads null the transcript is complete, with
+one exception: a **cancelled** OpenClaw turn is persisted by OpenClaw on its own
+schedule and can surface in `history` shortly after. If the harness history
+read fails (the route errors), a running turn stays discoverable: the error
+body carries its id as `error.response_id`.
 
 ### Files
 
@@ -322,7 +339,7 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 | `response_not_found` | 404 | No response with that id. |
 | `file_not_found` | 404 | No file at that path. |
 | `not_found` | 404 | Unknown route. |
-| `session_busy` | 409 | A response is already running on the session. |
+| `session_busy` | 409 | A response is already running on the session. On the 409, `error.response_id` names it — reattach via `GET /v1/responses/{id}/stream` or cancel it. (Treat the field as optional: a rare gateway/harness race surfaces this code as a failed response without it.) |
 | `title_conflict` | 409 | The requested session title is already in use by another session. |
 | `file_exists` | 409 | `PUT /v1/files/content?overwrite=false` and the file already exists. |
 | `modified` | 412 | `PUT /v1/files/content`'s `X-Expected-Mtime` no longer matches the file. |
@@ -335,7 +352,8 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 
 Agent/worker failures surface their own `code` and `hint` where available (e.g.
 `auth_error`, `quota_exhausted`, `model_error`). One response runs at a time per
-session; sending a new turn while one is in flight returns `409 session_busy`.
+session; sending a new turn while one is in flight returns `409 session_busy`,
+normally with the running response's id in `error.response_id`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -10,12 +10,13 @@ export class GatewayError extends Error {
   readonly code: string;
   readonly param?: string;
   readonly hint?: string;
+  readonly responseId?: string;
 
   constructor(
     status: number,
     code: string,
     message: string,
-    options?: { param?: string; hint?: string },
+    options?: { param?: string; hint?: string; responseId?: string },
   ) {
     super(message);
     this.name = 'GatewayError';
@@ -23,12 +24,14 @@ export class GatewayError extends Error {
     this.code = code;
     this.param = options?.param;
     this.hint = options?.hint;
+    this.responseId = options?.responseId;
   }
 
   toBody(): { error: ApiError } {
     const error: ApiError = { code: this.code, message: this.message };
     if (this.param) error.param = this.param;
     if (this.hint) error.hint = this.hint;
+    if (this.responseId) error.response_id = this.responseId;
     return { error };
   }
 }
@@ -84,9 +87,10 @@ export function fileModified(path: string): GatewayError {
   });
 }
 
-export function sessionBusy(): GatewayError {
+export function sessionBusy(responseId?: string): GatewayError {
   return new GatewayError(409, 'session_busy', 'A response is already running on this session.', {
-    hint: 'Cancel the running response, or start another session.',
+    hint: 'Reattach with GET /v1/responses/{response_id}/stream, cancel it, or start another session.',
+    responseId,
   });
 }
 

--- a/server/responses.ts
+++ b/server/responses.ts
@@ -66,7 +66,8 @@ export function beginResponse(req: ResponseRequest): BegunResponse {
   const sessionId = req.sessionId ?? newSessionId();
   const agent = req.agent;
 
-  if (activeResponseForSession(sessionId)) throw sessionBusy();
+  const activeResponseId = activeResponseForSession(sessionId);
+  if (activeResponseId) throw sessionBusy(activeResponseId);
 
   const responseId = newResponseId();
   insertResponse({

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import type { AgentType, SessionMessage } from '../../shared/types.js';
 import { getAdapter, agentFromQuery } from '../agent.js';
-import { gatewayErrorFromWorker, renameUnsupported, validationError } from '../errors.js';
+import { GatewayError, gatewayErrorFromWorker, renameUnsupported, validationError } from '../errors.js';
+import { activeResponseForSession } from '../live-runs.js';
 
 export const sessionsRouter = Router();
 
@@ -21,7 +22,14 @@ sessionsRouter.get('/', async (req, res, next) => {
 
 // GET /v1/sessions/:id?agent= — the session's transcript, projected from the
 // harness. An unknown id projects to empty history rather than 404 — the harness
-// owns existence.
+// owns existence. `active_response_id` names the in_progress response on the
+// session (null when idle): harnesses persist a turn's rows at turn end, so
+// while it is set the running turn is normally not in `history` yet — follow it
+// via GET /v1/responses/{id}/stream. The two reads aren't atomic: right at turn
+// end one response can briefly show the finished turn in `history` AND its id
+// still set — reattaching is still correct (a finished run's replay ends
+// immediately). Null means the transcript is complete, except a cancelled
+// OpenClaw turn, which OpenClaw persists on its own schedule shortly after.
 sessionsRouter.get('/:id', async (req, res, next) => {
   let agent: AgentType | undefined;
   try {
@@ -35,9 +43,27 @@ sessionsRouter.get('/:id', async (req, res, next) => {
       thinking: m.thinking,
       created_at: m.created_at,
     }));
-    res.json({ id: req.params.id, agent, history });
+    res.json({
+      id: req.params.id,
+      agent,
+      active_response_id: activeResponseForSession(req.params.id) ?? null,
+      history,
+    });
   } catch (error) {
-    next(gatewayErrorFromWorker(error, 'Session history unavailable', agent));
+    // The run registry is local and healthy even when the harness read fails —
+    // keep the running response discoverable (error.response_id) so a client
+    // can still reattach or cancel while history is unavailable.
+    const err = gatewayErrorFromWorker(error, 'Session history unavailable', agent);
+    const active = activeResponseForSession(req.params.id);
+    next(
+      active
+        ? new GatewayError(err.status, err.code, err.message, {
+            param: err.param,
+            hint: err.hint,
+            responseId: active,
+          })
+        : err,
+    );
   }
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -48,6 +48,8 @@ export interface ApiError {
   message: string;
   param?: string;
   hint?: string;
+  /** On `session_busy`: the id of the response already running on the session. */
+  response_id?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -128,9 +128,11 @@ test('responses and sessions work end-to-end through the local LLM', async () =>
 
   const session = await jsonOk<{
     id: string;
+    active_response_id: string | null;
     history: Array<{ role: string; content: string }>;
   }>(await fetch(`${base}/v1/sessions/${created.session_id}`));
   assert.equal(session.id, created.session_id);
+  assert.equal(session.active_response_id, null); // idle session
   assert.ok(session.history.some((message) => message.role === 'user' && message.content.includes(marker)));
   assert.ok(session.history.some((message) => message.role === 'assistant' && message.content.trim()));
 
@@ -221,13 +223,28 @@ test('an in-flight response blocks another turn and can be cancelled', async () 
   const responseId = created.data.id as string;
   const sessionId = created.data.session_id as string;
 
+  // While the turn runs, the session names its in_progress response — this is
+  // how a client that lost its state (reload) rediscovers and reattaches.
+  const running = await jsonOk<{ active_response_id: string | null }>(
+    await fetch(`${base}/v1/sessions/${sessionId}`),
+  );
+  assert.equal(running.active_response_id, responseId);
+
   const busy = await postJson(base, { session_id: sessionId, input: 'start another turn' });
   assert.equal(busy.status, 409);
-  assert.equal((await busy.json()).error.code, 'session_busy');
+  const busyBody = (await busy.json()) as { error: { code: string; response_id: string } };
+  assert.equal(busyBody.error.code, 'session_busy');
+  assert.equal(busyBody.error.response_id, responseId);
 
   const cancel = await fetch(`${base}/v1/responses/${responseId}/cancel`, { method: 'POST' });
   assert.equal(cancel.status, 200);
   await reader.drain(); // the in-flight stream ends once the turn is cancelled
+
+  // Terminal turn: the session lock is released and active_response_id nulls.
+  const settled = await jsonOk<{ active_response_id: string | null }>(
+    await fetch(`${base}/v1/sessions/${sessionId}`),
+  );
+  assert.equal(settled.active_response_id, null);
 
   // Reconnecting replays the now-terminal turn and closes immediately.
   const replay = await new SseReader(


### PR DESCRIPTION
## Why

A customer's coding agent (and our own Starter Kit) had no way to rediscover an in-flight response after losing client state (page reload, new device): `GET /v1/responses/{id}/stream` reconnects fine, but you had to already hold the id from `response.created`. Both ended up string-matching live input text against transcript rows plus settle timers.

## What

Two additive changes, both reading live-runs' existing `sessionId → responseId` map — no new state, no harness changes, works identically for Hermes, OpenClaw, and future adapters:

- `GET /v1/sessions/{id}` now returns `active_response_id` — the `in_progress` response on the session, `null` when idle. Since harnesses persist a turn's rows at turn end, `null` also means the transcript is complete (timing edges documented in the README: the non-atomic read at turn end, and the OpenClaw-cancel case).
- `409 session_busy` now carries the running response's id as `error.response_id` (`ApiError.response_id`), so a blind re-POST gets a recovery path. Documented as optional: the rare worker-originated `task_busy` race surfaces `session_busy` without it.
- If the harness history read fails, the session GET's error body still carries `error.response_id` for a running turn — the run registry is local and stays healthy when the harness is flaky.

## Testing

`npm run typecheck && npm test` — 30/30 green against the real local Hermes worker/LLM, including new assertions: `active_response_id` set mid-turn, echoed in the 409 body, and `null` after cancel.

## Release

v0.5.0 (additive surface). Note main carries the un-shipped v0.4.2 delta (fallback_model list fix), which rides along in the next image roll. Docs PR: agent37-platform/docs, Starter Kit PR: agent37-platform/starter-kit (merge that one only after images roll — its post-reload cancel reads the new field).

https://claude.ai/code/session_01LDE22AaExFnK7E5QVpmZsa