### PR TITLE
Drop the session-history error-path response_id rewrap (v0.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,7 @@ null when it is idle. Harnesses persist a turn's messages at turn end, so while
 `active_response_id` is set the running turn is normally **not** in `history`
 yet — follow it live with `GET /v1/responses/{id}/stream`. This is how a client
 that lost its state (page reload, new device) rediscovers and reattaches to a
-running turn. Two timing edges to code for: right at turn end, one read can
-briefly show the finished turn in `history` **and** its id still in
-`active_response_id` — reattaching is still correct, the finished run's replay
-just ends immediately. And once it reads null the transcript is complete, with
-one exception: a **cancelled** OpenClaw turn is persisted by OpenClaw on its own
-schedule and can surface in `history` shortly after. If the harness history
-read fails (the route errors), a running turn stays discoverable: the error
-body carries its id as `error.response_id`.
+running turn.
 
 ### Files
 
@@ -339,7 +332,7 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 | `response_not_found` | 404 | No response with that id. |
 | `file_not_found` | 404 | No file at that path. |
 | `not_found` | 404 | Unknown route. |
-| `session_busy` | 409 | A response is already running on the session. On the 409, `error.response_id` names it — reattach via `GET /v1/responses/{id}/stream` or cancel it. (Treat the field as optional: a rare gateway/harness race surfaces this code as a failed response without it.) |
+| `session_busy` | 409 | A response is already running on the session. `error.response_id` names it — reattach via `GET /v1/responses/{id}/stream` or cancel it. |
 | `title_conflict` | 409 | The requested session title is already in use by another session. |
 | `file_exists` | 409 | `PUT /v1/files/content?overwrite=false` and the file already exists. |
 | `modified` | 412 | `PUT /v1/files/content`'s `X-Expected-Mtime` no longer matches the file. |
@@ -353,7 +346,7 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 Agent/worker failures surface their own `code` and `hint` where available (e.g.
 `auth_error`, `quota_exhausted`, `model_error`). One response runs at a time per
 session; sending a new turn while one is in flight returns `409 session_busy`,
-normally with the running response's id in `error.response_id`.
+with the running response's id in `error.response_id`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import type { AgentType, SessionMessage } from '../../shared/types.js';
 import { getAdapter, agentFromQuery } from '../agent.js';
-import { GatewayError, gatewayErrorFromWorker, renameUnsupported, validationError } from '../errors.js';
+import { gatewayErrorFromWorker, renameUnsupported, validationError } from '../errors.js';
 import { activeResponseForSession } from '../live-runs.js';
 
 export const sessionsRouter = Router();
@@ -23,13 +23,7 @@ sessionsRouter.get('/', async (req, res, next) => {
 // GET /v1/sessions/:id?agent= — the session's transcript, projected from the
 // harness. An unknown id projects to empty history rather than 404 — the harness
 // owns existence. `active_response_id` names the in_progress response on the
-// session (null when idle): harnesses persist a turn's rows at turn end, so
-// while it is set the running turn is normally not in `history` yet — follow it
-// via GET /v1/responses/{id}/stream. The two reads aren't atomic: right at turn
-// end one response can briefly show the finished turn in `history` AND its id
-// still set — reattaching is still correct (a finished run's replay ends
-// immediately). Null means the transcript is complete, except a cancelled
-// OpenClaw turn, which OpenClaw persists on its own schedule shortly after.
+// session (null when idle); follow it via GET /v1/responses/{id}/stream.
 sessionsRouter.get('/:id', async (req, res, next) => {
   let agent: AgentType | undefined;
   try {
@@ -50,20 +44,7 @@ sessionsRouter.get('/:id', async (req, res, next) => {
       history,
     });
   } catch (error) {
-    // The run registry is local and healthy even when the harness read fails —
-    // keep the running response discoverable (error.response_id) so a client
-    // can still reattach or cancel while history is unavailable.
-    const err = gatewayErrorFromWorker(error, 'Session history unavailable', agent);
-    const active = activeResponseForSession(req.params.id);
-    next(
-      active
-        ? new GatewayError(err.status, err.code, err.message, {
-            param: err.param,
-            hint: err.hint,
-            responseId: active,
-          })
-        : err,
-    );
+    next(gatewayErrorFromWorker(error, 'Session history unavailable', agent));
   }
 });
 


### PR DESCRIPTION
Follow-up simplification to #16.

That PR's `GET /v1/sessions/{id}` catch block re-wrapped a failed harness history read to attach the running response's id as `error.response_id`. This reverts that: the path is **redundant** (a client hitting it can just re-POST and get the same id on the `409 session_busy`) and it added complexity the route didn't need.

- `server/routes/sessions.ts`: catch back to its one-liner; drop the now-unused `GatewayError` import; trim the oversized route comment.
- `README.md`: drop the timing-edge / history-read-failure prose and the "optional field / rare race" caveat on `session_busy`.
- `package.json`: `0.5.0` → `0.5.1`.

The two additive parts from #16 stay: `active_response_id` on the session and `response_id` on the `409`. `errors.ts`, `shared/types.ts`, and the integration test are unchanged.

Gate: `npm run typecheck && npm test` — typecheck clean, 30/30 pass locally.

https://claude.ai/code/session_01NM8V2kM5YpMHJvJGc6jRvx