### PR TITLE
Enable the Hermes cronjob tool in gateway sessions (v0.5.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/adapters/hermes-worker.ts
+++ b/server/adapters/hermes-worker.ts
@@ -331,6 +331,9 @@ class HermesWorkerClient {
         ...process.env,
         HERMES_QUIET: '1',
         HERMES_YOLO_MODE: '1',
+        // Hermes only registers the agent-facing `cronjob` tool (self-scheduling
+        // via chat) when the process declares itself a gateway session.
+        HERMES_GATEWAY_SESSION: '1',
       },
     });
 


### PR DESCRIPTION
## What

One env line: the spawned Hermes worker now sets `HERMES_GATEWAY_SESSION=1` (next to `HERMES_QUIET`/`HERMES_YOLO_MODE`). Version bumped to 0.5.4.

## Why

Hermes registers its agent-facing `cronjob` tool (self-scheduling from chat: "check my inbox every morning") only when the process declares itself an interactive/gateway session (`tools/cronjob_tools.py` checks `HERMES_INTERACTIVE`/`HERMES_GATEWAY_SESSION`/`HERMES_EXEC_ASK`). Our worker declared none, so agents on every instance silently lacked the tool while the cron scheduler itself was already running. This is the same env var Hermes's own gateway sets for itself (`tui_gateway/server.py`).

Side effects audited: a sudo-failure hint string in terminal output, a skills setup hint, and approval-context routing that is moot under `HERMES_YOLO_MODE=1`.

## Test status

`npm run typecheck` clean. `npm test`: all tests pass **except** three LLM-turn tests failing with `HTTP 429: The usage limit has been reached` — the local Hermes default model is `openai-codex/gpt-5.5` and the Codex subscription hit its nightly cap (resets 11:42 PM EDT); the OpenClaw session test fails the same way. Environmental, not this change: the failures are provider 429s, every non-LLM test passes, and a full green rerun is scheduled after the quota window resets — the `v0.5.4` tag and image publish wait on that green run.