### PR TITLE
Worker: a failed Hermes run result is a failed turn, even with failure prose

### DIFF
--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -1369,13 +1369,20 @@ def _run_chat(request_id: str, request: dict[str, Any]) -> None:
         return
 
     final_text = str(result.get("final_response") or "")
-    if result.get("failed") and not final_text:
-        # The agent's run loop aborted (e.g. every provider call was refused)
-        # without producing a reply. Surface it as an error instead of letting
-        # the turn settle as an empty success.
-        error_text = str(result.get("error") or "") or "The agent run failed without producing a response."
+    if result.get("failed"):
+        # The agent's run loop aborted (every provider call refused, billing
+        # wall, ...). Hermes' explicit `failed` flag is the signal: newer
+        # versions also fill final_response with the failure prose ("Billing or
+        # credits exhausted: HTTP 402 ..."), which must not settle the turn as
+        # a completed reply.
+        error_text = (
+            str(result.get("error") or "")
+            or final_text
+            or "The agent run failed without producing a response."
+        )
         payload = _error_payload(RuntimeError(error_text))
-        raise WorkerError(error_text, code=payload["code"], hint=payload.get("hint"))
+        code = payload["code"] if payload["code"] != "worker_error" else "provider_error"
+        raise WorkerError(error_text, code=code, hint=payload.get("hint"))
 
     failure_message = _agent_failure_message(final_text)
     if failure_message:


### PR DESCRIPTION
## What

Trust Hermes' explicit `failed` flag on the run result instead of only raising when `final_response` is empty.

## Why

Hermes v2026.8.13 (the version baked into production images) fills `final_response` with the failure prose on billing walls (`Billing or credits exhausted: HTTP 402 ...`), context-length and payload-too-large aborts. The worker only raised when the run failed AND `final_response` was empty, so a mid-chat 402 settled as `response.completed` with the error prose in `output_text`, instead of `response.failed` with the structured `quota_exhausted` error the API documents. The two provider-failure integration tests were red on `main` for the same reason.

## Verification

- `npm run typecheck` green
- `npm test`: 30/31 (both `provider-failure` tests back to green; the only red is the OpenClaw LLM-turn test, which rides the local Codex subscription that is out of quota until Aug 19; unrelated to this path)

https://claude.ai/code/session_01Nh4A9wjnUVVdTDwuB4rBmX