### PR TITLE
Worker: drop the clarify tool; the agent asks by ending its turn

### DIFF
--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -64,6 +64,27 @@ ACTIVE_TASKS_LOCK = threading.Lock()
 DEFAULT_INTERRUPT_REASON = "Stopped by user"
 
 ALLOWED_REASONING = {"none", "minimal", "low", "medium", "high", "xhigh"}
+
+# Hermes ships an interactive `clarify` tool that blocks the agent loop until a
+# human answers inside the same turn (CLI arrow keys, Telegram buttons). The
+# gateway is a turn-based HTTP API: the caller reads the response and replies
+# on the same session, so the right way to ask is to end the turn with the
+# question as the response. Expose no clarify tool at all (Hermes' own
+# api_server posture, and what cron / delegate children do) rather than a
+# canned callback that tells the model to guess.
+DISABLED_TOOLSETS = ["clarify"]
+
+# Appended to the system prompt at API-call time only (never stored in the
+# session), so it also reaches sessions created before this hint existed.
+GATEWAY_PLATFORM_HINT = (
+    "You are working through the Agent37 gateway, a turn-based API: the person "
+    "you are working for reads your final response and can reply in the next "
+    "turn. There is no interactive clarify tool. When you need a decision or "
+    "information only they can give, and the choice has real trade-offs, stop "
+    "and ask: make the question (and the options, if any) your response, then "
+    "end the turn and wait for their reply. Do not silently pick a branch and "
+    "keep going. Low-stakes ambiguity: choose a sensible default and say so."
+)
 KNOWN_PROVIDER_PREFIXES = {
     "anthropic",
     "openai",
@@ -1016,12 +1037,6 @@ def _create_agent(
     if not resolved_base_url:
         resolved_base_url = string_or_none(runtime.get("base_url"))
 
-    def clarify_callback(question: Any, choices: Any = None) -> str:
-        return (
-            "The user is not available for an interactive clarification right now. "
-            "Make a reasonable assumption, proceed, and call out the assumption in the response if it matters."
-        )
-
     session_db = None
     if _SessionDB is not None:
         try:
@@ -1041,9 +1056,10 @@ def _create_agent(
         "session_id": session_id,
         "session_db": session_db,
         "enabled_toolsets": _resolve_toolsets(cfg),
+        "disabled_toolsets": list(DISABLED_TOOLSETS),
         "fallback_model": _fallback_model(cfg),
-        "clarify_callback": clarify_callback,
         "max_iterations": _max_iterations(cfg),
+        "ephemeral_system_prompt": GATEWAY_PLATFORM_HINT,
     }
     if callbacks:
         agent_kwargs.update(callbacks)

--- a/test/agent-kwargs.test.ts
+++ b/test/agent-kwargs.test.ts
@@ -1,0 +1,13 @@
+// Regression gate for the AIAgent kwargs the Python worker builds: the
+// interactive `clarify` toolset must be disabled (the gateway is turn-based;
+// the model asks by ending its turn with the question) and no canned clarify
+// callback may be registered. Pure unit tests — no live Hermes/LLM needed.
+// The real assertions live in test/agent_kwargs_test.py.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+test('hermes worker disables the clarify toolset and registers no clarify callback', () => {
+  const result = spawnSync('python3', ['test/agent_kwargs_test.py'], { encoding: 'utf8' });
+  assert.equal(result.status, 0, `python unit tests failed:\n${result.stdout}\n${result.stderr}`);
+});

--- a/test/agent_kwargs_test.py
+++ b/test/agent_kwargs_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression tests for the AIAgent kwargs _create_agent hands to Hermes.
+
+The gateway is a turn-based HTTP API: the caller reads the response and replies
+on the same session. Hermes' interactive `clarify` tool (which blocks the agent
+loop until a human answers in-turn) must therefore not be exposed at all, and
+the model must be told to ask by ending its turn with the question. A canned
+clarify callback that says "the user is unavailable, make an assumption" made
+agents silently pick a branch and run on it.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "server" / "workers"))
+
+import hermes_worker
+
+
+class _RecordingAgent:
+    calls: list[dict] = []
+
+    def __init__(self, **kwargs):
+        _RecordingAgent.calls.append(kwargs)
+
+
+def _fake_runtime_provider_module() -> types.ModuleType:
+    module = types.ModuleType("hermes_cli.runtime_provider")
+
+    def resolve_runtime_provider(**_kwargs):
+        return {"provider": "openrouter", "base_url": "https://example.invalid/v1", "api_key": "k"}
+
+    module.resolve_runtime_provider = resolve_runtime_provider
+    return module
+
+
+class CreateAgentKwargsTest(unittest.TestCase):
+    def setUp(self):
+        _RecordingAgent.calls = []
+        params = {
+            "model", "provider", "base_url", "api_key", "quiet_mode", "verbose_logging",
+            "platform", "session_id", "session_db", "enabled_toolsets", "disabled_toolsets",
+            "fallback_model", "clarify_callback", "ephemeral_system_prompt",
+        }
+        fake_hermes_cli = types.ModuleType("hermes_cli")
+        fake_hermes_cli.__path__ = []  # mark as package so submodule lookups work
+        self._patches = [
+            mock.patch.object(hermes_worker, "_ensure_imports", lambda: None),
+            mock.patch.object(hermes_worker, "_AIAgent", _RecordingAgent),
+            mock.patch.object(hermes_worker, "_AIAgent_PARAMS", params),
+            mock.patch.object(hermes_worker, "_SessionDB", None),
+            mock.patch.object(hermes_worker, "_load_config", lambda: {}),
+            mock.patch.object(hermes_worker, "_resolve_toolsets", lambda cfg: ["hermes-cli"]),
+            mock.patch.dict(sys.modules, {
+                "hermes_cli": fake_hermes_cli,
+                "hermes_cli.runtime_provider": _fake_runtime_provider_module(),
+            }),
+        ]
+        for p in self._patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in reversed(self._patches)])
+
+    def _kwargs(self) -> dict:
+        hermes_worker._create_agent(
+            session_id="s1", requested_model="test-model", reasoning_effort=None,
+        )
+        self.assertEqual(len(_RecordingAgent.calls), 1)
+        return _RecordingAgent.calls[0]
+
+    def test_clarify_toolset_is_disabled(self):
+        kwargs = self._kwargs()
+        self.assertEqual(kwargs.get("enabled_toolsets"), ["hermes-cli"])
+        self.assertIn("clarify", kwargs.get("disabled_toolsets") or [])
+
+    def test_no_clarify_callback_is_registered(self):
+        self.assertNotIn("clarify_callback", self._kwargs())
+
+    def test_platform_hint_tells_model_to_ask_by_ending_the_turn(self):
+        hint = self._kwargs().get("ephemeral_system_prompt") or ""
+        self.assertIn("end the turn", hint)
+        self.assertIn("no interactive clarify tool", hint)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- Disable Hermes' `clarify` toolset for gateway sessions (`disabled_toolsets=["clarify"]`, applied last by Hermes so it also strips it from composite/fallback toolsets), and drop the canned `clarify_callback`.
- Append an ephemeral platform hint (API-call time only, never stored in the session) telling the model that this is a turn-based API: when it needs a decision with real trade-offs, make the question its response, end the turn, and wait for the reply.
- Hermetic regression test: `test/agent_kwargs_test.py` (wired into `npm test`).

## Why

Hermes' `clarify` tool blocks the agent loop until a human answers inside the same turn (CLI arrow keys, Telegram buttons). The gateway registered it via the `cli` toolset with a stub that answered, in the same millisecond, "the user is not available, make an assumption and proceed". An agent that wanted a decision from the user therefore asked nobody, picked a branch, and ran with it while the person was watching the chat.

The gateway is turn-based: the caller reads the response and replies on the same session. That is how the agent should ask. This is also what Hermes' own `api_server`, `cron` and `delegate` paths do (no clarify tool at all) instead of a callback that tells the model to guess.

## Verification

- `npm run typecheck` green; `npm test` 30/31 (only red: OpenClaw LLM-turn test on the exhausted local Codex quota, unrelated).
- Real AIAgent constructed through `_create_agent` against a local Hermes: 26 tools, no `clarify`, `disabled_toolsets=['clarify']`, hint set.
- Live A/B on the same undecided-fork prompt (Sonnet 4.5 via OpenRouter):
  - **before**: `response.tool_call.started {tool:"clarify", label:"...What best describes your current stage?"}`, then "Let me ask a few strategic questions... Given your 90-day constraint I'll build a dual-track strategy" and 4k tokens of work on assumptions.
  - **after**: zero tool calls; the response is the question ("What I need from you: 1. monthly burn 2. team background ..."); answering on the same `session_id` in the next turn produced the plan.

Release: v0.5.5 together with #20.

https://claude.ai/code/session_01Nh4A9wjnUVVdTDwuB4rBmX