### PR TITLE
Release v0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent37-gateway",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent37-gateway",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump for the v0.5.5 tag.

- #21 drop the clarify tool; the agent asks by ending its turn
- #20 a failed Hermes run result is a failed turn (mid-chat 402 settles as `response.failed`)
- #19 tool-calling ceiling from `agent.max_turns`

https://claude.ai/code/session_01Nh4A9wjnUVVdTDwuB4rBmX