### PR TITLE
Worker: deliver background delegation results at the next turn

### DIFF
--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -83,7 +83,10 @@ GATEWAY_PLATFORM_HINT = (
     "information only they can give, and the choice has real trade-offs, stop "
     "and ask: make the question (and the options, if any) your response, then "
     "end the turn and wait for their reply. Do not silently pick a branch and "
-    "keep going. Low-stakes ambiguity: choose a sensible default and say so."
+    "keep going. Low-stakes ambiguity: choose a sensible default and say so. "
+    "If you dispatched background work (a delegated subagent, a watched "
+    "process), its result is delivered to you at the start of a later turn, "
+    "so end your turn instead of waiting or polling for it."
 )
 KNOWN_PROVIDER_PREFIXES = {
     "anthropic",
@@ -1274,6 +1277,55 @@ def _usage_from_result(result: dict[str, Any]) -> dict[str, Any]:
     return usage
 
 
+def _drain_async_completions(session_id: str) -> list[str]:
+    """Collect background-completion notifications owed to this session.
+
+    Hermes parks finished background work (delegate_task children, terminal
+    notify_on_complete / watch_patterns events) on
+    ``process_registry.completion_queue`` and relies on the platform loop to
+    hand it to the model: the CLI drains the queue before each prompt, the
+    Hermes daemon self-posts a wake turn. This worker IS the platform loop for
+    gateway sessions, so drain here before each turn; without it a delegation
+    completion sits undelivered forever (``delivery_state='pending'``,
+    ``delivery_attempts=0``) and the parent never hears from its children.
+
+    Ownership is plain session-key equality: delegate_task stamps the batch
+    with ``get_current_session_key()``, which our ``set_session_vars`` binding
+    makes the gateway session id. Claim/complete mirrors the CLI's
+    ``_drain_process_notifications`` so a completion restored into several
+    worker processes is still delivered exactly once. Rows finished before a
+    worker restart re-enter the queue via ``ProcessRegistry.__init__``.
+    """
+    try:
+        from tools.process_registry import process_registry
+        from tools.async_delegation import (
+            claim_event_delivery,
+            complete_event_delivery,
+        )
+    except Exception:
+        return []
+    try:
+        pairs = process_registry.drain_notifications(
+            session_key=session_id, skip_poll_observed=False
+        )
+    except Exception:
+        return []
+    texts: list[str] = []
+    for evt, text in pairs:
+        try:
+            claim = claim_event_delivery(evt, f"agent37-gateway:{session_id}")
+        except Exception:
+            continue
+        if claim is None:
+            continue  # another consumer already claimed this delivery
+        texts.append(text)
+        try:
+            complete_event_delivery(evt, claim)
+        except Exception:
+            pass
+    return texts
+
+
 def _run_chat(request_id: str, request: dict[str, Any]) -> None:
     settings = request.get("settings") if isinstance(request.get("settings"), dict) else {}
     requested_model = string_or_none(settings.get("model"))
@@ -1287,6 +1339,13 @@ def _run_chat(request_id: str, request: dict[str, Any]) -> None:
 
     session_db, session_id = open_session(session_id)
     history = load_agent_history(session_db, session_id)
+
+    # Deliver any finished background work (subagent results, watched-process
+    # notifications) owed to this session by prepending it to the turn's
+    # message, the turn-based equivalent of the CLI's pre-prompt drain.
+    notifications = _drain_async_completions(session_id)
+    if notifications:
+        message = "\n\n".join([*notifications, message])
     system_message = request.get("systemMessage")
     if not isinstance(system_message, str):
         system_message = None

--- a/test/delegation-delivery.integration.test.ts
+++ b/test/delegation-delivery.integration.test.ts
@@ -1,0 +1,79 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+// A background delegate_task child must hand its result back to the parent
+// session: the worker drains Hermes' completion queue at the start of the next
+// turn (see _drain_async_completions in hermes_worker.py). Before that drain
+// existed, completions parked at delivery_state='pending' forever and the
+// parent never heard from its children.
+
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test('a background delegate_task result is delivered on the next turn', { timeout: 600_000 }, async () => {
+  const outFile = join(process.env.AGENT37_GATEWAY_HOME!, `delegated-child-${Date.now()}.txt`);
+
+  // Turn 1: dispatch a child that invents a secret the parent's own transcript
+  // cannot contain, so quoting it later proves the child's report was
+  // actually delivered (not reconstructed from the parent's history).
+  const first = await postJson(base, {
+    input:
+      'Call the delegate_task tool exactly once, right now, with this goal: ' +
+      '"Invent a random 8-character lowercase code. Write ONLY that code to ' +
+      `${outFile} using the write tool, and end your reply with: the code is <code>". ` +
+      'After dispatching, end your turn immediately with only the word DISPATCHED. ' +
+      'Do not wait for the subagent, do not poll, do not read files.',
+    reasoning_effort: 'low',
+  });
+  const created = (await first.json()) as { session_id: string; status: string; output_text: string };
+  assert.equal(first.status, 200, JSON.stringify(created));
+  assert.equal(created.status, 'completed', JSON.stringify(created));
+
+  // Wait for the detached child to finish (it writes the file last).
+  const deadline = Date.now() + 300_000;
+  while (!existsSync(outFile)) {
+    assert.ok(Date.now() < deadline, `child never wrote ${outFile}`);
+    await sleep(2_000);
+  }
+  const secret = readFileSync(outFile, 'utf8').trim().toLowerCase();
+  assert.ok(secret.length > 0, 'child wrote an empty file');
+  // Let the batch finalize and enqueue its completion after the file write.
+  await sleep(10_000);
+
+  // Turn 2, streamed so tool use is observable: the completion block is
+  // prepended to this turn, so the model can quote the secret without tools.
+  const res = await postJson(base, {
+    session_id: created.session_id,
+    input:
+      'Did your subagent report back to you in this conversation? Answer with ' +
+      'YES or NO first. If YES, also quote the exact code from its report. ' +
+      'Do not use any tools.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(res.status, 200);
+  const events = await new SseReader(res).drain();
+  const completedEvent = events.at(-1);
+  assert.equal(completedEvent?.event, 'response.completed', JSON.stringify(events.at(-1)));
+  const answer = String(completedEvent?.data.output_text ?? '');
+
+  // No tool calls: the secret can only have come from the delivered report.
+  const toolEvents = events.filter((event) => event.event.startsWith('response.tool_call.'));
+  assert.deepEqual(toolEvents, [], 'turn 2 must not need tools to see the child result');
+  assert.match(answer.trim(), /^\W*yes/i, `expected YES, got: ${answer}`);
+  assert.ok(answer.toLowerCase().includes(secret), `answer does not quote the child's code (${secret}): ${answer}`);
+});


### PR DESCRIPTION
## Problem

On gateway sessions, a background `delegate_task` child finishes, records its result, and the parent agent never hears about it. Rows in `async_delegations` sit at `delivery_state='pending'`, `delivery_attempts=0` forever: delivery is never even attempted.

Hermes only delivers background completions through one of its own platform loops. The CLI drains the completion queue before each prompt; the `hermes gateway` daemon self-posts a wake turn. This worker embeds Hermes as a library and runs neither, so nothing ever consumed the queue, while `delegate_task`'s return note kept promising "its full result re-enters the conversation as a new message when it finishes."

## Fix

`_drain_async_completions` in `hermes_worker.py`: at the start of every turn, drain `process_registry.completion_queue` for that session and prepend the completion blocks to the turn's message. This is the CLI's pre-prompt pattern, using the same `claim_event_delivery` / `complete_event_delivery` protocol, so delivery stays exactly-once across worker restarts (restored rows re-enter the queue via `ProcessRegistry.__init__`). Ownership is session-key equality: the batch is stamped with the gateway session id via the worker's existing `set_session_vars` binding.

One sentence added to the platform hint tells the model background results arrive at the start of a later turn, so it ends its turn instead of polling for output files.

Known limit: a child finishing while the parent's turn is still running is delivered on the following turn, not mid-turn.

## Tests

New `test/delegation-delivery.integration.test.ts`: turn 1 dispatches a real child that invents a secret code and writes it to a file; turn 2 (streamed) must answer YES and quote the code with zero `response.tool_call.*` events, proving the child's report was delivered rather than reconstructed.

`npm run typecheck` and `npm test` green: 30 pass, 0 fail, 2 skipped (OpenClaw tests; this change does not touch the OpenClaw adapter).

---

# Async delegation delivery — Prompt Request

**User:**
> A customer bug report says async `delegate_task` completions are never delivered on gateway sessions: children run and store results, but every row stays `pending` with zero delivery attempts and the parent never sees a summary. Verify whether this is real, explain it simply, then fix it, bump the gateway version, and re-pin the downstream image. Decisions made along the way: deliver at the next turn by draining Hermes' completion queue in the vendored worker (the CLI's own pattern), rather than running the Hermes gateway daemon in the container or forcing delegations synchronous; also tell the model in the platform hint that results arrive next turn so it stops polling for files.

**Assistant:**
> Reproduced the bug locally first try (row pending, zero attempts, parent answers "NO, nothing reported back"), then added a pre-turn drain to `hermes_worker.py` using Hermes' claim/complete delivery protocol, plus one platform-hint sentence. Added an integration test that proves delivery via a child-invented secret quoted with no tool calls. Typecheck and the live suite pass.
