### PR TITLE
OpenClaw adapter: speak the WebSocket gateway RPC for everything (v0.6.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ HERMES_AGENT_RUN_LIMIT=10                  # Max concurrent agent runs in the Py
 GATEWAY_MODEL_LIST_CACHE_TTL_SECONDS=60    # Cache TTL for GET /v1/models
 
 # --- OpenClaw (the `agent: "openclaw"` route) ---
-# Enable the responses endpoint in ~/.openclaw/openclaw.json first:
-#   "gateway": { "http": { "endpoints": { "responses": { "enabled": true } } } }
+# The adapter speaks OpenClaw's WebSocket gateway RPC (chat, sessions, models);
+# no OpenClaw config changes are needed.
 OPENCLAW_TOKEN=                            # gateway.auth.token from ~/.openclaw/openclaw.json
-OPENCLAW_BASE_URL=                         # OpenClaw gateway URL (default: http://localhost:18789)
+OPENCLAW_BASE_URL=                         # OpenClaw gateway URL (default: http://localhost:18789; ws:// is derived)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ npm run typecheck && npm test
 
 Both must pass. Never open a PR on a red or un-run suite — fix the code (or the test) first.
 
-The OpenClaw tests in the suite auto-skip when no local OpenClaw gateway is running. If your change touches the OpenClaw adapter or routing, start OpenClaw locally (`openclaw start`, port 18789) so those tests actually run. The adapter also needs two things set up from `~/.openclaw/openclaw.json`: the responses endpoint enabled (`gateway.http.endpoints.responses.enabled: true`) and that file's `gateway.auth.token` copied into `OPENCLAW_TOKEN` in your `.env`. See "Set up OpenClaw" in `README.md` for the exact steps.
+The OpenClaw tests in the suite auto-skip when no local OpenClaw gateway is running. If your change touches the OpenClaw adapter or routing, start OpenClaw locally (`openclaw start`, port 18789) so those tests actually run. The adapter speaks OpenClaw's WebSocket gateway RPC and needs one thing from `~/.openclaw/openclaw.json`: its `gateway.auth.token` copied into `OPENCLAW_TOKEN` in your `.env`. See "Set up OpenClaw" in `README.md`.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -47,49 +47,41 @@ State is split deliberately:
 
 ## How it talks to OpenClaw
 
-The OpenClaw adapter is plain HTTP: it forwards turns to OpenClaw's own gateway
-(`POST /v1/responses`, OpenResponses-compatible) at `OPENCLAW_BASE_URL`
-(defaults to a local OpenClaw, `http://localhost:18789`, when unset),
-authenticated with `OPENCLAW_TOKEN`.
+The OpenClaw adapter speaks OpenClaw's WebSocket gateway RPC — OpenClaw's
+native API, the one its own UI and CLI use — at `OPENCLAW_BASE_URL` (defaults
+to a local OpenClaw, `http://localhost:18789`, when unset; the adapter derives
+`ws://` from it), authenticated with `OPENCLAW_TOKEN`.
 
-Session history reads through OpenClaw's `GET /sessions/{key}/history`, where the
-key is `openresponses-user:{user}` — OpenClaw stores each turn under the `user`
-we send (the gateway session id) and resolves that partial key to the full
-session. `GET /v1/sessions/{id}` projects that transcript. OpenClaw exposes no
-HTTP route to delete a stored transcript, so `DELETE /v1/sessions/{id}` reports
-`deleted: false` and OpenClaw keeps its copy; likewise there is no cancel API, so
-cancel aborts the gateway-side stream only (OpenClaw may keep working
-server-side). It also has no round-trippable session title, so
-`PATCH /v1/sessions/{id}` (rename) answers `405 rename_unsupported` rather than
-keeping a gateway-side name the read paths couldn't surface.
+Turns go through `chat.send` and stream back over OpenClaw's `chat`/`agent`
+events, so the gateway relays text deltas, thinking, and tool activity, and
+cancel is real (`chat.abort` stops the run inside OpenClaw). Each session is
+keyed `openresponses-user:{user}` under OpenClaw's default agent, where `user`
+is the gateway session id. `GET /v1/sessions/{id}` projects the transcript
+(`sessions.get`), the session list is OpenClaw's own (`sessions.list`),
+`DELETE /v1/sessions/{id}` removes the session (`sessions.delete`; OpenClaw
+archives the transcript off its active path), and `PATCH /v1/sessions/{id}`
+(rename) writes the session's label (`sessions.patch`).
+
+`GET /v1/models` lists OpenClaw's configured LLM catalog (`models.list`) as
+`provider/model` ids. A turn that names a `model` applies it to the session
+(`sessions.patch`) — set when chosen, never cleared, so a model picked through
+OpenClaw's own surfaces isn't clobbered by turns that don't choose — and
+`reasoning_effort` maps onto OpenClaw's per-turn thinking level
+(`none|minimal|low|medium|high|xhigh` → `off|minimal|low|medium|high|xhigh`).
 
 ### Set up OpenClaw
 
-Two steps, both reading from your `~/.openclaw/openclaw.json`:
+One step: copy `gateway.auth.token` from `~/.openclaw/openclaw.json` into
+`OPENCLAW_TOKEN` in your `.env`:
 
-1. **Enable the responses endpoint.** Add an `http` block under `gateway` in
-   `~/.openclaw/openclaw.json`, then restart OpenClaw:
-
-   ```jsonc
-   "gateway": {
-     // …your existing config…
-     "http": {
-       "endpoints": {
-         "responses": { "enabled": true }
-       }
-     }
-   }
-   ```
-
-2. **Set the token.** Copy `gateway.auth.token` from that same file into
-   `OPENCLAW_TOKEN` in your `.env`:
-
-   ```bash
-   OPENCLAW_TOKEN=<gateway.auth.token from openclaw.json>
-   ```
+```bash
+OPENCLAW_TOKEN=<gateway.auth.token from openclaw.json>
+```
 
 Then route any turn to it with `"agent": "openclaw"`. If OpenClaw runs somewhere
-other than `http://localhost:18789`, set `OPENCLAW_BASE_URL` too.
+other than `http://localhost:18789`, set `OPENCLAW_BASE_URL` too. No OpenClaw
+config changes are needed — the WebSocket gateway is OpenClaw's always-on
+native surface.
 
 ## Quickstart
 
@@ -197,7 +189,7 @@ running response as `active_response_id`.
 | --- | --- |
 | List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw`; native backend fields pass through) |
 | Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history }` (`?agent=` to pick the harness) |
-| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store. Hermes only (titles are length-capped and must be unique — a clash is `409 title_conflict`); harnesses without an editable title answer `405 rename_unsupported`. |
+| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label). A harness without an editable title answers `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |
 
 `active_response_id` is the id of the `in_progress` response on the session, or

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/adapters/openclaw-adapter.ts
+++ b/server/adapters/openclaw-adapter.ts
@@ -40,7 +40,14 @@ function baseUrl(): string {
 }
 
 function wsUrl(): string {
-  return baseUrl().replace(/^http/, 'ws');
+  const url = new URL(baseUrl().replace(/^http/, 'ws'));
+  const loopback = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+  if (url.protocol === 'ws:' && !loopback) {
+    // Mirrors OpenClaw's own client policy: the shared token never rides
+    // plaintext off the local machine.
+    throw new Error(`OPENCLAW_BASE_URL must be https:// for remote hosts — refusing to send the OpenClaw token in cleartext to ${url.hostname}`);
+  }
+  return url.toString();
 }
 
 function sessionKeyFor(sessionId: string): string {
@@ -182,6 +189,7 @@ export class OpenClawAdapter implements AgentAdapter {
           if (dropped) throw dropped;
           await new Promise<void>((resolve) => {
             wake = resolve;
+            if (dropped) resolve();
           });
           wake = null;
           continue;

--- a/server/adapters/openclaw-adapter.ts
+++ b/server/adapters/openclaw-adapter.ts
@@ -41,7 +41,7 @@ function baseUrl(): string {
 
 function wsUrl(): string {
   const url = new URL(baseUrl().replace(/^http/, 'ws'));
-  const loopback = ['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname);
+  const loopback = ['localhost', '::1', '[::1]'].includes(url.hostname) || url.hostname.startsWith('127.');
   if (url.protocol === 'ws:' && !loopback) {
     // Mirrors OpenClaw's own client policy: the shared token never rides
     // plaintext off the local machine.

--- a/server/adapters/openclaw-adapter.ts
+++ b/server/adapters/openclaw-adapter.ts
@@ -1,89 +1,55 @@
+import { randomUUID } from 'node:crypto';
 import type {
   AgentDefaults,
   AgentModelsResponse,
+  AgentModelOption,
   HermesMessage,
   SessionMetadata,
+  TurnUsage,
 } from '../../shared/types.js';
 import type { AgentAdapter, AgentRunOptions, StreamEvent } from './types.js';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { OpenClawSocket, type OpenClawEvent } from './openclaw-ws.js';
 
-const execFileAsync = promisify(execFile);
-
-// OpenClaw's gateway serves an OpenResponses-compatible `POST /v1/responses`
-// (must be enabled via `gateway.http.endpoints.responses.enabled` in
-// openclaw.json) plus `GET /v1/models` and `/health`. Session history reads
-// through `GET /sessions/{key}/history`, where the key is
-// `openresponses-user:{user}` — OpenClaw stores each turn we send under the
-// `user` we pass and resolves that partial key to the full session. There is
-// no HTTP route to list sessions or delete a transcript, nor to cancel a turn;
-// `listSessions` therefore shells out to the `openclaw` CLI.
+// The adapter speaks OpenClaw's WebSocket gateway RPC for everything: chat
+// (`chat.send` + the broadcast `chat`/`agent` event streams), session
+// management (`sessions.list/get/patch/delete`), and the model catalog
+// (`models.list`). OpenClaw's HTTP surface is not used — it exposes none of
+// the management API, cannot cancel a turn, and its `/v1/models` lists agent
+// targets rather than LLMs.
 export const DEFAULT_BASE_URL = 'http://localhost:18789';
 
-// OpenClaw keys each gateway session as `openresponses-user:{gateway session id}`.
-// We build that key when reading history and strip it back off when listing.
+// OpenClaw keys each gateway session as `openresponses-user:{gateway session
+// id}` under its default agent (canonically `agent:main:openresponses-user:…`).
+// The WS session RPCs resolve the partial key exactly like the HTTP routes
+// did, so we keep addressing sessions by the short form.
 const SESSION_KEY_PREFIX = 'openresponses-user:';
+
+// Our reasoning efforts map 1:1 onto OpenClaw thinking levels ('none' → 'off');
+// OpenClaw additionally knows max/ultra/adaptive, which we never send.
+const THINKING_MAP: Record<string, string> = {
+  none: 'off',
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+};
 
 function baseUrl(): string {
   return process.env.OPENCLAW_BASE_URL?.trim().replace(/\/$/, '') || DEFAULT_BASE_URL;
 }
 
-function authHeaders(): Record<string, string> {
-  const token = process.env.OPENCLAW_TOKEN?.trim();
-  return token ? { Authorization: `Bearer ${token}` } : {};
+function wsUrl(): string {
+  return baseUrl().replace(/^http/, 'ws');
 }
 
-// OpenClaw serves its web UI as a catch-all, so an unknown route (e.g. an older
-// OpenClaw without the /sessions/{key}/history route) answers 200 text/html
-// rather than 404. Treat any non-JSON body as "endpoint absent" so we degrade
-// to empty history instead of choking on `<!doctype …>` in res.json().
-function isJson(res: Response): boolean {
-  return res.headers.get('content-type')?.includes('application/json') ?? false;
+function sessionKeyFor(sessionId: string): string {
+  return `${SESSION_KEY_PREFIX}${sessionId}`;
 }
 
-async function* parseSSE(body: ReadableStream<Uint8Array>): AsyncGenerator<{ event: string; data: string }> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buf = '';
-  let currentEvent = '';
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buf += decoder.decode(value, { stream: true });
-      const lines = buf.split('\n');
-      buf = lines.pop() ?? '';
-
-      for (const raw of lines) {
-        const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
-        if (line.startsWith('event:')) {
-          currentEvent = line.slice(6).trim();
-        } else if (line.startsWith('data:') && currentEvent) {
-          yield { event: currentEvent, data: line.slice(5).trim() };
-          currentEvent = '';
-        } else if (line === '') {
-          currentEvent = '';
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
-
-interface OpenResponsesEnvelope {
-  response?: {
-    usage?: { input_tokens?: number; output_tokens?: number };
-    error?: { code?: string; message?: string };
-  };
-  delta?: string;
-}
-
-// `GET /sessions/{key}/history` message shape. `content` is polymorphic: a bare
-// string, or an array of typed blocks (text / thinking / toolCall). Assistant
-// turns also carry per-turn `usage` and the resolved `model`.
+// Transcript message shape (sessions.get / chat.history). `content` is
+// polymorphic: a bare string, or an array of typed blocks (text / thinking /
+// toolCall). Assistant turns carry per-turn `usage` and the resolved `model`.
 type OpenClawBlock = { type: string; text?: string; thinking?: string };
 interface OpenClawMessage {
   role: 'user' | 'assistant' | 'toolResult' | 'system';
@@ -102,18 +68,52 @@ function blockText(content: string | OpenClawBlock[], kind: 'text' | 'thinking')
     .join('');
 }
 
-// The gateway accepts none..xhigh; OpenClaw only low|medium|high. 'none' is intentionally
-// left unmapped (undefined) so no reasoning param is sent.
-const EFFORT_MAP: Record<string, 'low' | 'medium' | 'high'> = {
-  minimal: 'low',
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
-  xhigh: 'high',
-};
+// `chat` event payloads (state union) and `agent` event payloads, trimmed to
+// the fields we consume.
+interface ChatEventPayload {
+  runId?: string;
+  state?: 'delta' | 'final' | 'aborted' | 'error';
+  deltaText?: string;
+  replace?: boolean;
+  message?: OpenClawMessage;
+  usage?: { input?: number; output?: number };
+  errorMessage?: string;
+  errorKind?: string;
+}
+
+interface AgentEventPayload {
+  runId?: string;
+  stream?: string;
+  data?: { text?: string; delta?: string; name?: string; phase?: string };
+}
+
+interface ModelChoice {
+  id: string;
+  name: string;
+  provider: string;
+  alias?: string;
+  available?: boolean;
+}
+
+function usageFrom(message: OpenClawMessage | undefined, fallback?: { input?: number; output?: number }): TurnUsage | null {
+  const usage = message?.usage ?? fallback;
+  if (!usage) return null;
+  return {
+    input_tokens: usage.input ?? 0,
+    output_tokens: usage.output ?? 0,
+    cost_usd: (usage as OpenClawMessage['usage'])?.cost?.total ?? null,
+  };
+}
+
+// The model catalog values round-trip as `provider/model` (what sessions.patch
+// expects); some catalog ids already carry the provider prefix.
+function modelRef(provider: string, id: string): string {
+  return id.toLowerCase().startsWith(`${provider.toLowerCase()}/`) ? id : `${provider}/${id}`;
+}
 
 export class OpenClawAdapter implements AgentAdapter {
-  private activeRuns = new Map<string, AbortController>();
+  private readonly socket = new OpenClawSocket(wsUrl, () => process.env.OPENCLAW_TOKEN?.trim() || undefined);
+  private readonly activeRuns = new Map<string, string>();
 
   async *chatStream(
     sessionId: string,
@@ -121,137 +121,196 @@ export class OpenClawAdapter implements AgentAdapter {
     options?: AgentRunOptions,
   ): AsyncIterable<StreamEvent> {
     const { settings } = options ?? {};
-    const effort = settings?.reasoningEffort ? EFFORT_MAP[settings.reasoningEffort] : undefined;
+    const sessionKey = sessionKeyFor(sessionId);
+    const runId = randomUUID();
 
-    const controller = new AbortController();
-    this.activeRuns.set(sessionId, controller);
+    // A model pick has no per-turn channel in OpenClaw, so it is applied as
+    // session state — deliberately only when the turn names one, never cleared
+    // here, so a model set through OpenClaw's own surfaces (channels, its UI)
+    // is not clobbered by turns that don't choose.
+    if (settings?.model) {
+      await this.patchSession({ key: sessionKey, model: settings.model });
+    }
 
+    // Reasoning IS per-turn: chat.send's `thinking` overrides the session
+    // level for this run only.
+    const thinking = settings?.reasoningEffort ? THINKING_MAP[settings.reasoningEffort] : undefined;
+
+    // Buffer events from subscription time so nothing lands between the
+    // chat.send ack and the first read.
+    const queue: OpenClawEvent[] = [];
+    let wake: (() => void) | null = null;
+    let dropped: Error | null = null;
+    const unsubscribeEvents = this.socket.onEvent((event) => {
+      if (event.event !== 'chat' && event.event !== 'agent') return;
+      if ((event.payload as ChatEventPayload).runId !== runId) return;
+      queue.push(event);
+      wake?.();
+    });
+    const unsubscribeClose = this.socket.onClose(() => {
+      dropped = new Error('OpenClaw gateway connection dropped mid-turn');
+      (dropped as NodeJS.ErrnoException).code = 'ECONNRESET';
+      wake?.();
+    });
+
+    this.activeRuns.set(sessionId, runId);
     try {
-      // The request schema is strict: unknown fields are rejected, `model` is
-      // required, and `user` is what keys the conversation to a session.
-      const res = await fetch(`${baseUrl()}/v1/responses`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream', ...authHeaders() },
-        signal: controller.signal,
-        body: JSON.stringify({
-          // OpenClaw rejects requests without `model`. When the turn doesn't
-          // set one, bare "openclaw" routes to its default agent; the
-          // session's model stays null gateway-side.
-          model: settings?.model || 'openclaw',
-          input: message,
-          user: sessionId,
-          stream: true,
-          reasoning: effort ? { effort } : undefined,
-        }),
+      const ack = await this.socket.request<{ status?: string }>('chat.send', {
+        sessionKey,
+        message,
+        idempotencyKey: runId,
+        ...(thinking ? { thinking } : {}),
       });
-
-      if (!res.ok) {
-        const body = await res.text().catch(() => '');
-        throw new Error(`OpenClaw POST /v1/responses → ${res.status}: ${body}`);
-      }
-
-      if (!res.body) throw new Error('OpenClaw response has no body');
-
-      for await (const { event, data } of parseSSE(res.body)) {
-        let payload: OpenResponsesEnvelope;
-        try {
-          payload = JSON.parse(data) as OpenResponsesEnvelope;
-        } catch {
-          continue;
-        }
-
-        switch (event) {
-          case 'response.output_text.delta':
-            yield { type: 'text_delta', content: payload.delta ?? '' };
-            break;
-          case 'response.completed': {
-            const usage = payload.response?.usage;
-            yield {
-              type: 'done',
-              sessionId,
-              usage: usage
-                ? {
-                    input_tokens: usage.input_tokens ?? 0,
-                    output_tokens: usage.output_tokens ?? 0,
-                    cost_usd: null,
-                  }
-                : null,
-              interrupted: false,
-            };
-            break;
-          }
-          case 'response.failed': {
-            const err = payload.response?.error;
-            yield {
-              type: 'error',
-              error: err?.message ?? 'OpenClaw error',
-              code: err?.code,
-            };
-            break;
-          }
-        }
-      }
-    } catch (error) {
-      // OpenClaw has no cancel API; an interrupt aborts our stream and the
-      // turn ends as cancelled. OpenClaw may keep working server-side.
-      if (controller.signal.aborted) {
+      // OpenClaw can ack ok WITHOUT starting a run — its plain-text stop
+      // commands ("stop", "exit", …) and restart/admission races — and then
+      // no event ever carries this runId. Anything but a fresh start is
+      // terminal here, or the stream would wait forever and wedge the
+      // session behind session_busy.
+      if (ack.status !== 'started') {
         yield { type: 'done', sessionId, usage: null, interrupted: true };
         return;
       }
-      throw error;
+
+      // Text and thinking arrive both as increments and as cumulative
+      // refreshes (`replace` deltas / cumulative agent text); emitted-length
+      // counters keep the output append-only either way.
+      let sentText = 0;
+      let sentThinking = 0;
+
+      while (true) {
+        if (queue.length === 0) {
+          if (dropped) throw dropped;
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+          });
+          wake = null;
+          continue;
+        }
+        const { event, payload } = queue.shift()!;
+
+        if (event === 'agent') {
+          const agent = payload as AgentEventPayload;
+          if (agent.stream === 'thinking') {
+            const cumulative = agent.data?.text;
+            let delta = agent.data?.delta ?? '';
+            if (!delta && typeof cumulative === 'string' && cumulative.length > sentThinking) {
+              delta = cumulative.slice(sentThinking);
+            }
+            if (delta) {
+              sentThinking += delta.length;
+              yield { type: 'thinking_delta', content: delta };
+            }
+          } else if (agent.stream === 'tool' && agent.data?.name) {
+            const phase = agent.data.phase;
+            if (phase === 'start' || phase === 'result') {
+              yield {
+                type: 'tool_progress',
+                tool: agent.data.name,
+                status: phase === 'start' ? 'running' : 'completed',
+              };
+            }
+          }
+          continue;
+        }
+
+        const chat = payload as ChatEventPayload;
+        switch (chat.state) {
+          case 'delta': {
+            if (chat.replace) {
+              const full = blockText(chat.message?.content ?? chat.deltaText ?? '', 'text');
+              if (full.length > sentText) {
+                yield { type: 'text_delta', content: full.slice(sentText) };
+                sentText = full.length;
+              }
+            } else if (chat.deltaText) {
+              sentText += chat.deltaText.length;
+              yield { type: 'text_delta', content: chat.deltaText };
+            }
+            break;
+          }
+          case 'final': {
+            const full = chat.message ? blockText(chat.message.content, 'text') : '';
+            if (full.length > sentText) {
+              yield { type: 'text_delta', content: full.slice(sentText) };
+            }
+            // The live final event usually omits usage; the transcript's last
+            // assistant message carries the authoritative numbers.
+            let usage = usageFrom(chat.message, chat.usage);
+            if (!usage) usage = await this.lastAssistantUsage(sessionId);
+            yield { type: 'done', sessionId, usage, interrupted: false };
+            return;
+          }
+          case 'aborted':
+            yield { type: 'done', sessionId, usage: usageFrom(chat.message, chat.usage), interrupted: true };
+            return;
+          case 'error':
+            yield {
+              type: 'error',
+              error: chat.errorMessage ?? 'OpenClaw error',
+              code: chat.errorKind,
+            };
+            return;
+        }
+      }
     } finally {
+      unsubscribeEvents();
+      unsubscribeClose();
       this.activeRuns.delete(sessionId);
     }
   }
 
   async interruptChat(sessionId: string): Promise<boolean> {
-    const controller = this.activeRuns.get(sessionId);
-    if (!controller) return false;
-    controller.abort();
-    return true;
+    const runId = this.activeRuns.get(sessionId);
+    if (!runId) return false;
+    // The run then terminates through its own `state:'aborted'` chat event,
+    // which ends the stream above.
+    const result = await this.socket.request<{ aborted?: boolean }>('chat.abort', {
+      sessionKey: sessionKeyFor(sessionId),
+      runId,
+    });
+    return result.aborted === true;
   }
 
   async healthCheck(): Promise<boolean> {
     try {
-      const res = await fetch(`${baseUrl()}/health`);
-      return res.ok;
+      await this.socket.ensureConnected();
+      return true;
     } catch {
       return false;
     }
   }
 
-  // Raw transcript for a session, read through OpenClaw's history endpoint. The
-  // `user` we send on each turn keys the session as `openresponses-user:{user}`,
-  // which OpenClaw resolves from this partial key.
-  private async fetchHistory(sessionId: string): Promise<OpenClawMessage[]> {
-    const key = `${SESSION_KEY_PREFIX}${sessionId}`;
-    const res = await fetch(
-      `${baseUrl()}/sessions/${encodeURIComponent(key)}/history?limit=500`,
-      { headers: authHeaders() },
-    );
-    if (res.status === 404 || !isJson(res)) return []; // unknown session / no history API
-    if (!res.ok) throw new Error(`OpenClaw GET /sessions/{key}/history → ${res.status}`);
-    const { messages } = await res.json() as { messages?: OpenClawMessage[] };
-    return messages ?? [];
-  }
-
   async listSessions(): Promise<Record<string, unknown>[]> {
-    // OpenClaw's session list (`sessions.list`) is a gateway RPC, never exposed on
-    // the HTTP surface (only `/sessions/{key}/history` is). The supported machine
-    // path is the `openclaw` CLI, which reads the on-disk session store directly.
-    // We keep the sessions the gateway created — keyed `openresponses-user:{user}`
-    // under the default agent — and surface that `{user}` as `id`, so each entry
-    // round-trips to `GET /v1/sessions/:id` (which reads `openresponses-user:{id}`).
-    const { stdout } = await execFileAsync(
-      'openclaw',
-      ['sessions', 'list', '--json', '--limit', 'all'],
-      { maxBuffer: 16 * 1024 * 1024 },
-    );
-    const { sessions } = JSON.parse(stdout) as { sessions?: Record<string, unknown>[] };
-    return (sessions ?? [])
+    const result = await this.socket.request<{ sessions?: Record<string, unknown>[] }>('sessions.list', {
+      limit: 1000,
+    });
+    // Keep the sessions this gateway created and surface the `{user}` part as
+    // `id`, so each entry round-trips to `GET /v1/sessions/:id`.
+    return (result.sessions ?? [])
       .filter((s): s is Record<string, unknown> & { key: string } =>
         typeof s.key === 'string' && s.key.includes(SESSION_KEY_PREFIX))
       .map((s) => ({ ...s, id: s.key.slice(s.key.indexOf(SESSION_KEY_PREFIX) + SESSION_KEY_PREFIX.length) }));
+  }
+
+  private async lastAssistantUsage(sessionId: string): Promise<TurnUsage | null> {
+    try {
+      const result = await this.socket.request<{ messages?: OpenClawMessage[] }>('sessions.get', {
+        key: sessionKeyFor(sessionId),
+        limit: 10,
+      });
+      const last = [...(result.messages ?? [])].reverse().find((m) => m.role === 'assistant' && m.usage);
+      return last ? usageFrom(last) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async fetchHistory(sessionId: string): Promise<OpenClawMessage[]> {
+    const result = await this.socket.request<{ messages?: OpenClawMessage[] }>('sessions.get', {
+      key: sessionKeyFor(sessionId),
+      limit: 500,
+    });
+    return result.messages ?? [];
   }
 
   async getMessages(sessionId: string): Promise<HermesMessage[]> {
@@ -273,8 +332,7 @@ export class OpenClawAdapter implements AgentAdapter {
   async getSessionMetadata(sessionId: string): Promise<SessionMetadata | null> {
     const messages = await this.fetchHistory(sessionId);
     if (messages.length === 0) return null;
-    // OpenClaw has no HTTP session-meta route; aggregate the per-turn usage that
-    // rides on assistant messages instead.
+    // Aggregate the per-turn usage that rides on assistant messages.
     const meta: SessionMetadata = {
       id: sessionId,
       input_tokens: 0,
@@ -298,34 +356,71 @@ export class OpenClawAdapter implements AgentAdapter {
     return meta;
   }
 
-  async deleteSession(): Promise<boolean> {
-    // OpenClaw 2026.6.5 exposes no HTTP route to delete a stored transcript
-    // (only `/sessions/{key}/kill`, which aborts an active run). The gateway
-    // keeps no records of its own, so a delete is a no-op here.
-    return false;
+  async deleteSession(sessionId: string): Promise<boolean> {
+    // Removes the session entry and archives its transcript off the active
+    // path. An unknown key reports deleted:false rather than an error.
+    const result = await this.socket.request<{ deleted?: boolean }>('sessions.delete', {
+      key: sessionKeyFor(sessionId),
+      deleteTranscript: true,
+    });
+    return result.deleted === true;
+  }
+
+  async renameSession(sessionId: string, title: string): Promise<boolean> {
+    try {
+      await this.patchSession({ key: sessionKeyFor(sessionId), label: title });
+    } catch (error) {
+      // OpenClaw session labels are unique; surface a clash as the documented
+      // 409, matching the Hermes title semantics.
+      if (error instanceof Error && error.message.includes('label already in use')) {
+        (error as NodeJS.ErrnoException).code = 'title_conflict';
+      }
+      throw error;
+    }
+    return true;
+  }
+
+  // sessions.patch compare-and-sets against the session entry, and a patch
+  // landing right after a turn can lose to the run's own bookkeeping write.
+  // OpenClaw's conflict error literally instructs "Retry." — one retry is the
+  // protocol, not defensiveness.
+  private async patchSession(params: Record<string, unknown>): Promise<void> {
+    try {
+      await this.socket.request('sessions.patch', params);
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('changed before')) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await this.socket.request('sessions.patch', params);
+    }
   }
 
   async getModels(): Promise<AgentModelsResponse> {
-    const res = await fetch(`${baseUrl()}/v1/models`, { headers: authHeaders() });
-    if (!res.ok) throw new Error(`OpenClaw GET /v1/models → ${res.status}`);
-    const data = await res.json() as { data: { id: string }[] };
+    const result = await this.socket.request<{ models?: ModelChoice[] }>('models.list', { view: 'configured' });
+    const byProvider = new Map<string, AgentModelOption[]>();
+    for (const model of result.models ?? []) {
+      if (model.available === false) continue;
+      const options = byProvider.get(model.provider) ?? [];
+      options.push({
+        id: modelRef(model.provider, model.id),
+        label: model.alias ?? model.name,
+        source: 'catalog',
+        provider: model.provider,
+        isCurrentDefault: false,
+      });
+      byProvider.set(model.provider, options);
+    }
     return {
       defaultModel: null,
       activeProvider: 'openclaw',
-      groups: [{
-        provider: 'openclaw',
-        models: data.data.map((m) => ({
-          id: m.id,
-          label: m.id,
-          source: 'catalog',
-          provider: 'openclaw',
-          isCurrentDefault: false,
-        })),
-      }],
+      groups: [...byProvider.entries()].map(([provider, models]) => ({ provider, models })),
     };
   }
 
   async getDefaults(): Promise<AgentDefaults> {
     return { provider: null, model: null, baseUrl: null, apiMode: null, reasoningEffort: null, showReasoning: false };
+  }
+
+  async stop(): Promise<void> {
+    this.socket.close();
   }
 }

--- a/server/adapters/openclaw-ws.ts
+++ b/server/adapters/openclaw-ws.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from 'node:crypto';
+
+// OpenClaw's real API is its WebSocket gateway RPC: session management
+// (list/get/patch/delete), the LLM model catalog, and chat itself live there;
+// the HTTP surface exposes almost none of it. Frames are OpenClaw's own
+// envelope, not JSON-RPC: requests `{type:'req', id, method, params}`,
+// responses `{type:'res', id, ok, payload, error}`, server pushes
+// `{type:'event', event, payload, seq}`. The first request on a connection
+// must be `connect` (protocol 4), authenticated with the shared token
+// (config `gateway.auth.token`, passed as OPENCLAW_TOKEN).
+//
+// Two client identities, because OpenClaw's deviceless trust paths differ by
+// auth mode: under `gateway.auth.mode: 'token'` (local dev) only a loopback
+// CLI client (`client.id/mode = 'cli'`) keeps its requested operator scopes;
+// under `mode: 'none'` (how platform instances run) a CLI identity is
+// refused outright (NOT_PAIRED) and the accepted deviceless identity is the
+// local backend (`gateway-client`/`backend`). We try CLI first and fall back.
+
+const CONNECT_PROTOCOL = 4;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+// The scopes our RPCs need: read (list/get/models), write (chat.send/abort,
+// label patches), admin (model/thinking patches, sessions.delete).
+const SCOPES = ['operator.admin', 'operator.read', 'operator.write'];
+
+const CLIENT_IDENTITIES = [
+  { id: 'cli', mode: 'cli' },
+  { id: 'gateway-client', mode: 'backend' },
+];
+
+export interface OpenClawEvent {
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+interface WireFrame {
+  type?: string;
+  id?: string;
+  ok?: boolean;
+  payload?: unknown;
+  error?: { code?: string; message?: string };
+  event?: string;
+}
+
+interface Pending {
+  method: string;
+  resolve: (payload: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/** An RPC the OpenClaw gateway answered with `ok: false`. The backend was
+ *  reachable — never mapped to `agent_unavailable`. */
+export class OpenClawRpcError extends Error {
+  constructor(method: string, public readonly rpcCode: string | undefined, message: string | undefined) {
+    super(`OpenClaw ${method} → ${rpcCode ?? 'error'}: ${message ?? 'unknown error'}`);
+  }
+}
+
+function unreachable(message: string, cause?: unknown): Error {
+  // errors.ts maps syscall codes to the uniform `agent_unavailable` body; a
+  // socket that won't open or dies mid-call is exactly that condition.
+  const error = new Error(message, cause !== undefined ? { cause } : undefined);
+  (error as NodeJS.ErrnoException).code = 'ECONNREFUSED';
+  return error;
+}
+
+function parseFrame(raw: string): WireFrame | null {
+  try {
+    return JSON.parse(raw) as WireFrame;
+  } catch {
+    return null;
+  }
+}
+
+export class OpenClawSocket {
+  private socket: WebSocket | null = null;
+  private connecting: Promise<void> | null = null;
+  private readonly pending = new Map<string, Pending>();
+  private readonly eventListeners = new Set<(event: OpenClawEvent) => void>();
+  private readonly closeListeners = new Set<() => void>();
+
+  constructor(private readonly wsUrl: () => string, private readonly token: () => string | undefined) {}
+
+  /** One RPC round-trip, dialing (or re-dialing) the connection when needed. */
+  async request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    await this.ensureConnected();
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      throw unreachable('OpenClaw gateway connection is down');
+    }
+    const id = randomUUID();
+    const payload = await new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        const timeout = new Error(`OpenClaw ${method} timed out`);
+        (timeout as NodeJS.ErrnoException).code = 'ETIMEDOUT';
+        reject(timeout);
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { method, resolve, reject, timer });
+      socket.send(JSON.stringify({ type: 'req', id, method, params }));
+    });
+    return payload as T;
+  }
+
+  /** Subscribe to server-push events (chat/agent streams). Returns unsubscribe. */
+  onEvent(listener: (event: OpenClawEvent) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => this.eventListeners.delete(listener);
+  }
+
+  /** Fires when the live connection drops, so in-flight chat streams can fail
+   *  fast instead of waiting for events that will never arrive. */
+  onClose(listener: () => void): () => void {
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
+  }
+
+  async ensureConnected(): Promise<void> {
+    while (this.connecting) await this.connecting;
+    if (this.socket?.readyState === WebSocket.OPEN) return;
+    this.connecting = this.dial().finally(() => {
+      this.connecting = null;
+    });
+    await this.connecting;
+  }
+
+  close(): void {
+    const socket = this.socket;
+    this.socket = null;
+    socket?.close();
+    this.failPending(unreachable('OpenClaw gateway connection closed'));
+  }
+
+  private async dial(): Promise<void> {
+    let lastError: unknown;
+    for (const client of CLIENT_IDENTITIES) {
+      try {
+        this.socket = await this.connectAttempt(client);
+        return;
+      } catch (error) {
+        lastError = error;
+        // Only a handshake refusal is worth retrying under the other
+        // identity; an unreachable backend fails the same way for both.
+        if (!(error instanceof OpenClawRpcError)) throw error;
+      }
+    }
+    throw lastError;
+  }
+
+  /** Open one socket and complete the connect handshake. The socket is not
+   *  published to `this.socket` until the hello lands, so a concurrent
+   *  request() can never slip an RPC in front of `connect` (the server kills
+   *  the whole connection for that), and a stale socket's close event can
+   *  never fail RPCs riding its replacement. */
+  private async connectAttempt(client: { id: string; mode: string }): Promise<WebSocket> {
+    const socket = new WebSocket(this.wsUrl());
+
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener('open', () => resolve(), { once: true });
+      socket.addEventListener(
+        'error',
+        (event) => reject(unreachable('OpenClaw gateway is unreachable', (event as ErrorEvent).error)),
+        { once: true },
+      );
+    });
+
+    socket.addEventListener('message', (event) => this.onMessage(String((event as MessageEvent).data)));
+    socket.addEventListener('close', () => {
+      if (this.socket !== socket) return;
+      this.socket = null;
+      this.failPending(unreachable('OpenClaw gateway connection closed'));
+      for (const listener of this.closeListeners) listener();
+    });
+
+    const helloId = randomUUID();
+    const token = this.token();
+    const hello = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(unreachable('OpenClaw connect handshake timed out')), REQUEST_TIMEOUT_MS);
+      socket.addEventListener('message', (event) => {
+        const frame = parseFrame(String((event as MessageEvent).data));
+        if (frame?.type !== 'res' || frame.id !== helloId) return;
+        clearTimeout(timer);
+        if (frame.ok) resolve();
+        else reject(new OpenClawRpcError('connect', frame.error?.code, frame.error?.message));
+      });
+      socket.addEventListener(
+        'close',
+        () => {
+          clearTimeout(timer);
+          reject(unreachable('OpenClaw gateway closed during handshake'));
+        },
+        { once: true },
+      );
+    });
+
+    socket.send(
+      JSON.stringify({
+        type: 'req',
+        id: helloId,
+        method: 'connect',
+        params: {
+          minProtocol: CONNECT_PROTOCOL,
+          maxProtocol: CONNECT_PROTOCOL,
+          client: { ...client, version: 'agent37-gateway', platform: process.platform },
+          role: 'operator',
+          scopes: SCOPES,
+          ...(token ? { auth: { token } } : {}),
+        },
+      }),
+    );
+
+    try {
+      await hello;
+    } catch (error) {
+      socket.close();
+      throw error;
+    }
+    return socket;
+  }
+
+  private onMessage(raw: string): void {
+    const frame = parseFrame(raw);
+    if (!frame) return;
+
+    if (frame.type === 'res' && typeof frame.id === 'string') {
+      const entry = this.pending.get(frame.id);
+      if (!entry) return;
+      this.pending.delete(frame.id);
+      clearTimeout(entry.timer);
+      if (frame.ok) entry.resolve(frame.payload);
+      else entry.reject(new OpenClawRpcError(entry.method, frame.error?.code, frame.error?.message));
+      return;
+    }
+
+    if (frame.type === 'event' && typeof frame.event === 'string') {
+      const event: OpenClawEvent = {
+        event: frame.event,
+        payload: (frame.payload ?? {}) as Record<string, unknown>,
+      };
+      for (const listener of this.eventListeners) listener(event);
+    }
+  }
+
+  private failPending(error: Error): void {
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import './logging.js';
 import { createServer, type Server } from 'node:http';
 import app from './app.js';
-import { adapter } from './agent.js';
+import { adapter, getAdapter } from './agent.js';
 import { shutdownLiveRuns } from './live-runs.js';
 import { shutdownResponseStore } from './response-store.js';
 import { ensureGatewayStateDirs } from './paths.js';
@@ -91,7 +91,11 @@ async function shutdown(reason: ShutdownReason, exitCode = 0): Promise<void> {
 
   shutdownLiveRuns();
   shutdownResponseStore();
-  const results = await Promise.allSettled([closeHttpServer(), adapter.stop?.() ?? Promise.resolve()]);
+  const results = await Promise.allSettled([
+    closeHttpServer(),
+    adapter.stop?.() ?? Promise.resolve(),
+    getAdapter('openclaw').stop?.() ?? Promise.resolve(),
+  ]);
   for (const result of results) {
     if (result.status === 'rejected') console.error(result.reason);
   }

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -8,7 +8,7 @@ export const sessionsRouter = Router();
 
 // GET /v1/sessions?agent= — list a harness's sessions straight from its own
 // store, native fields untouched. The harness owns the transcript and the index;
-// the gateway keeps none. Harnesses without a list API (OpenClaw) return [].
+// the gateway keeps none. Harnesses without a list API return [].
 sessionsRouter.get('/', async (req, res, next) => {
   let agent: AgentType | undefined;
   try {
@@ -62,7 +62,7 @@ sessionsRouter.delete('/:id', async (req, res, next) => {
 
 // PATCH /v1/sessions/:id?agent= — rename a session by writing its title into the
 // harness's own store (no gateway DB). Only harnesses that natively store an
-// editable title implement it; the rest (OpenClaw) answer 405.
+// editable title implement it; the rest answer 405.
 sessionsRouter.patch('/:id', async (req, res, next) => {
   let agent: AgentType | undefined;
   try {

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -340,7 +340,7 @@ test('openclaw responses complete, stream, and stay on one session', { skip: ope
   assert.equal(recalled.session_id, created.session_id);
   assert.ok(recalled.output_text.includes(marker));
 
-  // History reads back through OpenClaw's GET /sessions/{key}/history. The
+  // History projects OpenClaw's own transcript (WS sessions.get). The
   // session lives on OpenClaw, so the read must name `?agent=openclaw` — the
   // gateway keeps no index to infer it from.
   const session = await jsonOk<{ history: { role: string; content: string }[] }>(
@@ -349,28 +349,44 @@ test('openclaw responses complete, stream, and stay on one session', { skip: ope
   assert.ok(session.history.some((m) => m.role === 'user' && m.content.includes(marker)));
   assert.ok(session.history.some((m) => m.role === 'assistant' && m.content.includes(marker)));
 
-  // OpenClaw has no list API over HTTP, so the adapter shells out to the
-  // `openclaw` CLI and surfaces each `openresponses-user:{user}` session under
-  // the `id` it reads back with — so the created session shows up here.
+  // The list is OpenClaw's own (WS sessions.list); the adapter surfaces each
+  // `openresponses-user:{user}` session under the `id` it reads back with — so
+  // the created session shows up here.
   const list = await jsonOk<{ agent: string; data: Array<{ id: string }> }>(
     await fetch(`${base}/v1/sessions?agent=openclaw`),
   );
   assert.equal(list.agent, 'openclaw');
   assert.ok(list.data.some((s) => s.id === created.session_id));
 
-  // OpenClaw stores no round-trippable session title, so rename is a 405 rather
-  // than a gateway-side name the read paths couldn't surface.
-  const rename = await fetch(`${base}/v1/sessions/${created.session_id}?agent=openclaw`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title: 'nope' }),
-  });
-  assert.equal(rename.status, 405);
-  assert.equal(((await rename.json()) as { error: { code: string } }).error.code, 'rename_unsupported');
+  // Rename writes the session's label into OpenClaw's own store and reads
+  // back on the list. Labels are unique in OpenClaw, so the name carries the
+  // marker to survive leftovers from earlier aborted runs.
+  const title = `integration-rename-${marker}`;
+  const rename = await jsonOk<{ renamed: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=openclaw`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    }),
+  );
+  assert.equal(rename.renamed, true);
+  const renamedList = await jsonOk<{ data: Array<{ id: string; label?: string }> }>(
+    await fetch(`${base}/v1/sessions?agent=openclaw`),
+  );
+  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.label, title);
+
+  // The model catalog lists OpenClaw's real LLM choices, not agent targets.
+  const models = await jsonOk<{ data: Array<{ id: string; owned_by: string }> }>(
+    await fetch(`${base}/v1/models?agent=openclaw`),
+  );
+  assert.ok(models.data.length > 0);
+  assert.ok(models.data.every((m) => m.id !== 'openclaw' && m.owned_by.length > 0));
 
   const stream = await postJson(base, {
     agent: 'openclaw',
-    input: 'Reply with one short sentence.',
+    // A bare meta-instruction can draw OpenClaw's NO_REPLY silence token;
+    // demanding a literal word always streams text.
+    input: 'Reply with exactly this word: PONG',
     stream: true,
   });
   assert.equal(stream.status, 200);
@@ -378,6 +394,17 @@ test('openclaw responses complete, stream, and stay on one session', { skip: ope
   assert.equal(events[0]?.event, 'response.created');
   assert.ok(events.some((event) => event.event === 'response.output_text.delta'));
   assert.equal(events.at(-1)?.event, 'response.completed');
+
+  // Delete removes the session from OpenClaw's store (transcript archived
+  // off the active path) and it disappears from the list.
+  const deleted = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=openclaw`, { method: 'DELETE' }),
+  );
+  assert.equal(deleted.deleted, true);
+  const afterDelete = await jsonOk<{ data: Array<{ id: string }> }>(
+    await fetch(`${base}/v1/sessions?agent=openclaw`),
+  );
+  assert.ok(!afterDelete.data.some((s) => s.id === created.session_id));
 });
 
 test('an in-flight openclaw turn can be cancelled', { skip: openclawSkip }, async () => {

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -19,7 +19,7 @@ export async function startTestServer(): Promise<TestServer> {
   process.env.NODE_ENV = 'test';
 
   const { default: app } = await import('../server/app.js');
-  const { adapter } = await import('../server/agent.js');
+  const { adapter, getAdapter } = await import('../server/agent.js');
   const { shutdownLiveRuns } = await import('../server/live-runs.js');
 
   const server: Server = createServer(app);
@@ -32,6 +32,7 @@ export async function startTestServer(): Promise<TestServer> {
       await new Promise<void>((resolve) => server.close(() => resolve()));
       shutdownLiveRuns();
       await adapter.stop?.();
+      await getAdapter('openclaw').stop?.();
     },
   };
 }


### PR DESCRIPTION
Rewrites the OpenClaw adapter from the HTTP OpenResponses veneer onto OpenClaw's native WebSocket gateway RPC, on one persistent authenticated connection.

**What changes**

- Chat turns go through `chat.send` and stream back over the `chat`/`agent` events: thinking and tool activity now stream, and cancel is real (`chat.abort` stops the run inside OpenClaw).
- `DELETE /v1/sessions/{id}` now deletes (previously a no-op), `PATCH` rename now works (session label; clashes are `409 title_conflict`), and `GET /v1/models` lists OpenClaw's real LLM catalog instead of agent targets.
- A turn's `model` applies to the session only when the turn names one; `reasoning_effort` maps 1:1 onto OpenClaw's per-turn thinking levels.
- The session list drops the `openclaw` CLI shell-out for `sessions.list`; history reads via `sessions.get`.
- Connect tries the loopback CLI identity, then the local backend identity (`gateway.auth.mode 'none'` refuses deviceless CLI clients).
- A `chat.send` acked without a started run (OpenClaw's plain-text stop commands like "stop"/"exit") ends the turn instead of hanging the session.

**Testing**

- `npm run typecheck` clean; `npm test` 32/32 twice against a real local OpenClaw 2026.7.1-2 under `gateway.auth.mode 'none'` (how platform instances run) and passing earlier under `'token'`.
- Live E2E across the whole surface: chat, continuity, streaming (text + reasoning deltas), cancel mid-turn, model switch (including error surfacing for a dead model id), reasoning effort, rename, first-turn model pick, history, delete, usage.

https://claude.ai/code/session_01JcNT3spxsc6SA323qVopQi