### PR TITLE
Session list: one typed row shape across harnesses (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ events, so the gateway relays text deltas, thinking, and tool activity, and
 cancel is real (`chat.abort` stops the run inside OpenClaw). Each session is
 keyed `openresponses-user:{user}` under OpenClaw's default agent, where `user`
 is the gateway session id. `GET /v1/sessions/{id}` projects the transcript
-(`sessions.get`), the session list is OpenClaw's own (`sessions.list`),
+(`sessions.get`), the session list projects OpenClaw's own (`sessions.list`;
+`label`/`updatedAt` become the shared `title`/`last_active`),
 `DELETE /v1/sessions/{id}` removes the session (`sessions.delete`; OpenClaw
 archives the transcript off its active path), and `PATCH /v1/sessions/{id}`
 (rename) writes the session's label (`sessions.patch`).
@@ -187,7 +188,7 @@ running response as `active_response_id`.
 
 | Action | Endpoint |
 | --- | --- |
-| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw`; native backend fields pass through) |
+| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
 | Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history }` (`?agent=` to pick the harness) |
 | Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label). A harness without an editable title answers `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent37-gateway",
-  "version": "0.5.6",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent37-gateway",
-      "version": "0.5.6",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/adapters/hermes-worker.ts
+++ b/server/adapters/hermes-worker.ts
@@ -11,8 +11,10 @@ import type {
   GoalStateSnapshot,
   HermesMessage,
   SessionMetadata,
+  SessionSummary,
 } from '../../shared/types.js';
 import type { AgentAdapter, AgentRunOptions, GoalCapableAdapter, StreamEvent } from './types.js';
+import { epochMillis } from './types.js';
 import type { WorkerEvent, WorkerRequest, WorkerResult, WorkerErrorPayload } from './worker-protocol.js';
 import { expandHomePrefix, resolveHermesHome, resolveWorkspaceDir } from '../paths.js';
 
@@ -489,11 +491,22 @@ export class HermesWorkerAdapter implements AgentAdapter, GoalCapableAdapter {
     }
   }
 
-  async listSessions(): Promise<Record<string, unknown>[]> {
+  async listSessions(): Promise<SessionSummary[]> {
     const result = await this.client.request<{ sessions: Record<string, unknown>[] }>({
       type: 'sessions.list',
     });
-    return result.sessions;
+    // Hermes' native rows already use the contract's names; project them so
+    // only the shared shape (and no SessionDB extras) leaves the gateway.
+    return result.sessions.flatMap((row) => {
+      if (typeof row.id !== 'string' || !row.id) return [];
+      return [{
+        id: row.id,
+        title: typeof row.title === 'string' && row.title.trim() ? row.title : null,
+        last_active: epochMillis(row.last_active),
+        message_count: typeof row.message_count === 'number' ? row.message_count : null,
+        preview: typeof row.preview === 'string' && row.preview.trim() ? row.preview : null,
+      }];
+    });
   }
 
   async getMessages(sessionId: string): Promise<HermesMessage[]> {

--- a/server/adapters/openclaw-adapter.ts
+++ b/server/adapters/openclaw-adapter.ts
@@ -5,9 +5,11 @@ import type {
   AgentModelOption,
   HermesMessage,
   SessionMetadata,
+  SessionSummary,
   TurnUsage,
 } from '../../shared/types.js';
 import type { AgentAdapter, AgentRunOptions, StreamEvent } from './types.js';
+import { epochMillis } from './types.js';
 import { OpenClawSocket, type OpenClawEvent } from './openclaw-ws.js';
 
 // The adapter speaks OpenClaw's WebSocket gateway RPC for everything: chat
@@ -288,16 +290,24 @@ export class OpenClawAdapter implements AgentAdapter {
     }
   }
 
-  async listSessions(): Promise<Record<string, unknown>[]> {
+  async listSessions(): Promise<SessionSummary[]> {
     const result = await this.socket.request<{ sessions?: Record<string, unknown>[] }>('sessions.list', {
       limit: 1000,
     });
     // Keep the sessions this gateway created and surface the `{user}` part as
-    // `id`, so each entry round-trips to `GET /v1/sessions/:id`.
+    // `id`, so each entry round-trips to `GET /v1/sessions/:id`. OpenClaw's
+    // `label` (what rename writes) and `updatedAt` become the contract's
+    // `title`/`last_active`; it tracks no message count or preview.
     return (result.sessions ?? [])
       .filter((s): s is Record<string, unknown> & { key: string } =>
         typeof s.key === 'string' && s.key.includes(SESSION_KEY_PREFIX))
-      .map((s) => ({ ...s, id: s.key.slice(s.key.indexOf(SESSION_KEY_PREFIX) + SESSION_KEY_PREFIX.length) }));
+      .map((s) => ({
+        id: s.key.slice(s.key.indexOf(SESSION_KEY_PREFIX) + SESSION_KEY_PREFIX.length),
+        title: typeof s.label === 'string' && s.label.trim() ? s.label : null,
+        last_active: epochMillis(s.updatedAt),
+        message_count: null,
+        preview: null,
+      }));
   }
 
   private async lastAssistantUsage(sessionId: string): Promise<TurnUsage | null> {

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -7,10 +7,24 @@ import type {
   GoalStateSnapshot,
   HermesMessage,
   SessionMetadata,
+  SessionSummary,
   TurnUsage,
 } from '../../shared/types.js';
 
 export type { AgentRunSettings, ContextUsage };
+
+/** Coerce a harness's native timestamp (epoch seconds, epoch ms, or a date
+ *  string) to the contract's epoch milliseconds. */
+export function epochMillis(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value < 1e12 ? Math.round(value * 1000) : Math.round(value);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
 
 export interface AgentRunOptions {
   /** Optional system prompt. The gateway is a thin passthrough and normally
@@ -56,9 +70,9 @@ export interface AgentAdapter {
   /** True when the backend is reachable and ready. */
   healthCheck(): Promise<boolean>;
 
-  /** The backend's own session list, native fields passed through untouched.
-   *  Backends without a list API return []. */
-  listSessions(): Promise<Record<string, unknown>[]>;
+  /** The backend's session list, projected into the shared SessionSummary
+   *  shape. Backends without a list API return []. */
+  listSessions(): Promise<SessionSummary[]>;
 
   /** Projected transcript for a session, from the backend's own store. */
   getMessages(sessionId: string): Promise<HermesMessage[]>;

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -6,9 +6,11 @@ import { activeResponseForSession } from '../live-runs.js';
 
 export const sessionsRouter = Router();
 
-// GET /v1/sessions?agent= — list a harness's sessions straight from its own
-// store, native fields untouched. The harness owns the transcript and the index;
-// the gateway keeps none. Harnesses without a list API return [].
+// GET /v1/sessions?agent= — list a harness's sessions from its own store,
+// projected into the shared SessionSummary shape (id, title, last_active,
+// message_count, preview) so clients never branch on the harness. The harness
+// owns the transcript and the index; the gateway keeps none. Harnesses without
+// a list API return [].
 sessionsRouter.get('/', async (req, res, next) => {
   let agent: AgentType | undefined;
   try {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -89,9 +89,19 @@ export interface ResponseObject {
 // Public API: sessions
 // ---------------------------------------------------------------------------
 
-// Listing a harness's sessions (`GET /v1/sessions?agent=`) passes the backend's
-// own session objects through untouched, so there is no gateway-owned session
-// type — each harness (Hermes SessionDB, ...) defines its own fields.
+/** One row of the session list (`GET /v1/sessions?agent=`). Every harness
+ *  projects its native store into this one shape (Hermes rows already use these
+ *  names; OpenClaw's `label`/`updatedAt` become `title`/`last_active`), so
+ *  clients never branch on the harness. Fields a harness doesn't track are null. */
+export interface SessionSummary {
+  id: string;
+  /** The harness's own editable title — what PATCH rename writes. */
+  title: string | null;
+  /** Last activity, epoch milliseconds. */
+  last_active: number | null;
+  message_count: number | null;
+  preview: string | null;
+}
 
 /** A message in a session's history, projected from the session's harness backend (Hermes SessionDB, OpenClaw history, ...). */
 export interface SessionMessage {

--- a/test/gateway.integration.test.ts
+++ b/test/gateway.integration.test.ts
@@ -105,14 +105,16 @@ test('responses and sessions work end-to-end through the local LLM', async () =>
   assertCompleted(created);
   assert.equal(created.metadata?.marker, marker);
 
-  // GET /v1/sessions lists straight from the harness, native fields untouched;
-  // the chosen agent is echoed at the top level. `?agent=` selects the harness
-  // (default hermes); an unknown agent is a 400.
-  const sessions = await jsonOk<{ agent: string; data: Array<{ id: string }> }>(
+  // GET /v1/sessions lists from the harness, projected into the shared
+  // SessionSummary row shape; the chosen agent is echoed at the top level.
+  // `?agent=` selects the harness (default hermes); an unknown agent is a 400.
+  const sessions = await jsonOk<{ agent: string; data: Array<{ id: string; title: string | null; last_active: number | null }> }>(
     await fetch(`${base}/v1/sessions`),
   );
   assert.equal(sessions.agent, 'hermes');
-  assert.ok(sessions.data.some((session) => session.id === created.session_id));
+  const listedRow = sessions.data.find((session) => session.id === created.session_id);
+  assert.ok(listedRow);
+  assert.equal(typeof listedRow.last_active, 'number');
 
   const hermesSessions = await jsonOk<{ agent: string; data: Array<{ id: string }> }>(
     await fetch(`${base}/v1/sessions?agent=hermes`),
@@ -147,8 +149,7 @@ test('responses and sessions work end-to-end through the local LLM', async () =>
   assert.equal(continued.session_id, created.session_id);
 
   // Rename writes the title straight into Hermes' SessionDB; it round-trips
-  // through the native `title` field the session list passes through — no
-  // gateway-side store involved.
+  // through the session list's `title` — no gateway-side store involved.
   const renameTitle = `renamed-${marker}`;
   const renamed = await jsonOk<{ id: string; agent: string; renamed: boolean }>(
     await fetch(`${base}/v1/sessions/${created.session_id}`, {
@@ -370,10 +371,10 @@ test('openclaw responses complete, stream, and stay on one session', { skip: ope
     }),
   );
   assert.equal(rename.renamed, true);
-  const renamedList = await jsonOk<{ data: Array<{ id: string; label?: string }> }>(
+  const renamedList = await jsonOk<{ data: Array<{ id: string; title: string | null }> }>(
     await fetch(`${base}/v1/sessions?agent=openclaw`),
   );
-  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.label, title);
+  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.title, title);
 
   // The model catalog lists OpenClaw's real LLM choices, not agent targets.
   const models = await jsonOk<{ data: Array<{ id: string; owned_by: string }> }>(


### PR DESCRIPTION
`GET /v1/sessions` passed native harness rows through untouched, so clients had to branch on the harness: Hermes rows say `title`/`last_active`, OpenClaw rows say `label`/`updatedAt`. Our dashboard read the Hermes names against OpenClaw rows, so every OpenClaw chat rendered as untitled and renames looked like no-ops.

This types the list as one `SessionSummary` row every adapter projects into:

```
{ id, title, last_active, message_count, preview }
```

- `title` is the harness's own editable title, exactly what `PATCH` rename writes (OpenClaw: `label`; Hermes: `title`).
- `last_active` is epoch milliseconds (`epochMillis` coerces native seconds/ms/date-strings).
- Fields a harness doesn't track are `null` (OpenClaw has no message count or preview).

Hermes native rows already used these names, so instances on older Hermes images keep working with contract-reading clients; only the OpenClaw image needs a roll. The integration test now asserts the typed row on both harnesses (rename readback moved from OpenClaw's `label` to the contract's `title`).

Full suite: **32/32** against a real local Hermes and the pinned OpenClaw 2026.7.1-2.

https://claude.ai/code/session_01JcNT3spxsc6SA323qVopQi