### PR TITLE
Unprovisioned Hermes is agent_unavailable; wallet-empty refusals are quota_exhausted (v0.8.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 | `payload_too_large` | 413 | Request body exceeded the size limit. |
 | `rate_limited` | 429 | The upstream agent/provider was rate-limited. |
 | `agent_error` | 502 | The agent backend failed (auth, model, provider, etc.). |
-| `agent_unavailable` | 503 | The targeted harness backend isn't available on this instance — never provisioned here, or down. |
+| `agent_unavailable` | 503 | The targeted harness backend isn't available on this instance — never provisioned here (including an image with no Hermes install), or down. |
 | `internal_error` | 500 | An unexpected gateway error. |
 
 Agent/worker failures surface their own `code` and `hint` where available (e.g.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent37-gateway",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent37-gateway",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
   "license": "MIT",
   "type": "module",

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -127,7 +127,7 @@ const WORKER_CODE_MAP: Record<string, { status: number; apiCode: string }> = {
   task_busy: { status: 409, apiCode: 'session_busy' },
   title_conflict: { status: 409, apiCode: 'title_conflict' },
   rate_limit: { status: 429, apiCode: 'rate_limited' },
-  hermes_not_found: { status: 503, apiCode: 'hermes_not_found' },
+  hermes_not_found: { status: 503, apiCode: 'agent_unavailable' },
   import_error: { status: 503, apiCode: 'import_error' },
   session_db_unavailable: { status: 503, apiCode: 'session_db_unavailable' },
   session_load_error: { status: 503, apiCode: 'session_load_error' },
@@ -151,12 +151,20 @@ const UNREACHABLE_SYSCALLS = new Set([
   'ECONNREFUSED', 'ENOENT', 'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT',
 ]);
 
+// Worker codes that mean the same thing at the harness layer: the Hermes worker
+// starts fine (it is plain Python) but finds no Hermes install on this instance
+// — e.g. `agent: "hermes"` on an OpenClaw image.
+const UNPROVISIONED_WORKER_CODES = new Set(['hermes_not_found']);
+
 /** True when an error (or its `cause` — Node's fetch nests the system error
- *  there) is a connection-level failure to reach a harness backend. */
+ *  there) says the harness backend isn't on this instance: a connection-level
+ *  failure to reach it, or the worker reporting no install to load. */
 function isBackendUnreachable(error: unknown): boolean {
   for (const e of [error, (error as { cause?: unknown })?.cause]) {
     const code = (e as { code?: unknown })?.code;
-    if (typeof code === 'string' && UNREACHABLE_SYSCALLS.has(code)) return true;
+    if (typeof code === 'string' && (UNREACHABLE_SYSCALLS.has(code) || UNPROVISIONED_WORKER_CODES.has(code))) {
+      return true;
+    }
   }
   return false;
 }

--- a/server/workers/hermes_worker.py
+++ b/server/workers/hermes_worker.py
@@ -197,9 +197,17 @@ def _error_payload(exc: BaseException) -> dict[str, str]:
     elif "unauthorized" in lower or "authentication" in lower or "401" in lower or "api key" in lower:
         code = "auth_error"
         hint = "Run hermes model or update ~/.hermes/config.yaml credentials."
-    elif "instance_budget_exhausted" in lower or "budget exhausted" in lower or "insufficient_balance" in lower:
+    elif (
+        "instance_budget_exhausted" in lower
+        or "budget exhausted" in lower
+        or "insufficient_balance" in lower
+        or "balance exhausted" in lower
+    ):
         # Checked before "rate limit": a budget refusal often reaches us as
         # "Rate limited after N retries — HTTP 402: Instance budget exhausted…".
+        # Hermes summarizes a 402 body to its `message` only (the `type` is
+        # dropped), so the wallet refusal arrives as "HTTP 402: Workspace
+        # balance exhausted. Top up the workspace wallet to continue."
         code = "quota_exhausted"
         hint = "Raise the instance budget or top up the workspace balance."
     elif "rate limit" in lower or "429" in lower:

--- a/test/error-payload.test.ts
+++ b/test/error-payload.test.ts
@@ -1,0 +1,12 @@
+// Regression gate for the Python worker's _error_payload classifier: managed
+// refusals (empty wallet, spent instance budget) must surface as
+// quota_exhausted from their message text alone. Pure unit tests — no live
+// Hermes/LLM needed. The assertions live in test/error_payload_test.py.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+test('hermes worker _error_payload classifies managed refusals as quota_exhausted', () => {
+  const result = spawnSync('python3', ['test/error_payload_test.py'], { encoding: 'utf8' });
+  assert.equal(result.status, 0, `python unit tests failed:\n${result.stdout}\n${result.stderr}`);
+});

--- a/test/error_payload_test.py
+++ b/test/error_payload_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Regression tests for _error_payload: the failure-text classifier that turns a
+provider/agent exception into the worker's {code, message, hint} payload.
+
+Hermes summarizes an HTTP 402 body down to its `message` (the `type` field is
+dropped), so both managed refusals must classify by their message text alone.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "server" / "workers"))
+
+import hermes_worker
+
+
+class ErrorPayloadTest(unittest.TestCase):
+    def test_wallet_empty_refusal_is_quota_exhausted(self):
+        payload = hermes_worker._error_payload(
+            Exception("HTTP 402: Workspace balance exhausted. Top up the workspace wallet to continue.")
+        )
+        self.assertEqual(payload["code"], "quota_exhausted")
+        self.assertIn("workspace balance", payload["hint"])
+
+    def test_instance_budget_refusal_is_quota_exhausted(self):
+        payload = hermes_worker._error_payload(
+            Exception("HTTP 402: Instance budget exhausted. Raise the monthly cap or top up this instance to continue.")
+        )
+        self.assertEqual(payload["code"], "quota_exhausted")
+
+    def test_retry_wrapped_budget_refusal_beats_rate_limit(self):
+        payload = hermes_worker._error_payload(
+            Exception("Rate limited after 3 retries — HTTP 402: Instance budget exhausted.")
+        )
+        self.assertEqual(payload["code"], "quota_exhausted")
+
+    def test_unrelated_failure_stays_generic(self):
+        payload = hermes_worker._error_payload(Exception("upstream connect error"))
+        self.assertEqual(payload["code"], "worker_error")
+        self.assertNotIn("hint", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/hermes-not-found.integration.test.ts
+++ b/test/hermes-not-found.integration.test.ts
@@ -1,0 +1,62 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startTestServer, type TestServer } from './test-helpers.js';
+
+// Run the real worker on a machine with no Hermes install in sight — the
+// shape of `agent: "hermes"` on an OpenClaw image. The worker itself starts
+// (it is plain Python) and reports hermes_not_found; the gateway must present
+// that as agent_unavailable, the same body a refused connection produces.
+// node:test isolates each file in its own process, so the env overrides don't
+// leak into the other suites.
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  // Resolve the venv python before hiding the real home directory.
+  if (!process.env.HERMES_PYTHON && !process.env.HERMES_AGENT_DIR) {
+    process.env.HERMES_PYTHON = join(homedir(), '.hermes/hermes-agent/venv/bin/python');
+  }
+  const emptyHome = mkdtempSync(join(tmpdir(), 'a37gw-no-hermes-'));
+  process.env.HOME = emptyHome;
+  process.env.HERMES_HOME = join(emptyHome, '.hermes');
+  process.env.HERMES_AGENT_DIR = join(emptyHome, 'missing-hermes-agent');
+  process.env.PATH = '/usr/bin:/bin'; // no `hermes` CLI to discover the install from
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+test('a request for a harness with no install here fails with agent_unavailable', async () => {
+  const res = await fetch(`${base}/v1/models?agent=hermes`);
+  assert.equal(res.status, 503);
+  const body = (await res.json()) as { error: { code: string; message: string } };
+  assert.equal(body.error.code, 'agent_unavailable');
+  assert.match(body.error.message, /hermes/);
+  assert.match(body.error.message, /not available on this instance/);
+});
+
+test('a turn for a harness with no install here settles as failed with agent_unavailable', async () => {
+  const res = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'hermes', input: 'hello' }),
+  });
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { status: string; error: { code: string } | null };
+  assert.equal(body.status, 'failed');
+  assert.equal(body.error?.code, 'agent_unavailable');
+});
+
+test('health reports the missing harness as unhealthy, not as an error', async () => {
+  const res = await fetch(`${base}/v1/health?agent=hermes`);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { ok: boolean; agent: string; healthy: boolean };
+  assert.equal(body.ok, true);
+  assert.equal(body.healthy, false);
+});


### PR DESCRIPTION
Two Agent API error codes leaked through as the worker's own instead of the documented ones (found while syncing the docs against v0.6.0 through v0.8.2, docs#125).

**`agent: "hermes"` on an image with no Hermes install** (the OpenClaw image) failed with `hermes_not_found`, while the mirror case for OpenClaw was `agent_unavailable`. `errors.ts` now treats the worker's `hermes_not_found` as "backend not on this instance": `503 agent_unavailable` on the read routes (`/v1/models`, `/v1/sessions`), a failed turn with `error.code` `agent_unavailable` on `/v1/responses`, and the same uniform body a refused connection gets.

**Empty-wallet refusal classified as `provider_error`.** The managed proxy answers 402 `{ type: "insufficient_balance", message: "Workspace balance exhausted. Top up the workspace wallet to continue." }`; Hermes summarizes that to the message alone, which matched none of the worker's quota keywords. `"balance exhausted"` now maps to `quota_exhausted`, same as the instance-budget refusal (whose text says "budget exhausted").

**Tests**
- `test/hermes-not-found.integration.test.ts`: the real worker with no Hermes install in reach (empty `HOME`/`HERMES_HOME`, bogus `HERMES_AGENT_DIR`, no `hermes` on `PATH`) → `503 agent_unavailable` on models, failed turn with `agent_unavailable`, `healthy: false` on health.
- `test/error_payload_test.py` (via `error-payload.test.ts`): pins `_error_payload` for the wallet text, the budget text, the retry-wrapped budget text, and an unrelated failure.
- `npm run typecheck` clean. `npm test`: every Hermes-side test green; the two OpenClaw tests are skipped in this run because the local OpenClaw here is 2026.6.6 and refuses the adapter's `operator.write` scope on `chat.abort` (identical failures on unmodified `main`, so environmental; the adapter is untouched by this change).

Docs follow-up lands once the images carry v0.8.3.

https://claude.ai/code/session_01FmjYE5nG8UZovdYPBUa8wz
