### PR TITLE
Claude Code adapter: a third harness behind the same seam (v0.9.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # --- Gateway HTTP server ---
 PORT=3737                 # Port to listen on
 HOST=0.0.0.0              # Interface to bind (0.0.0.0 so the host/Docker can reach it)
-GATEWAY_DEFAULT_AGENT=    # Agent a turn routes to when the request omits `agent` (hermes|openclaw; default hermes)
+GATEWAY_DEFAULT_AGENT=    # Agent a turn routes to when the request omits `agent` (hermes|openclaw|claude-code; default hermes)
 
 # --- Gateway state ---
 AGENT37_GATEWAY_HOME=~/.agent37-gateway   # Root for the SQLite db, logs, and the agent workspace
@@ -22,3 +22,9 @@ GATEWAY_MODEL_LIST_CACHE_TTL_SECONDS=60    # Cache TTL for GET /v1/models
 # no OpenClaw config changes are needed.
 OPENCLAW_TOKEN=                            # gateway.auth.token from ~/.openclaw/openclaw.json
 OPENCLAW_BASE_URL=                         # OpenClaw gateway URL (default: http://localhost:18789; ws:// is derived)
+
+# --- Claude Code (the `agent: "claude-code"` route) ---
+# The adapter runs the Claude Code CLI through the Claude Agent SDK, on Claude
+# Code's own login (`claude auth login`, or ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN
+# in this environment). No gateway-side credentials.
+CLAUDE_CODE_BIN=                           # Path to the `claude` binary (default: the one on PATH)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ Guidance for AI coding agents working in this repo. `CLAUDE.md` imports this fil
 
 ## What this is
 
-The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam — Hermes (via a Python worker) and OpenClaw today, Claude Code next. A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
+The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), and Claude Code (the Claude Agent SDK). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
 
 Orientation (Node >= 24, TypeScript ESM):
 
 - `server/routes/` — the `/v1` surface (responses, sessions, models, files)
-- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes and OpenClaw adapters, and the JSONL worker protocol (`worker-protocol.ts`)
+- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, and Claude Code adapters, and the JSONL worker protocol (`worker-protocol.ts`)
 - `server/workers/hermes_worker.py` — the Python side; imports Hermes directly. `npm run selftest:worker` checks it can reach Hermes without booting the server
 - `server/live-runs.ts` + `server/response-store.ts` — in-memory replayable event buffers for in-flight responses, and in-memory (TTL/count-bounded, lost on restart) response metadata; session metadata is never stored — session lists and transcripts project from the session's harness backend (Hermes' SessionDB, OpenClaw's history, ...)
 - `shared/types.ts` — the public API types; `test/` — the integration suite; `bruno/` — hand-poke collection (see `bruno/README.md`)
@@ -31,6 +31,8 @@ npm run typecheck && npm test
 Both must pass. Never open a PR on a red or un-run suite — fix the code (or the test) first.
 
 The OpenClaw tests in the suite auto-skip when no local OpenClaw gateway is running. If your change touches the OpenClaw adapter or routing, start OpenClaw locally (`openclaw start`, port 18789) so those tests actually run. The adapter speaks OpenClaw's WebSocket gateway RPC and needs one thing from `~/.openclaw/openclaw.json`: its `gateway.auth.token` copied into `OPENCLAW_TOKEN` in your `.env`. See "Set up OpenClaw" in `README.md`.
+
+The Claude Code tests likewise auto-skip unless the Claude Code CLI is installed here and logged in (`claude auth login`); they run on that login. If your change touches the Claude Code adapter, make sure they actually run.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ work back, and keeps the conversation going. The streaming contract and request
 shape are the same whatever agent is behind it — so client code doesn't change
 when the agent does.
 
-Today it routes to **Hermes** (the default) and **OpenClaw** — pick per request
-with the `agent` field. The adapter seam is built so **Claude Code** slots in
-next.
+Today it routes to **Hermes** (the default), **OpenClaw**, and **Claude Code**:
+pick per request with the `agent` field.
 
 > Want the hosted API? Use [Agent37 Cloud](https://www.agent37.com/cloud). This
 > repo is the gateway service that powers an Agent37 agent.
@@ -84,6 +83,50 @@ other than `http://localhost:18789`, set `OPENCLAW_BASE_URL` too. No OpenClaw
 config changes are needed — the WebSocket gateway is OpenClaw's always-on
 native surface.
 
+## How it talks to Claude Code
+
+The Claude Code adapter drives the Claude Code CLI through the
+[Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk):
+one `query()` (one `claude` process) per turn, resumed by session id, in
+`bypassPermissions` mode so tools run unprompted (the instance is the customer's
+own box, as with the other harnesses). Text and thinking deltas, tool calls and
+tool results stream back as the same SSE events, and cancel is real
+(`interrupt()` stops the run inside Claude Code).
+
+Transcripts live where Claude Code keeps them (`~/.claude/projects/<cwd>/<id>.jsonl`,
+keyed by the gateway's workspace directory) and the gateway keeps no index:
+`GET /v1/sessions?agent=claude-code` lists that store (Claude Code's own title,
+custom or auto-generated, as `title`; the first prompt as `preview`),
+`GET /v1/sessions/{id}` projects the transcript, `PATCH /v1/sessions/{id}`
+(rename) writes Claude Code's custom title (its `/rename`), and
+`DELETE /v1/sessions/{id}` removes the transcript. A gateway session id is the
+Claude Code session UUID with the dashes removed, so a session started from a
+terminal in the workspace directory shows up in the list too.
+
+The gateway passes no credential: Claude Code runs on its own login. Until one
+exists, a turn fails with `auth_error` (and a hint to log in) and
+`GET /v1/health?agent=claude-code` reports `healthy: false`.
+
+`GET /v1/models?agent=claude-code` lists Claude Code's model aliases (`sonnet`,
+`opus`, `fable`, `haiku`, each the latest of its family); a turn's `model` is
+passed through as is, and `reasoning_effort` maps onto Claude Code's effort
+level (`none|minimal|low` → `low`, `medium|high|xhigh` unchanged). `usage`
+(cost included) and `context` come from Claude Code's own per-turn result.
+
+### Set up Claude Code
+
+Install Claude Code on the machine the gateway runs on and log in:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude auth login
+```
+
+Then route any turn to it with `"agent": "claude-code"`. The adapter runs the
+`claude` on `PATH`; set `CLAUDE_CODE_BIN` to pin a specific binary. An
+`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (what `claude setup-token`
+prints) in the gateway's environment works instead of the interactive login.
+
 ## Quickstart
 
 **Prerequisites:**
@@ -134,7 +177,7 @@ behind the host, which handles and forwards authentication.
 | Field | Type | Notes |
 | --- | --- | --- |
 | `input` | string, required | The message or task. |
-| `agent` | string | `hermes` or `openclaw`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
+| `agent` | string | `hermes`, `openclaw`, or `claude-code`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
 | `session_id` | string | Continue a conversation. Omit to start a new one. |
 | `files` | string[] | Absolute paths of files to attach (write them first with `PUT /v1/files/content`). Appended to the message as an `[Attached files: …]` block; the agent reads them from disk. |
 | `stream` | boolean | `true` for Server-Sent Events; default `false`. |
@@ -189,9 +232,9 @@ running response as `active_response_id`.
 
 | Action | Endpoint |
 | --- | --- |
-| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
+| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
 | Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history, context }` (`?agent=` to pick the harness; `context` is the session's last reported context window, null until a turn reports one) |
-| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label). A harness without an editable title answers `405 rename_unsupported`. |
+| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title). A harness without an editable title answers `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |
 
 `active_response_id` is the id of the `in_progress` response on the session, or
@@ -275,13 +318,14 @@ and stored paths assume the instance's home directory stays stable.
 
 | Action | Endpoint |
 | --- | --- |
-| Models a harness can run | `GET /v1/models` (configured default; add `?agent=hermes\|openclaw` to target one) |
-| Liveness + harness reachability | `GET /v1/health` (configured default; add `?agent=hermes\|openclaw` to target one) |
+| Models a harness can run | `GET /v1/models` (configured default; add `?agent=hermes\|openclaw\|claude-code` to target one) |
+| Liveness + harness reachability | `GET /v1/health` (configured default; add `?agent=hermes\|openclaw\|claude-code` to target one) |
 | Version | `GET /v1/version` |
 
 `GET /v1/health` reports on the gateway's configured default harness, or the
 one named by an optional `?agent=` query param. It returns `{ ok, agent,
-healthy }`, plus a legacy `hermes` field when Hermes is probed.
+healthy }`, plus a legacy `hermes` field when Hermes is probed. For Claude Code,
+`healthy` also means it is logged in.
 
 `GET /v1/models` returns the OpenAI list shape, so any OpenAI-compatible client
 works. It lists the models of one harness — the configured default, or the one
@@ -352,7 +396,9 @@ npm test          # integration suite against the real local Hermes worker/LLM
 state dir. Response tests call the local Hermes worker and configured LLM; the
 suite also covers replay, `session_busy`, cancel, history, and
 error bodies. The OpenClaw tests run against a local OpenClaw gateway and are
-skipped automatically when none is running.
+skipped automatically when none is running; the Claude Code tests run the
+Claude Code CLI installed on this machine, on its own login, and are skipped
+when it isn't installed or logged in.
 
 ### Poke it by hand (Bruno)
 
@@ -361,7 +407,8 @@ open that folder in Bruno, pick the **local** environment (`baseUrl`
 `http://localhost:3737`), and run the requests top to bottom. *Create Response*
 saves the `session_id` and response id into the environment, so *Continue
 Session*, *Cancel*, and *Delete Session* just work. The
-*(openclaw)* requests do the same for OpenClaw (start `openclaw` locally first).
+*(openclaw)* requests do the same for OpenClaw (start `openclaw` locally first),
+and the *(claude-code)* requests for Claude Code (installed and logged in).
 *Upload File* writes a file via `PUT /v1/files/content` and saves its path for
 *Download File*.
 
@@ -371,12 +418,13 @@ All optional — see [`.env.example`](.env.example). Highlights: `PORT` (3737),
 `HOST` (0.0.0.0), `GATEWAY_DEFAULT_AGENT` (the harness a turn routes to when the
 request omits `agent`; `hermes` by default), `AGENT37_GATEWAY_HOME`
 (`~/.agent37-gateway`), the `HERMES_*` variables that locate the Hermes install,
-and `OPENCLAW_BASE_URL` / `OPENCLAW_TOKEN` for the OpenClaw route.
+`OPENCLAW_BASE_URL` / `OPENCLAW_TOKEN` for the OpenClaw route, and
+`CLAUDE_CODE_BIN` for the Claude Code route.
 
 ## Roadmap
 
 - **`goal` mode** — autonomous, multi-turn runs (the worker primitives are in place).
-- **More adapters** — Claude Code, behind the same `AgentAdapter` seam.
+- **More adapters**, behind the same `AgentAdapter` seam.
 
 ## License
 

--- a/bruno/environments/local.example.bru
+++ b/bruno/environments/local.example.bru
@@ -4,5 +4,7 @@ vars {
   responseId:
   openclawSessionId:
   openclawResponseId:
+  claudeCodeSessionId:
+  claudeCodeResponseId:
   uploadedFilePath:
 }

--- a/bruno/gateway/01 Health (claude-code).bru
+++ b/bruno/gateway/01 Health (claude-code).bru
@@ -1,0 +1,36 @@
+meta {
+  name: 01 Health (claude-code)
+  type: http
+  seq: 16
+}
+
+get {
+  url: {{baseUrl}}/v1/health?agent=claude-code
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: claude-code
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("reports Claude Code health", function () {
+    expect(res.body.ok).to.equal(true);
+    expect(res.body.agent).to.equal("claude-code");
+    expect(res.body.healthy).to.be.a("boolean");
+  });
+}
+
+docs {
+  Liveness + whether the Claude Code harness backend is reachable, selected
+  with `?agent=claude-code`. The gateway runs the Claude Code CLI through the
+  Claude Agent SDK on Claude Code's own login. `healthy` is false until this
+  machine has Claude Code installed (`claude` on PATH, or CLAUDE_CODE_BIN) and
+  logged in (`claude auth login`, or ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN
+  in the gateway's environment).
+}

--- a/bruno/gateway/03 List Models (claude-code).bru
+++ b/bruno/gateway/03 List Models (claude-code).bru
@@ -1,0 +1,37 @@
+meta {
+  name: 03 List Models (claude-code)
+  type: http
+  seq: 17
+}
+
+get {
+  url: {{baseUrl}}/v1/models?agent=claude-code
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: claude-code
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("is a Claude Code model list", function () {
+    expect(res.body.object).to.equal("list");
+    expect(res.body.agent).to.equal("claude-code");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The models the Claude Code harness can run, selected with
+  `?agent=claude-code` (`hermes` | `openclaw` | `claude-code`). Omit the
+  filter (see "03 List Models") for the gateway's configured default. This is
+  a fixed set of Claude Code's own model aliases (sonnet, opus, fable, haiku),
+  not a live catalog call. Needs Claude Code installed on this machine
+  (`claude` on PATH, or CLAUDE_CODE_BIN): otherwise the gateway returns
+  503 agent_unavailable.
+}

--- a/bruno/gateway/04 Create Response (claude-code).bru
+++ b/bruno/gateway/04 Create Response (claude-code).bru
@@ -1,0 +1,57 @@
+meta {
+  name: 04 Create Response (claude-code)
+  type: http
+  seq: 18
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "What is the time now in IST?",
+    "agent": "claude-code",
+    "reasoning_effort": "low"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body) {
+    if (res.body.session_id) bru.setEnvVar("claudeCodeSessionId", res.body.session_id, { persist: true });
+    if (res.body.id) bru.setEnvVar("claudeCodeResponseId", res.body.id, { persist: true });
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("completed with text", function () {
+    expect(res.body.id).to.be.a("string");
+    expect(res.body.session_id).to.be.a("string");
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("claude-code");
+    expect(res.body.output_text).to.be.a("string");
+  });
+}
+
+docs {
+  Start a new Claude Code session. Pass `"agent": "claude-code"`: the gateway
+  runs the Claude Code CLI through the Claude Agent SDK on Claude Code's own
+  login, one `claude` process per turn.
+
+  The reply saves `claudeCodeSessionId` and `claudeCodeResponseId` to the
+  environment so the follow-up requests below can reuse them.
+
+  Claude Code must be installed on this machine (`claude` on PATH, or
+  CLAUDE_CODE_BIN) and logged in (`claude auth login`, or ANTHROPIC_API_KEY /
+  CLAUDE_CODE_OAUTH_TOKEN in the gateway's environment).
+}

--- a/bruno/gateway/05 Continue Session (claude-code).bru
+++ b/bruno/gateway/05 Continue Session (claude-code).bru
@@ -1,0 +1,42 @@
+meta {
+  name: 05 Continue Session (claude-code)
+  type: http
+  seq: 19
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "session_id": "{{claudeCodeSessionId}}",
+    "input": "In one short sentence, what did I just ask you to say?",
+    "agent": "claude-code",
+    "reasoning_effort": "low"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("same session, completed", function () {
+    expect(res.body.session_id).to.equal(bru.getEnvVar("claudeCodeSessionId"));
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("claude-code");
+  });
+}
+
+docs {
+  Continue a Claude Code conversation. Reuses `claudeCodeSessionId` saved by
+  "04 Create Response (claude-code)". Always include `"agent": "claude-code"`
+  so the gateway routes the turn to the right backend.
+}

--- a/bruno/gateway/07 Create Response (streaming) (claude-code).bru
+++ b/bruno/gateway/07 Create Response (streaming) (claude-code).bru
@@ -1,0 +1,44 @@
+meta {
+  name: 07 Create Response (streaming) (claude-code)
+  type: http
+  seq: 20
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "Count from 1 to 5, one number per line.",
+    "agent": "claude-code",
+    "reasoning_effort": "low",
+    "stream": true
+  }
+}
+
+docs {
+  Streaming is agent-agnostic: pass `"agent": "claude-code"` alongside
+  `"stream": true` and the gateway streams the Claude Code turn back as
+  Server-Sent Events, exactly like the Hermes streaming request above:
+    response.created -> response.reasoning.delta / response.output_text.delta /
+    response.tool_call.* -> response.completed (or response.failed)
+
+  The Claude Code adapter reads the Claude Agent SDK's own partial-message
+  stream and re-emits it as gateway SSE, so there's no extra setup beyond a
+  Claude Code install that's logged in on this machine:
+    claude auth login   (or ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN in the
+    gateway's environment)
+
+  Bruno shows the assembled event stream in the Response pane. For raw frames:
+
+    curl -N localhost:3737/v1/responses \
+      -H 'content-type: application/json' \
+      -d '{"input":"hi","agent":"claude-code","stream":true}'
+}

--- a/bruno/gateway/09 List Sessions (claude-code).bru
+++ b/bruno/gateway/09 List Sessions (claude-code).bru
@@ -1,0 +1,35 @@
+meta {
+  name: 09 List Sessions (claude-code)
+  type: http
+  seq: 21
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions?agent=claude-code
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: claude-code
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("claude-code sessions", function () {
+    expect(res.body.agent).to.equal("claude-code");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The Claude Code chat sessions on this instance, selected with
+  `?agent=claude-code` (`hermes` | `openclaw` | `claude-code`), projected from
+  Claude Code's own session store (`~/.claude/projects/...`) as
+  `{ agent, data }`. Omitting `?agent=` falls back to the instance's default
+  harness: not a merged listing. Unknown agent values return a
+  400 validation_error.
+}

--- a/bruno/gateway/10 Get Session (claude-code history).bru
+++ b/bruno/gateway/10 Get Session (claude-code history).bru
@@ -1,0 +1,34 @@
+meta {
+  name: 10 Get Session (claude-code history)
+  type: http
+  seq: 22
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions/{{claudeCodeSessionId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("includes transcript history", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("claudeCodeSessionId"));
+    expect(res.body.agent).to.equal("claude-code");
+    expect(res.body.history).to.be.an("array");
+  });
+}
+
+docs {
+  The Claude Code session plus its transcript. Reuses `claudeCodeSessionId`
+  saved by "04 Create Response (claude-code)". History is projected on demand
+  from Claude Code's own transcript file
+  (`~/.claude/projects/.../<uuid>.jsonl`): the gateway never duplicates
+  messages.
+
+  Claude Code must have written that transcript for history to be non-empty;
+  otherwise `history` comes back as an empty array.
+}

--- a/bruno/gateway/12 Delete Session (claude-code).bru
+++ b/bruno/gateway/12 Delete Session (claude-code).bru
@@ -1,0 +1,30 @@
+meta {
+  name: 12 Delete Session (claude-code)
+  type: http
+  seq: 24
+}
+
+delete {
+  url: {{baseUrl}}/v1/sessions/{{claudeCodeSessionId}}?agent=claude-code
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: claude-code
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("deleted", function () {
+    expect(res.body.deleted).to.equal(true);
+  });
+}
+
+docs {
+  Permanently remove the Claude Code session's transcript from Claude Code's
+  own store. Other sessions on the instance are untouched.
+}

--- a/bruno/gateway/15 Rename Session (claude-code).bru
+++ b/bruno/gateway/15 Rename Session (claude-code).bru
@@ -1,0 +1,47 @@
+meta {
+  name: 15 Rename Session (claude-code)
+  type: http
+  seq: 23
+}
+
+patch {
+  url: {{baseUrl}}/v1/sessions/{{claudeCodeSessionId}}?agent=claude-code
+  body: json
+  auth: none
+}
+
+params:query {
+  agent: claude-code
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "title": "Renamed from Bruno"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("renamed", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("claudeCodeSessionId"));
+    expect(res.body.renamed).to.equal(true);
+  });
+}
+
+docs {
+  Rename a Claude Code session by writing its title straight into Claude
+  Code's own store (`PATCH /v1/sessions/:id?agent=claude-code`, body
+  `{ "title": "…" }` → `{ id, agent, renamed }`). The gateway calls the Claude
+  Agent SDK's rename helper, which appends a custom-title entry to the
+  transcript that the session list reads back as its title. Supported on both
+  Hermes and Claude Code; harnesses without an editable title (OpenClaw)
+  return `405 rename_unsupported`. Reuses the `claudeCodeSessionId` saved by
+  "04 Create Response (claude-code)".
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.241",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2"
@@ -25,6 +26,178 @@
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.241.tgz",
+      "integrity": "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.241.tgz",
+      "integrity": "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.241.tgz",
+      "integrity": "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.241.tgz",
+      "integrity": "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.241.tgz",
+      "integrity": "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.241.tgz",
+      "integrity": "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.241.tgz",
+      "integrity": "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.241.tgz",
+      "integrity": "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.241.tgz",
+      "integrity": "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
+      "integrity": "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -469,6 +642,443 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -590,6 +1200,41 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -709,6 +1354,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -867,6 +1527,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -912,6 +1595,82 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -1046,6 +1805,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1084,6 +1853,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1092,6 +1871,58 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1210,6 +2041,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1219,11 +2060,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1275,6 +2136,69 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -1354,6 +2278,29 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -1426,6 +2373,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1443,6 +2401,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -1522,6 +2487,49 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent37-gateway",
-  "version": "0.8.3",
-  "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets. Hermes and OpenClaw today; Claude Code next.",
+  "version": "0.9.0",
+  "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, or Claude Code.",
   "license": "MIT",
   "type": "module",
   "bin": {
@@ -30,6 +30,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.241",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2"

--- a/server/adapters/claude-code-adapter.ts
+++ b/server/adapters/claude-code-adapter.ts
@@ -1,0 +1,552 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  deleteSession as deleteClaudeSession,
+  getSessionMessages,
+  listSessions as listClaudeSessions,
+  query,
+  renameSession as renameClaudeSession,
+  type Query,
+  type SDKAssistantMessage,
+  type SDKAssistantMessageError,
+  type SDKResultMessage,
+  type SDKUserMessage,
+} from '@anthropic-ai/claude-agent-sdk';
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  HermesMessage,
+  ReasoningEffort,
+  SessionMetadata,
+  SessionSummary,
+  TurnUsage,
+} from '../../shared/types.js';
+import type { AgentAdapter, AgentRunOptions, ContextUsage, StreamEvent } from './types.js';
+import { epochMillis } from './types.js';
+import { resolveWorkspaceDir } from '../paths.js';
+
+// The adapter drives Claude Code through the Claude Agent SDK: one `query()`
+// (one `claude` child process) per turn, resumed by session id. Transcripts
+// live where Claude Code keeps them (`~/.claude/projects/<cwd>/<uuid>.jsonl`),
+// and the session list, history, rename and delete all go through the SDK's
+// session helpers over that store — the gateway keeps no index. Credentials
+// are Claude Code's own (`claude auth login` on the box, or ANTHROPIC_API_KEY /
+// CLAUDE_CODE_OAUTH_TOKEN in the environment); the gateway never touches them.
+
+const HEALTHY_TTL_MS = 60_000;
+// A not-logged-in probe is re-run sooner so a fresh `claude auth login` shows up.
+const UNHEALTHY_TTL_MS = 10_000;
+// After `interrupt()`, how long Claude Code gets to close the turn with its own
+// `result` before the process is killed outright.
+const INTERRUPT_GRACE_MS = 5_000;
+const LOGIN_HINT =
+  'Run `claude auth login` in the instance terminal, or set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in the environment.';
+
+// Claude Code's effort levels are a subset of ours (no none/minimal).
+const EFFORT_MAP: Record<ReasoningEffort, 'low' | 'medium' | 'high' | 'xhigh'> = {
+  none: 'low',
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+};
+
+// Claude Code has no model catalog call; its own /model picker is this fixed
+// set of aliases, each resolving to the latest model of its family.
+const MODEL_ALIASES = [
+  { id: 'sonnet', label: 'Claude Sonnet (latest)' },
+  { id: 'opus', label: 'Claude Opus (latest)' },
+  { id: 'fable', label: 'Claude Fable (latest)' },
+  { id: 'haiku', label: 'Claude Haiku (latest)' },
+];
+
+// Claude Code's typed failure signal (SDKAssistantMessage.error) → the worker
+// codes server/errors.ts already knows how to render.
+const ERROR_CODE_MAP: Partial<Record<SDKAssistantMessageError, string>> = {
+  authentication_failed: 'auth_error',
+  oauth_org_not_allowed: 'auth_error',
+  account_on_hold: 'auth_error',
+  billing_error: 'quota_exhausted',
+  rate_limit: 'rate_limit',
+  overloaded: 'rate_limit',
+  model_not_found: 'model_error',
+};
+
+let pathBin: string | null = null;
+
+/** The `claude` binary a turn spawns: CLAUDE_CODE_BIN, else the one on PATH.
+ *  Throws ENOENT when neither exists — the gateway renders that as
+ *  `503 agent_unavailable`, like any other unprovisioned harness. */
+function requireClaudeBin(): string {
+  let bin = process.env.CLAUDE_CODE_BIN?.trim();
+  if (!bin) {
+    if (!pathBin) {
+      try {
+        pathBin = execFileSync('which', ['claude'], { encoding: 'utf8' }).trim() || null;
+      } catch {
+        pathBin = null;
+      }
+    }
+    bin = pathBin ?? undefined;
+  }
+  if (!bin || !existsSync(bin)) {
+    const error: NodeJS.ErrnoException = new Error(
+      `Claude Code binary not found${bin ? ` at ${bin}` : ' on PATH'}. Install Claude Code or set CLAUDE_CODE_BIN.`,
+    );
+    error.code = 'ENOENT';
+    throw error;
+  }
+  return bin;
+}
+
+// Claude Code names the transcript directory after the cwd it was given, so
+// hand it the canonical path (macOS /var → /private/var) and look for the
+// transcript under the same spelling. The directory must exist to be spawned in.
+function workspaceCwd(): string {
+  const dir = resolveWorkspaceDir();
+  mkdirSync(dir, { recursive: true });
+  return realpathSync(dir);
+}
+
+function transcriptPath(uuid: string, cwd: string): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), '.claude');
+  return join(configDir, 'projects', cwd.replace(/[^a-zA-Z0-9]/g, '-'), `${uuid}.jsonl`);
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function dashed(hex32: string): string {
+  return `${hex32.slice(0, 8)}-${hex32.slice(8, 12)}-${hex32.slice(12, 16)}-${hex32.slice(16, 20)}-${hex32.slice(20)}`;
+}
+
+/** Claude Code requires a UUID session id. Gateway-minted ids are a UUID with
+ *  the dashes removed, so they re-dash losslessly (and a listed session's UUID
+ *  strips back to the id the client used). Any other client-supplied id maps
+ *  to a stable name-based UUID. */
+export function claudeSessionUuid(sessionId: string): string {
+  const lower = sessionId.toLowerCase();
+  if (/^[0-9a-f]{32}$/.test(lower) && UUID_RE.test(dashed(lower))) return dashed(lower);
+  if (UUID_RE.test(lower)) return lower;
+  const digest = createHash('sha1').update('agent37-gateway:claude-code:').update(sessionId).digest();
+  digest[6] = (digest[6] & 0x0f) | 0x50;
+  digest[8] = (digest[8] & 0x3f) | 0x80;
+  return dashed(digest.subarray(0, 16).toString('hex'));
+}
+
+// Messages API content, trimmed to the block fields we read.
+type Block = {
+  type: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  is_error?: boolean;
+  content?: unknown;
+};
+
+type ApiUsage = {
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+};
+
+function blocksOf(content: unknown): Block[] {
+  if (!Array.isArray(content)) return [];
+  return content.filter((b): b is Block => typeof b === 'object' && b !== null && typeof (b as Block).type === 'string');
+}
+
+function textOf(content: unknown): string {
+  if (typeof content === 'string') return content;
+  return blocksOf(content)
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text ?? '')
+    .join('');
+}
+
+function thinkingOf(content: unknown): string {
+  return blocksOf(content)
+    .filter((b) => b.type === 'thinking')
+    .map((b) => b.thinking ?? '')
+    .join('');
+}
+
+// A one-line label for a tool call: the command, path, pattern or URL it acts on.
+function toolLabel(input: unknown): string | undefined {
+  if (typeof input !== 'object' || input === null) return undefined;
+  const record = input as Record<string, unknown>;
+  for (const key of ['command', 'file_path', 'path', 'pattern', 'url', 'query', 'description', 'prompt']) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value.length > 120 ? `${value.slice(0, 117)}...` : value;
+  }
+  return undefined;
+}
+
+// Prompt-side tokens of one API call: fresh input plus what the cache served.
+function inputTokens(usage: ApiUsage | undefined): number {
+  return (usage?.input_tokens ?? 0) + (usage?.cache_creation_input_tokens ?? 0) + (usage?.cache_read_input_tokens ?? 0);
+}
+
+function turnUsage(result: SDKResultMessage): TurnUsage {
+  return {
+    input_tokens: inputTokens(result.usage),
+    output_tokens: result.usage.output_tokens ?? 0,
+    cost_usd: result.total_cost_usd,
+  };
+}
+
+// The tokens occupying the window after the turn are the last API call's
+// prompt plus its output; the window size rides on the result's per-model
+// usage. Null when Claude Code reported neither. The prompt side comes from
+// the last assistant message; its output_tokens is a placeholder while
+// streaming, so the output side comes from the last message_delta event.
+function contextOf(
+  last: SDKAssistantMessage | undefined,
+  lastOutputTokens: number,
+  result: SDKResultMessage,
+): ContextUsage | null {
+  if (last?.context_usage) {
+    return { used_tokens: last.context_usage.total_tokens, window_tokens: last.context_usage.raw_max_tokens };
+  }
+  const usage = last?.message.usage as ApiUsage | undefined;
+  const used = inputTokens(usage) + lastOutputTokens;
+  const model = last?.message.model;
+  const window =
+    (model ? result.modelUsage[model]?.contextWindow : undefined) || Object.values(result.modelUsage)[0]?.contextWindow;
+  if (used <= 0 || !window) return null;
+  return { used_tokens: used, window_tokens: window };
+}
+
+function failureEvent(signal: SDKAssistantMessageError | undefined, text: string): StreamEvent {
+  const code =
+    (signal && ERROR_CODE_MAP[signal]) ||
+    // Fallback for CLIs that report the failure only as text.
+    (/not logged in|invalid api key|please run \/login/i.test(text) ? 'auth_error' : 'agent_error');
+  return {
+    type: 'error',
+    code,
+    error: text || 'Claude Code ended the turn on an error.',
+    ...(code === 'auth_error' ? { hint: LOGIN_HINT } : {}),
+  };
+}
+
+function loggedIn(): Promise<boolean> {
+  let bin: string;
+  try {
+    bin = requireClaudeBin();
+  } catch {
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve) => {
+    execFile(bin, ['auth', 'status', '--json'], { timeout: 15_000 }, (error, stdout) => {
+      if (error) {
+        resolve(false);
+        return;
+      }
+      try {
+        resolve((JSON.parse(stdout) as { loggedIn?: boolean }).loggedIn === true);
+      } catch {
+        resolve(false);
+      }
+    });
+  });
+}
+
+interface ActiveTurn {
+  query: Query;
+  abort: AbortController;
+  interrupted: boolean;
+  killTimer?: NodeJS.Timeout;
+}
+
+export class ClaudeCodeAdapter implements AgentAdapter {
+  private readonly activeTurns = new Map<string, ActiveTurn>();
+  private health: { at: number; ok: boolean } | null = null;
+
+  async *chatStream(sessionId: string, message: string, options?: AgentRunOptions): AsyncIterable<StreamEvent> {
+    const bin = requireClaudeBin();
+    const cwd = workspaceCwd();
+    const uuid = claudeSessionUuid(sessionId);
+    // An id with a transcript resumes it; any other id starts a fresh thread
+    // (the documented contract for client-supplied ids).
+    const resume = existsSync(transcriptPath(uuid, cwd));
+    const settings = options?.settings;
+
+    // Streaming-input mode (the prompt as an async iterable) is the only mode
+    // where interrupt() works. Keep stdin open until the turn has settled so
+    // the interrupt control request always has a channel.
+    let release = (): void => {};
+    const inputDone = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    async function* input(): AsyncGenerator<SDKUserMessage> {
+      yield { type: 'user', message: { role: 'user', content: message }, parent_tool_use_id: null, session_id: uuid };
+      await inputDone;
+    }
+
+    // Claude Code's stderr, size-bounded, for the rare exit with no result.
+    let stderrTail = '';
+    const abort = new AbortController();
+    const q = query({
+      prompt: input(),
+      options: {
+        cwd,
+        pathToClaudeCodeExecutable: bin,
+        ...(resume ? { resume: uuid } : { sessionId: uuid }),
+        // Sandbox parity with the other harnesses (HERMES_YOLO_MODE): the
+        // instance is the customer's own box, so tools run unprompted.
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        includePartialMessages: true,
+        // Only ~/.claude/settings.json: a .claude/ or CLAUDE.md inside the
+        // workspace must not reconfigure server turns.
+        settingSources: ['user'],
+        ...(settings?.model ? { model: settings.model } : {}),
+        ...(settings?.reasoningEffort ? { effort: EFFORT_MAP[settings.reasoningEffort] } : {}),
+        abortController: abort,
+        stderr: (chunk) => {
+          stderrTail = (stderrTail + chunk).slice(-4096);
+        },
+      },
+    });
+    const turn: ActiveTurn = { query: q, abort, interrupted: false };
+    this.activeTurns.set(sessionId, turn);
+
+    const tools = new Map<string, { name: string; startedAt: number }>();
+    let signal: SDKAssistantMessageError | undefined;
+    let lastAssistant: SDKAssistantMessage | undefined;
+    let lastOutputTokens = 0;
+    let result: SDKResultMessage | undefined;
+    try {
+      for await (const msg of q) {
+        // Subagent (Task) traffic carries parent_tool_use_id; only the main
+        // loop streams to the client.
+        if ('parent_tool_use_id' in msg && msg.parent_tool_use_id) continue;
+
+        if (msg.type === 'stream_event') {
+          const event = msg.event as unknown as {
+            type: string;
+            delta?: { type: string; text?: string; thinking?: string };
+            usage?: { output_tokens?: number };
+          };
+          if (event.type === 'message_delta' && typeof event.usage?.output_tokens === 'number') {
+            lastOutputTokens = event.usage.output_tokens;
+          }
+          if (event.type !== 'content_block_delta' || !event.delta) continue;
+          if (event.delta.type === 'text_delta' && event.delta.text) {
+            yield { type: 'text_delta', content: event.delta.text };
+          } else if (event.delta.type === 'thinking_delta' && event.delta.thinking) {
+            yield { type: 'thinking_delta', content: event.delta.thinking };
+          }
+        } else if (msg.type === 'assistant') {
+          if (msg.error) signal = msg.error;
+          lastAssistant = msg;
+          for (const block of blocksOf(msg.message.content)) {
+            if (block.type !== 'tool_use' || !block.id || !block.name) continue;
+            tools.set(block.id, { name: block.name, startedAt: Date.now() });
+            yield { type: 'tool_progress', tool: block.name, status: 'running', label: toolLabel(block.input) };
+          }
+        } else if (msg.type === 'user') {
+          for (const block of blocksOf(msg.message.content)) {
+            if (block.type !== 'tool_result' || !block.tool_use_id) continue;
+            const started = tools.get(block.tool_use_id);
+            if (!started) continue;
+            tools.delete(block.tool_use_id);
+            yield block.is_error
+              ? { type: 'tool_progress', tool: started.name, status: 'error', label: textOf(block.content).slice(0, 200) || undefined }
+              : { type: 'tool_progress', tool: started.name, status: 'completed', duration: Date.now() - started.startedAt };
+          }
+        } else if (msg.type === 'result') {
+          result = msg;
+          break;
+        }
+      }
+    } catch (error) {
+      // The SDK throws after an error result (already terminal) and on abort
+      // (the interrupt backstop); anything else is a real failure, and the
+      // SDK's own message already carries a stderr tail.
+      if (!result && !turn.interrupted) throw error;
+    } finally {
+      release();
+      clearTimeout(turn.killTimer);
+      this.activeTurns.delete(sessionId);
+    }
+
+    if (turn.interrupted) {
+      // An interrupted result carries zeroed usage, not the partial turn's.
+      yield { type: 'done', sessionId, usage: null, interrupted: true };
+    } else if (!result) {
+      const detail = stderrTail.trim();
+      yield { type: 'error', code: 'agent_error', error: `Claude Code exited before finishing the turn.${detail ? ` ${detail}` : ''}` };
+    } else if (result.subtype !== 'success') {
+      yield failureEvent(signal, result.errors.join(' ') || `Claude Code stopped: ${result.subtype}.`);
+    } else if (result.is_error) {
+      yield failureEvent(signal, result.result);
+    } else {
+      yield {
+        type: 'done',
+        sessionId,
+        usage: turnUsage(result),
+        context: contextOf(lastAssistant, lastOutputTokens, result),
+        interrupted: false,
+      };
+    }
+  }
+
+  async interruptChat(sessionId: string): Promise<boolean> {
+    const turn = this.activeTurns.get(sessionId);
+    if (!turn) return false;
+    turn.interrupted = true;
+    // Claude Code answers an interrupt with its own `result`, which ends the
+    // stream above; if none lands within the grace period, kill the process.
+    turn.killTimer = setTimeout(() => turn.abort.abort(), INTERRUPT_GRACE_MS);
+    try {
+      await turn.query.interrupt();
+    } catch {
+      turn.abort.abort();
+    }
+    return true;
+  }
+
+  // Healthy means the binary is there and Claude Code reports a login (or an
+  // API key in the environment). `false` until the customer logs in.
+  async healthCheck(): Promise<boolean> {
+    if (this.health && Date.now() - this.health.at < (this.health.ok ? HEALTHY_TTL_MS : UNHEALTHY_TTL_MS)) {
+      return this.health.ok;
+    }
+    const ok = await loggedIn();
+    this.health = { at: Date.now(), ok };
+    return ok;
+  }
+
+  async listSessions(): Promise<SessionSummary[]> {
+    const rows = await listClaudeSessions({ dir: workspaceCwd(), includeWorktrees: false });
+    // `summary` is Claude Code's own display title: the custom title (what
+    // rename writes) when set, else its auto summary or the first prompt.
+    return rows.map((row) => ({
+      id: row.sessionId.replace(/-/g, ''),
+      title: row.summary?.trim() || null,
+      last_active: row.lastModified ?? null,
+      message_count: null,
+      preview: row.firstPrompt?.trim() || null,
+    }));
+  }
+
+  async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    const rows = await getSessionMessages(claudeSessionUuid(sessionId), { dir: workspaceCwd() });
+    // Keep user/assistant turns with visible text; tool plumbing (tool_use
+    // and tool_result blocks) is dropped. Claude Code writes one row per
+    // content block, so a reply's text and thinking blocks are folded back
+    // into one assistant message.
+    const out: HermesMessage[] = [];
+    let pendingThinking = '';
+    for (const row of rows) {
+      if (row.parent_tool_use_id || (row.type !== 'user' && row.type !== 'assistant')) continue;
+      const content = (row.message as { content?: unknown }).content;
+      const text = textOf(content);
+      const thinking = thinkingOf(content);
+      if (row.type === 'assistant' && thinking) pendingThinking = pendingThinking ? `${pendingThinking}\n\n${thinking}` : thinking;
+      if (!text.trim()) continue;
+      if (row.type === 'user' && text.startsWith('[Request interrupted')) continue;
+      const previous = out.at(-1);
+      if (row.type === 'assistant' && previous?.role === 'assistant') {
+        previous.content += `\n\n${text}`;
+        if (pendingThinking) previous.thinking = previous.thinking ? `${previous.thinking}\n\n${pendingThinking}` : pendingThinking;
+      } else {
+        out.push({
+          id: row.uuid,
+          task_id: sessionId,
+          role: row.type,
+          content: text,
+          thinking: row.type === 'assistant' && pendingThinking ? pendingThinking : undefined,
+          created_at: epochMillis((row as { timestamp?: string }).timestamp) ?? 0,
+        });
+      }
+      pendingThinking = '';
+    }
+    return out;
+  }
+
+  async getSessionMetadata(sessionId: string): Promise<SessionMetadata | null> {
+    const rows = await getSessionMessages(claudeSessionUuid(sessionId), { dir: workspaceCwd() });
+    if (rows.length === 0) return null;
+    const meta: SessionMetadata = {
+      id: sessionId,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      reasoning_tokens: 0,
+      estimated_cost_usd: null,
+      cost_status: null,
+      model: null,
+    };
+    // Usage rides on every per-block row of an API message; count each message once.
+    const seen = new Set<string>();
+    for (const row of rows) {
+      if (row.type !== 'assistant' || row.parent_tool_use_id) continue;
+      const message = row.message as { id?: string; model?: string; usage?: ApiUsage };
+      if (!message.usage || !message.id || seen.has(message.id)) continue;
+      seen.add(message.id);
+      meta.input_tokens += message.usage.input_tokens ?? 0;
+      meta.output_tokens += message.usage.output_tokens ?? 0;
+      meta.cache_read_tokens += message.usage.cache_read_input_tokens ?? 0;
+      meta.cache_write_tokens += message.usage.cache_creation_input_tokens ?? 0;
+      if (message.model && !message.model.startsWith('<')) meta.model = message.model;
+    }
+    return meta;
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    const cwd = workspaceCwd();
+    const uuid = claudeSessionUuid(sessionId);
+    if (!existsSync(transcriptPath(uuid, cwd))) return false;
+    await deleteClaudeSession(uuid, { dir: cwd });
+    return true;
+  }
+
+  // Claude Code's own /rename: appends a custom-title entry to the transcript,
+  // which the session list reads back as `summary`.
+  async renameSession(sessionId: string, title: string): Promise<boolean> {
+    const cwd = workspaceCwd();
+    const uuid = claudeSessionUuid(sessionId);
+    if (!existsSync(transcriptPath(uuid, cwd))) return false;
+    await renameClaudeSession(uuid, title, { dir: cwd });
+    return true;
+  }
+
+  async getModels(): Promise<AgentModelsResponse> {
+    requireClaudeBin();
+    return {
+      defaultModel: null,
+      activeProvider: 'anthropic',
+      groups: [
+        {
+          provider: 'anthropic',
+          models: MODEL_ALIASES.map((alias) => ({
+            id: alias.id,
+            label: alias.label,
+            source: 'alias',
+            provider: 'anthropic',
+            isCurrentDefault: false,
+          })),
+        },
+      ],
+    };
+  }
+
+  async getDefaults(): Promise<AgentDefaults> {
+    return { provider: 'anthropic', model: null, baseUrl: null, apiMode: null, reasoningEffort: null, showReasoning: true };
+  }
+
+  async stop(): Promise<void> {
+    for (const turn of this.activeTurns.values()) turn.abort.abort();
+    this.activeTurns.clear();
+  }
+}

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -1,5 +1,6 @@
 import { HermesWorkerAdapter } from './adapters/hermes-worker.js';
 import { OpenClawAdapter } from './adapters/openclaw-adapter.js';
+import { ClaudeCodeAdapter } from './adapters/claude-code-adapter.js';
 import type { AgentAdapter } from './adapters/types.js';
 import { resolveConfiguredDefaultAgent, SUPPORTED_AGENTS, type AgentType } from '../shared/types.js';
 import { optionalEnum, queryParam } from './errors.js';
@@ -12,6 +13,7 @@ export interface GatewayAdapter extends AgentAdapter {
 const registry: Record<AgentType, GatewayAdapter> = {
   hermes: new HermesWorkerAdapter(),
   openclaw: new OpenClawAdapter(),
+  'claude-code': new ClaudeCodeAdapter(),
 };
 
 export function getAdapter(agent: AgentType): GatewayAdapter {

--- a/server/index.ts
+++ b/server/index.ts
@@ -95,6 +95,7 @@ async function shutdown(reason: ShutdownReason, exitCode = 0): Promise<void> {
     closeHttpServer(),
     adapter.stop?.() ?? Promise.resolve(),
     getAdapter('openclaw').stop?.() ?? Promise.resolve(),
+    getAdapter('claude-code').stop?.() ?? Promise.resolve(),
   ]);
   for (const result of results) {
     if (result.status === 'rejected') console.error(result.reason);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -16,7 +16,7 @@ export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 /** Response modes. `chat` runs one turn; `goal` is reserved for a fast-follow. */
 export const RESPONSE_MODES = ['chat', 'goal'] as const;
 
-export const SUPPORTED_AGENTS = ['hermes', 'openclaw'] as const;
+export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code'] as const;
 export type AgentType = (typeof SUPPORTED_AGENTS)[number];
 export const DEFAULT_AGENT: AgentType = 'hermes';
 

--- a/test/agent-unavailable.integration.test.ts
+++ b/test/agent-unavailable.integration.test.ts
@@ -2,15 +2,17 @@ import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { startTestServer, type TestServer } from './test-helpers.js';
 
-// Point the OpenClaw adapter at a dead port so its backend is unreachable —
-// the same shape as targeting a harness that isn't provisioned on this
-// instance. node:test isolates each file in its own process, so this env
-// override doesn't leak into the other suites.
+// Point the OpenClaw adapter at a dead port and the Claude Code adapter at a
+// missing binary so their backends are unreachable — the same shape as
+// targeting a harness that isn't provisioned on this instance. node:test
+// isolates each file in its own process, so these env overrides don't leak
+// into the other suites.
 let server: TestServer | undefined;
 let base: string;
 
 before(async () => {
   process.env.OPENCLAW_BASE_URL = 'http://127.0.0.1:59321';
+  process.env.CLAUDE_CODE_BIN = '/nonexistent/claude';
   server = await startTestServer();
   base = server.base;
 });
@@ -38,4 +40,25 @@ test('a turn for an unreachable harness settles as failed with agent_unavailable
   const body = (await res.json()) as { status: string; error: { code: string } | null };
   assert.equal(body.status, 'failed');
   assert.equal(body.error?.code, 'agent_unavailable');
+});
+
+test('a claude-code request without the claude binary fails with agent_unavailable', async () => {
+  const models = await fetch(`${base}/v1/models?agent=claude-code`);
+  assert.equal(models.status, 503);
+  const modelsBody = (await models.json()) as { error: { code: string; message: string } };
+  assert.equal(modelsBody.error.code, 'agent_unavailable');
+  assert.match(modelsBody.error.message, /claude-code/);
+
+  const turn = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'claude-code', input: 'hello' }),
+  });
+  assert.equal(turn.status, 200);
+  const body = (await turn.json()) as { status: string; error: { code: string } | null };
+  assert.equal(body.status, 'failed');
+  assert.equal(body.error?.code, 'agent_unavailable');
+
+  const health = (await (await fetch(`${base}/v1/health?agent=claude-code`)).json()) as { healthy: boolean };
+  assert.equal(health.healthy, false);
 });

--- a/test/claude-code.integration.test.ts
+++ b/test/claude-code.integration.test.ts
@@ -1,0 +1,227 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+// --- Claude Code adapter (needs the Claude Code CLI on this machine, logged
+// in on its own account; skipped otherwise — the same shape as the OpenClaw
+// probe). Turns run on that login, so they cost real usage.
+
+const claudeCodeSkip = await new Promise<false | string>((resolve) => {
+  execFile(process.env.CLAUDE_CODE_BIN?.trim() || 'claude', ['auth', 'status', '--json'], { timeout: 15_000 }, (error, stdout) => {
+    if (error) {
+      resolve('no Claude Code CLI installed');
+      return;
+    }
+    try {
+      resolve((JSON.parse(stdout) as { loggedIn?: boolean }).loggedIn === true ? false : 'Claude Code is not logged in');
+    } catch {
+      resolve('Claude Code auth status unreadable');
+    }
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+interface ResponseBody {
+  id: string;
+  session_id: string;
+  status: string;
+  agent: string;
+  model: string | null;
+  output_text: string;
+  usage: { input_tokens: number; output_tokens: number; cost_usd: number | null } | null;
+  context: { used_tokens: number; window_tokens: number } | null;
+  error: { code: string; message: string; hint?: string } | null;
+}
+
+async function jsonOk<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  assert.equal(res.status, 200, JSON.stringify(body));
+  return body as T;
+}
+
+test('claude-code responses complete, resume, and manage sessions on Claude Code\'s own store', { skip: claudeCodeSkip }, async () => {
+  const marker = `claude-code-marker-${Date.now()}`;
+  const created = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'claude-code',
+      input: `Remember this marker: ${marker}. Reply with just OK.`,
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(created.status, 'completed', JSON.stringify(created.error));
+  assert.equal(created.agent, 'claude-code');
+  assert.match(created.session_id, /^[a-f0-9]{32}$/);
+  assert.ok(created.output_text.trim().length > 0);
+  assert.ok(created.usage && created.usage.output_tokens > 0);
+  assert.equal(typeof created.usage.cost_usd, 'number');
+  // The window the turn ran in, from Claude Code's own per-model usage.
+  assert.ok(created.context && created.context.used_tokens > 0);
+  assert.ok(created.context.window_tokens >= created.context.used_tokens);
+
+  assert.deepEqual(await jsonOk(await fetch(`${base}/v1/health?agent=claude-code`)), {
+    ok: true,
+    agent: 'claude-code',
+    healthy: true,
+  });
+
+  // A known session id resumes the transcript (`--resume`), so the marker is recalled.
+  const recalled = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'claude-code',
+      session_id: created.session_id,
+      input: 'Reply with just the marker I asked you to remember.',
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(recalled.status, 'completed', JSON.stringify(recalled.error));
+  assert.equal(recalled.session_id, created.session_id);
+  assert.ok(recalled.output_text.includes(marker), recalled.output_text);
+
+  // History projects Claude Code's transcript; reads must name `?agent=claude-code`.
+  const session = await jsonOk<{ history: { role: string; content: string; created_at: number }[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=claude-code`),
+  );
+  assert.ok(session.history.some((m) => m.role === 'user' && m.content.includes(marker)));
+  assert.ok(session.history.some((m) => m.role === 'assistant' && m.content.includes(marker)));
+  assert.ok(session.history.every((m) => m.created_at > 0));
+
+  // The list is Claude Code's own (its projects store for the workspace cwd);
+  // the UUID strips back to the gateway id, and the display title is set.
+  const list = await jsonOk<{ agent: string; data: Array<{ id: string; title: string | null; last_active: number | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=claude-code`),
+  );
+  assert.equal(list.agent, 'claude-code');
+  const row = list.data.find((s) => s.id === created.session_id);
+  assert.ok(row);
+  assert.ok(row.title && row.title.length > 0);
+  assert.equal(typeof row.last_active, 'number');
+
+  // Rename is Claude Code's own /rename (a custom-title entry in the transcript).
+  const title = `integration-rename-${marker}`;
+  const rename = await jsonOk<{ renamed: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=claude-code`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    }),
+  );
+  assert.equal(rename.renamed, true);
+  const renamedList = await jsonOk<{ data: Array<{ id: string; title: string | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=claude-code`),
+  );
+  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.title, title);
+
+  // Models are Claude Code's fixed aliases.
+  const models = await jsonOk<{ agent: string; data: Array<{ id: string; owned_by: string; source: string }> }>(
+    await fetch(`${base}/v1/models?agent=claude-code`),
+  );
+  assert.equal(models.agent, 'claude-code');
+  assert.ok(models.data.some((m) => m.id === 'sonnet' && m.owned_by === 'anthropic' && m.source === 'alias'));
+
+  const stream = await postJson(base, {
+    agent: 'claude-code',
+    input: 'Reply with exactly this word: PONG',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(stream.status, 200);
+  const events = await new SseReader(stream).drain();
+  assert.equal(events[0]?.event, 'response.created');
+  assert.ok(events.some((event) => event.event === 'response.output_text.delta'));
+  assert.equal(events.at(-1)?.event, 'response.completed');
+  assert.ok(events.at(-1)?.data.context);
+  await fetch(`${base}/v1/sessions/${events[0]?.data.session_id as string}?agent=claude-code`, { method: 'DELETE' });
+
+  // Delete removes the transcript; the session leaves the list and its history projects empty.
+  const deleted = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=claude-code`, { method: 'DELETE' }),
+  );
+  assert.equal(deleted.deleted, true);
+  const afterDelete = await jsonOk<{ data: Array<{ id: string }> }>(await fetch(`${base}/v1/sessions?agent=claude-code`));
+  assert.ok(!afterDelete.data.some((s) => s.id === created.session_id));
+  const gone = await jsonOk<{ history: unknown[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=claude-code`),
+  );
+  assert.deepEqual(gone.history, []);
+
+  // Unknown ids are not an error: no transcript means nothing to delete or rename.
+  const unknown = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/missing?agent=claude-code`, { method: 'DELETE' }),
+  );
+  assert.equal(unknown.deleted, false);
+});
+
+test('an in-flight claude-code turn can be cancelled', { skip: claudeCodeSkip }, async () => {
+  const slow = await postJson(base, {
+    agent: 'claude-code',
+    input: 'Write a 1500 word essay about oceans. Do not use any tools.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(slow.status, 200);
+
+  const reader = new SseReader(slow);
+  const opening = await reader.until((event) => event.event === 'response.output_text.delta');
+  const created = opening.find((event) => event.event === 'response.created');
+  assert.ok(created);
+  const responseId = created.data.id as string;
+  const sessionId = created.data.session_id as string;
+
+  const cancel = await fetch(`${base}/v1/responses/${responseId}/cancel`, { method: 'POST' });
+  assert.equal(cancel.status, 200);
+  await reader.drain(); // the in-flight stream ends once the turn is cancelled
+
+  // Terminal turn: the session lock is released and the replay closes immediately.
+  const settled = await jsonOk<{ active_response_id: string | null }>(
+    await fetch(`${base}/v1/sessions/${sessionId}?agent=claude-code`),
+  );
+  assert.equal(settled.active_response_id, null);
+  const replay = await new SseReader(await fetch(`${base}/v1/responses/${responseId}/stream`)).drain();
+  assert.equal(replay.at(-1)?.event, 'response.completed');
+  // A cancelled turn reports no usage or context; a completed one always carries the window.
+  assert.equal(replay.at(-1)?.data.context, null);
+  assert.equal(replay.at(-1)?.data.usage, null);
+
+  await fetch(`${base}/v1/sessions/${sessionId}?agent=claude-code`, { method: 'DELETE' });
+});
+
+// Point Claude Code at an empty config dir (no login) — the turn must settle as
+// a failed response with the documented auth_error and the login hint.
+const notLoggedInSkip =
+  claudeCodeSkip ||
+  (process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_TOKEN
+    ? 'a Claude credential is set in the environment'
+    : false);
+
+test('a claude-code turn without a login fails with auth_error', { skip: notLoggedInSkip }, async () => {
+  const previous = process.env.CLAUDE_CONFIG_DIR;
+  const configDir = mkdtempSync(join(tmpdir(), 'a37gw-claude-nologin-'));
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  try {
+    const failed = await jsonOk<ResponseBody>(
+      await postJson(base, { agent: 'claude-code', input: 'hello', reasoning_effort: 'low' }),
+    );
+    assert.equal(failed.status, 'failed');
+    assert.equal(failed.error?.code, 'auth_error');
+    assert.match(failed.error?.hint ?? '', /claude auth login/);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previous;
+    rmSync(configDir, { recursive: true, force: true });
+  }
+});

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -33,6 +33,7 @@ export async function startTestServer(): Promise<TestServer> {
       shutdownLiveRuns();
       await adapter.stop?.();
       await getAdapter('openclaw').stop?.();
+      await getAdapter('claude-code').stop?.();
     },
   };
 }


### PR DESCRIPTION
## What

`agent: "claude-code"` routes a turn to the Claude Code CLI through the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk` 0.3.241, paired with CLI 2.1.241): one `query()` per turn, resumed by session id, `bypassPermissions` like the other harnesses, text/thinking/tool events on the same SSE stream, and a real cancel through `interrupt()`.

Sessions live where Claude Code keeps them (`~/.claude/projects/<cwd>/<uuid>.jsonl`): list, history, rename (its custom title) and delete go through the SDK's session helpers, and a gateway id is the session UUID with the dashes removed (any other client id maps to a stable name-based UUID). Models are Claude Code's aliases (`sonnet`, `opus`, `fable`, `haiku`), usage and context come from its per-turn result, `reasoning_effort` maps onto its effort levels.

No credential passes through the gateway: Claude Code runs on its own login (`claude auth login` on the box, or `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` in the environment). Without one a turn fails with `auth_error` plus a login hint, and `GET /v1/health?agent=claude-code` reports `healthy: false`. A missing binary is the usual `503 agent_unavailable`; `CLAUDE_CODE_BIN` pins the binary the gateway spawns (else the `claude` on PATH).

## Touch list

- `server/adapters/claude-code-adapter.ts` (new), registry + stop hooks, `SUPPORTED_AGENTS`
- README (new "How it talks to Claude Code" + "Set up Claude Code", every `?agent=` row), AGENTS.md, `.env.example`, package description
- Bruno: `(claude-code)` twins of the OpenClaw requests + env vars
- Tests: `test/claude-code.integration.test.ts` (create, resume, history, list, rename, models, stream, delete, cancel, not-logged-in), a claude-code case in `agent-unavailable`

## Verification

`npm run typecheck && npm test` on this machine: all Hermes, files, and Claude Code tests pass (Claude Code on the local login). The two OpenClaw tests fail here with `OpenClaw chat.abort → INVALID_REQUEST: missing scope: operator.write` from the local OpenClaw 2026.6.6; this branch does not touch the OpenClaw adapter or routes, so that is the local OpenClaw token, not this change.

https://claude.ai/code/session_01PJpDp5YqU1j3iHuyDT31Cp
