### PR TITLE
Codex adapter: a fourth harness behind the same seam (v0.11.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,12 @@ OPENCLAW_BASE_URL=                         # OpenClaw gateway URL (default: http
 # Code's own login (`claude auth login`, or ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN
 # in this environment). No gateway-side credentials.
 CLAUDE_CODE_BIN=                           # Path to the `claude` binary (default: the one on PATH)
+
+# --- Codex (the `agent: "codex"` route) ---
+# The adapter drives `codex app-server` over stdio, on Codex's own login
+# (`codex login`, or auth written from OPENAI_API_KEY via `codex login
+# --with-api-key`). No gateway-side credentials. A bare OPENAI_API_KEY does not
+# authenticate the app-server by itself.
+CODEX_BIN=                                 # Path to the `codex` binary (default: the one on PATH)
+CODEX_HOME=                                # Codex config/credentials dir (default: ~/.codex)
+CODEX_IDLE_MS=30000                        # How long `codex app-server` lingers after the last call before it is killed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ Guidance for AI coding agents working in this repo. `CLAUDE.md` imports this fil
 
 ## What this is
 
-The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), and Claude Code (the Claude Agent SDK). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
+The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), Claude Code (the Claude Agent SDK), and Codex (`codex app-server` over stdio). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
 
 Orientation (Node >= 24, TypeScript ESM):
 
 - `server/routes/` — the `/v1` surface (responses, sessions, models, files)
-- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, and Claude Code adapters, and the JSONL worker protocol (`worker-protocol.ts`)
+- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, Claude Code, and Codex adapters (Codex: `codex-adapter.ts` + `codex-app-server.ts`, sharing the `idle-child.ts` spawn-with-idle-kill helper), and the JSONL worker protocol (`worker-protocol.ts`)
 - `server/workers/hermes_worker.py` — the Python side; imports Hermes directly. `npm run selftest:worker` checks it can reach Hermes without booting the server
 - `server/live-runs.ts` + `server/response-store.ts` — in-memory replayable event buffers for in-flight responses, and in-memory (TTL/count-bounded, lost on restart) response metadata; session metadata is never stored — session lists and transcripts project from the session's harness backend (Hermes' SessionDB, OpenClaw's history, ...)
 - `shared/types.ts` — the public API types; `test/` — the integration suite; `bruno/` — hand-poke collection (see `bruno/README.md`)
@@ -32,7 +32,7 @@ Both must pass. Never open a PR on a red or un-run suite — fix the code (or th
 
 The OpenClaw tests in the suite auto-skip when no local OpenClaw gateway is running. If your change touches the OpenClaw adapter or routing, start OpenClaw locally (`openclaw start`, port 18789) so those tests actually run. The adapter speaks OpenClaw's WebSocket gateway RPC and needs one thing from `~/.openclaw/openclaw.json`: its `gateway.auth.token` copied into `OPENCLAW_TOKEN` in your `.env`. See "Set up OpenClaw" in `README.md`.
 
-The Claude Code tests are NOT optional: a missing or logged-out Claude Code CLI fails the suite (Claude Code ships in the release images, so a green run must include it). Install the CLI and `claude auth login`; the tests run on that login.
+The Claude Code and Codex tests are NOT optional: a missing or logged-out CLI fails the suite (both ship in release images, so a green run must include them). Install the CLIs and log in (`claude auth login`; `codex login`, or `codex login --with-api-key`); the tests run on those logins and cost real usage.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ work back, and keeps the conversation going. The streaming contract and request
 shape are the same whatever agent is behind it — so client code doesn't change
 when the agent does.
 
-Today it routes to **Hermes** (the default), **OpenClaw**, and **Claude Code**:
-pick per request with the `agent` field.
+Today it routes to **Hermes** (the default), **OpenClaw**, **Claude Code**, and
+**Codex**: pick per request with the `agent` field.
 
 > Want the hosted API? Use [Agent37 Cloud](https://www.agent37.com/cloud). This
 > repo is the gateway service that powers an Agent37 agent.
@@ -130,6 +130,55 @@ Then route any turn to it with `"agent": "claude-code"`. The adapter runs the
 `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` (what `claude setup-token`
 prints) in the gateway's environment works instead of the interactive login.
 
+## How it talks to Codex
+
+The Codex adapter drives the [Codex CLI](https://developers.openai.com/codex)
+through `codex app-server` (newline-delimited JSON-RPC over stdio): one process
+spawned on demand that lingers a few seconds so a UI burst (list + read + turn)
+reuses it, then falls to zero idle RAM. Tools run with `approvalPolicy: "never"`
+and `sandbox: "danger-full-access"` (the instance is the customer's own box, as
+with the other harnesses). Text and reasoning deltas, tool calls and their
+results stream back as the same SSE events, and cancel is real
+(`turn/interrupt`).
+
+A gateway session id **is** a Codex thread id: the harness store owns the id, so
+the gateway resolves it before a turn begins — a turn with no `session_id`
+creates a Codex thread and returns its id; a turn with one resumes that thread
+(an id Codex doesn't know is a `400 validation_error`). Threads, history,
+rename, and delete all go through Codex's own store
+(`~/.codex/sessions/**/rollout-*.jsonl`); the gateway keeps no index.
+`GET /v1/sessions?agent=codex` lists that store (including threads started from
+a terminal in the workspace), `GET /v1/sessions/{id}` projects the transcript,
+`PATCH /v1/sessions/{id}` (rename) writes Codex's thread name, and
+`DELETE /v1/sessions/{id}` removes the thread.
+
+The gateway passes no credential: Codex runs on its own login. Until an account
+is configured, a turn fails with `auth_error` (and a hint to log in) and
+`GET /v1/health?agent=codex` reports `healthy: false`.
+
+`GET /v1/models?agent=codex` lists Codex's live model catalog (`owned_by:
+"openai"`); a turn's `model` is passed through and `reasoning_effort` maps onto
+Codex's efforts (`none`/`minimal` → `low`, `low`…`xhigh` by name, `max`, and
+`ultra` → Codex's multi-agent mode), clamped to the target model's advertised
+set. `usage` reports Codex's per-turn tokens (`cost_usd` is `null` — Codex
+bills its own account, not the gateway) and `context` its window occupancy.
+
+### Set up Codex
+
+Install Codex on the machine the gateway runs on and log in:
+
+```bash
+npm install -g @openai/codex
+codex login            # ChatGPT sign-in, or: codex login --with-api-key
+```
+
+Then route any turn to it with `"agent": "codex"`. The adapter runs the `codex`
+on `PATH`; set `CODEX_BIN` to pin a specific binary and `CODEX_HOME` to point at
+a specific config/credentials directory. A bare `OPENAI_API_KEY` in the
+environment does **not** authenticate Codex's app-server on its own — write it
+to `~/.codex/auth.json` with `codex login --with-api-key` (the Agent37 image's
+boot script does this from `OPENAI_API_KEY` automatically).
+
 ## Quickstart
 
 **Prerequisites:**
@@ -180,7 +229,7 @@ behind the host, which handles and forwards authentication.
 | Field | Type | Notes |
 | --- | --- | --- |
 | `input` | string, required | The message or task. |
-| `agent` | string | `hermes`, `openclaw`, or `claude-code`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
+| `agent` | string | `hermes`, `openclaw`, `claude-code`, or `codex`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
 | `session_id` | string | Continue a conversation. Omit to start a new one. |
 | `files` | string[] | Absolute paths of files to attach (write them first with `PUT /v1/files/content`). Appended to the message as an `[Attached files: …]` block; the agent reads them from disk. |
 | `stream` | boolean | `true` for Server-Sent Events; default `false`. |
@@ -235,9 +284,9 @@ running response as `active_response_id`.
 
 | Action | Endpoint |
 | --- | --- |
-| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
+| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code\|codex`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
 | Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history, context }` (`?agent=` to pick the harness; `context` is the session's last reported context window, null until a turn reports one) |
-| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title). A harness without an editable title answers `405 rename_unsupported`. |
+| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title; Codex stores it as the thread name). A harness without an editable title answers `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |
 
 `active_response_id` is the id of the `in_progress` response on the session, or
@@ -321,14 +370,14 @@ and stored paths assume the instance's home directory stays stable.
 
 | Action | Endpoint |
 | --- | --- |
-| Models a harness can run | `GET /v1/models` (configured default; add `?agent=hermes\|openclaw\|claude-code` to target one) |
-| Liveness + harness reachability | `GET /v1/health` (configured default; add `?agent=hermes\|openclaw\|claude-code` to target one) |
+| Models a harness can run | `GET /v1/models` (configured default; add `?agent=hermes\|openclaw\|claude-code\|codex` to target one) |
+| Liveness + harness reachability | `GET /v1/health` (configured default; add `?agent=hermes\|openclaw\|claude-code\|codex` to target one) |
 | Version | `GET /v1/version` |
 
 `GET /v1/health` reports on the gateway's configured default harness, or the
 one named by an optional `?agent=` query param. It returns `{ ok, agent,
-healthy }`, plus a legacy `hermes` field when Hermes is probed. For Claude Code,
-`healthy` also means it is logged in.
+healthy }`, plus a legacy `hermes` field when Hermes is probed. For Claude Code and
+Codex, `healthy` also means an account is configured.
 
 `GET /v1/models` returns the OpenAI list shape, so any OpenAI-compatible client
 works. It lists the models of one harness — the configured default, or the one
@@ -399,9 +448,9 @@ npm test          # integration suite against the real local Hermes worker/LLM
 state dir. Response tests call the local Hermes worker and configured LLM; the
 suite also covers replay, `session_busy`, cancel, history, and
 error bodies. The OpenClaw tests run against a local OpenClaw gateway and are
-skipped automatically when none is running; the Claude Code tests run the
-Claude Code CLI installed on this machine, on its own login, and are skipped
-when it isn't installed or logged in.
+skipped automatically when none is running; the Claude Code and Codex tests run the
+Claude Code and Codex CLIs installed on this machine, on their own logins, and
+fail the suite when either isn't installed or logged in.
 
 ### Poke it by hand (Bruno)
 
@@ -411,7 +460,8 @@ open that folder in Bruno, pick the **local** environment (`baseUrl`
 saves the `session_id` and response id into the environment, so *Continue
 Session*, *Cancel*, and *Delete Session* just work. The
 *(openclaw)* requests do the same for OpenClaw (start `openclaw` locally first),
-and the *(claude-code)* requests for Claude Code (installed and logged in).
+the *(claude-code)* requests for Claude Code, and the *(codex)* requests for
+Codex (each installed and logged in).
 *Upload File* writes a file via `PUT /v1/files/content` and saves its path for
 *Download File*.
 
@@ -421,8 +471,8 @@ All optional — see [`.env.example`](.env.example). Highlights: `PORT` (3737),
 `HOST` (0.0.0.0), `GATEWAY_DEFAULT_AGENT` (the harness a turn routes to when the
 request omits `agent`; `hermes` by default), `AGENT37_GATEWAY_HOME`
 (`~/.agent37-gateway`), the `HERMES_*` variables that locate the Hermes install,
-`OPENCLAW_BASE_URL` / `OPENCLAW_TOKEN` for the OpenClaw route, and
-`CLAUDE_CODE_BIN` for the Claude Code route.
+`OPENCLAW_BASE_URL` / `OPENCLAW_TOKEN` for the OpenClaw route, `CLAUDE_CODE_BIN` for the Claude Code route, and `CODEX_BIN` / `CODEX_HOME`
+(and `CODEX_IDLE_MS`) for the Codex route.
 
 ## Roadmap
 

--- a/bruno/environments/local.example.bru
+++ b/bruno/environments/local.example.bru
@@ -6,5 +6,7 @@ vars {
   openclawResponseId:
   claudeCodeSessionId:
   claudeCodeResponseId:
+  codexSessionId:
+  codexResponseId:
   uploadedFilePath:
 }

--- a/bruno/gateway/01 Health (codex).bru
+++ b/bruno/gateway/01 Health (codex).bru
@@ -1,0 +1,36 @@
+meta {
+  name: 01 Health (codex)
+  type: http
+  seq: 25
+}
+
+get {
+  url: {{baseUrl}}/v1/health?agent=codex
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: codex
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("reports Codex health", function () {
+    expect(res.body.ok).to.equal(true);
+    expect(res.body.agent).to.equal("codex");
+    expect(res.body.healthy).to.be.a("boolean");
+  });
+}
+
+docs {
+  Liveness + whether the Codex harness backend is reachable, selected
+  with `?agent=codex`. The gateway runs the Codex CLI through the
+  `codex app-server` on Codex's own login. `healthy` is false until this
+  machine has Codex installed (`codex` on PATH, or CODEX_BIN) and
+  logged in (`codex login`, or OPENAI_API_KEY (via `codex login --with-api-key`)
+  in the gateway's environment).
+}

--- a/bruno/gateway/03 List Models (codex).bru
+++ b/bruno/gateway/03 List Models (codex).bru
@@ -1,0 +1,36 @@
+meta {
+  name: 03 List Models (codex)
+  type: http
+  seq: 26
+}
+
+get {
+  url: {{baseUrl}}/v1/models?agent=codex
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: codex
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("is a Codex model list", function () {
+    expect(res.body.object).to.equal("list");
+    expect(res.body.agent).to.equal("codex");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The models the Codex harness can run, selected with
+  `?agent=codex` (`hermes` | `openclaw` | `claude-code` | `codex`). Omit the
+  filter (see "03 List Models") for the gateway's configured default. This is Codex's live model catalog (owned_by: openai);
+  when logged out it is still listed. Needs Codex installed on this machine
+  (`codex` on PATH, or CODEX_BIN): otherwise the gateway returns
+  503 agent_unavailable.
+}

--- a/bruno/gateway/04 Create Response (codex).bru
+++ b/bruno/gateway/04 Create Response (codex).bru
@@ -1,0 +1,57 @@
+meta {
+  name: 04 Create Response (codex)
+  type: http
+  seq: 27
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "What is the time now in IST?",
+    "agent": "codex",
+    "reasoning_effort": "low"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body) {
+    if (res.body.session_id) bru.setEnvVar("codexSessionId", res.body.session_id, { persist: true });
+    if (res.body.id) bru.setEnvVar("codexResponseId", res.body.id, { persist: true });
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("completed with text", function () {
+    expect(res.body.id).to.be.a("string");
+    expect(res.body.session_id).to.be.a("string");
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("codex");
+    expect(res.body.output_text).to.be.a("string");
+  });
+}
+
+docs {
+  Start a new Codex session. Pass `"agent": "codex"`: the gateway
+  runs the Codex CLI through `codex app-server` on Codex's own
+  login, spawning the process on demand.
+
+  The reply saves `codexSessionId` and `codexResponseId` to the
+  environment so the follow-up requests below can reuse them.
+
+  Codex must be installed on this machine (`codex` on PATH, or
+  CODEX_BIN) and logged in (`codex login`, or an OPENAI_API_KEY written to auth via
+  `codex login --with-api-key`).
+}

--- a/bruno/gateway/05 Continue Session (codex).bru
+++ b/bruno/gateway/05 Continue Session (codex).bru
@@ -1,0 +1,42 @@
+meta {
+  name: 05 Continue Session (codex)
+  type: http
+  seq: 28
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "session_id": "{{codexSessionId}}",
+    "input": "In one short sentence, what did I just ask you to say?",
+    "agent": "codex",
+    "reasoning_effort": "low"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("same session, completed", function () {
+    expect(res.body.session_id).to.equal(bru.getEnvVar("codexSessionId"));
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("codex");
+  });
+}
+
+docs {
+  Continue a Codex conversation. Reuses `codexSessionId` saved by
+  "04 Create Response (codex)". Always include `"agent": "codex"`
+  so the gateway routes the turn to the right backend.
+}

--- a/bruno/gateway/07 Create Response (streaming) (codex).bru
+++ b/bruno/gateway/07 Create Response (streaming) (codex).bru
@@ -1,0 +1,44 @@
+meta {
+  name: 07 Create Response (streaming) (codex)
+  type: http
+  seq: 29
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "Count from 1 to 5, one number per line.",
+    "agent": "codex",
+    "reasoning_effort": "low",
+    "stream": true
+  }
+}
+
+docs {
+  Streaming is agent-agnostic: pass `"agent": "codex"` alongside
+  `"stream": true` and the gateway streams the Codex turn back as
+  Server-Sent Events, exactly like the Hermes streaming request above:
+    response.created -> response.reasoning.delta / response.output_text.delta /
+    response.tool_call.* -> response.completed (or response.failed)
+
+  The Codex adapter reads `codex app-server`'s own partial-message
+  stream and re-emits it as gateway SSE, so there's no extra setup beyond a
+  Codex install that's logged in on this machine:
+    codex login   (or OPENAI_API_KEY via `codex login --with-api-key` in the
+    gateway's environment)
+
+  Bruno shows the assembled event stream in the Response pane. For raw frames:
+
+    curl -N localhost:3737/v1/responses \
+      -H 'content-type: application/json' \
+      -d '{"input":"hi","agent":"codex","stream":true}'
+}

--- a/bruno/gateway/09 List Sessions (codex).bru
+++ b/bruno/gateway/09 List Sessions (codex).bru
@@ -1,0 +1,35 @@
+meta {
+  name: 09 List Sessions (codex)
+  type: http
+  seq: 30
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions?agent=codex
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: codex
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("codex sessions", function () {
+    expect(res.body.agent).to.equal("codex");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The Codex chat sessions on this instance, selected with
+  `?agent=codex` (`hermes` | `openclaw` | `codex`), projected from
+  Codex's own thread store (`~/.codex/sessions/...`) as
+  `{ agent, data }`. Omitting `?agent=` falls back to the instance's default
+  harness: not a merged listing. Unknown agent values return a
+  400 validation_error.
+}

--- a/bruno/gateway/10 Get Session (codex history).bru
+++ b/bruno/gateway/10 Get Session (codex history).bru
@@ -1,0 +1,34 @@
+meta {
+  name: 10 Get Session (codex history)
+  type: http
+  seq: 31
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions/{{codexSessionId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("includes transcript history", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("codexSessionId"));
+    expect(res.body.agent).to.equal("codex");
+    expect(res.body.history).to.be.an("array");
+  });
+}
+
+docs {
+  The Codex session plus its transcript. Reuses `codexSessionId`
+  saved by "04 Create Response (codex)". History is projected on demand
+  from Codex's own transcript file
+  (`~/.codex/sessions/**/rollout-*.jsonl`): the gateway never duplicates
+  messages.
+
+  Codex must have written that transcript for history to be non-empty;
+  otherwise `history` comes back as an empty array.
+}

--- a/bruno/gateway/12 Delete Session (codex).bru
+++ b/bruno/gateway/12 Delete Session (codex).bru
@@ -1,0 +1,30 @@
+meta {
+  name: 12 Delete Session (codex)
+  type: http
+  seq: 32
+}
+
+delete {
+  url: {{baseUrl}}/v1/sessions/{{codexSessionId}}?agent=codex
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: codex
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("deleted", function () {
+    expect(res.body.deleted).to.equal(true);
+  });
+}
+
+docs {
+  Permanently remove the Codex session's transcript from Codex's
+  own store. Other sessions on the instance are untouched.
+}

--- a/bruno/gateway/15 Rename Session (codex).bru
+++ b/bruno/gateway/15 Rename Session (codex).bru
@@ -1,0 +1,47 @@
+meta {
+  name: 15 Rename Session (codex)
+  type: http
+  seq: 33
+}
+
+patch {
+  url: {{baseUrl}}/v1/sessions/{{codexSessionId}}?agent=codex
+  body: json
+  auth: none
+}
+
+params:query {
+  agent: codex
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "title": "Renamed from Bruno"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("renamed", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("codexSessionId"));
+    expect(res.body.renamed).to.equal(true);
+  });
+}
+
+docs {
+  Rename a Codex session by writing its title straight into Codex's
+  Code's own store (`PATCH /v1/sessions/:id?agent=codex`, body
+  `{ "title": "…" }` → `{ id, agent, renamed }`). The gateway calls Codex's
+  `thread/name/set`, which sets the
+  transcript that the session list reads back as its title. Supported on both
+  Hermes and Codex; harnesses without an editable title (OpenClaw)
+  return `405 rename_unsupported`. Reuses the `codexSessionId` saved by
+  "04 Create Response (codex)".
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent37-gateway",
-  "version": "0.10.0",
-  "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, or Claude Code.",
+  "version": "0.11.0",
+  "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, Claude Code, or Codex.",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/server/adapters/codex-adapter.ts
+++ b/server/adapters/codex-adapter.ts
@@ -1,0 +1,507 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  HermesMessage,
+  ReasoningEffort,
+  SessionMetadata,
+  SessionSummary,
+  TurnUsage,
+} from '../../shared/types.js';
+import type { AgentAdapter, AgentRunOptions, ContextUsage, StreamEvent } from './types.js';
+import { epochMillis } from './types.js';
+import { resolveWorkspaceDir } from '../paths.js';
+import { validationError } from '../errors.js';
+import { IdleChild } from './idle-child.js';
+import {
+  CodexClient,
+  CodexError,
+  spawnCodexClient,
+  type CodexItem,
+  type CodexModel,
+  type CodexThread,
+  type CodexTurn,
+  type CodexTurnError,
+  type ThreadTokenUsage,
+} from './codex-app-server.js';
+
+// The adapter drives Codex through `codex app-server` (JSON-RPC over stdio),
+// one process per burst of calls that lingers a few seconds so a UI burst
+// (list + read + turn) reuses it, then falls to zero RAM. A gateway session id
+// IS a Codex thread id: the harness store owns the id, so the responses route
+// calls `resolveSession` before a response begins (create-on-first-turn, or
+// verify an existing thread). Threads, history, rename, and delete all go
+// through Codex's own store — the gateway keeps no index. Credentials are
+// Codex's own (`codex login` on the box, or the image's boot script writing
+// auth from OPENAI_API_KEY); the gateway never reads them.
+
+const HEALTHY_TTL_MS = 60_000;
+const UNHEALTHY_TTL_MS = 10_000;
+// After turn/interrupt, how long Codex gets to close the turn before the child
+// is killed outright (interrupt is fast in practice; this is the backstop).
+const INTERRUPT_GRACE_MS = 5_000;
+// How long the app-server lingers after the last call before it is killed.
+const IDLE_MS = Number(process.env.CODEX_IDLE_MS) || 30_000;
+const LOGIN_HINT =
+  'Run `codex login --device-auth` in the instance terminal, or set OPENAI_API_KEY in the environment.';
+
+// Our public effort ladder → Codex's `turn/start.effort`. Codex advertises
+// low/medium/high/xhigh (plus max/ultra on its top models) and has no
+// none/minimal, so both floor to `low`; `ultra` is Codex's multi-agent mode
+// (our harness Ultra). The nominal value is clamped at call time to the target
+// model's advertised list (clampEffort) so a weaker model never rejects a turn.
+const EFFORT_MAP: Record<ReasoningEffort, string> = {
+  none: 'low',
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+  max: 'max',
+  ultra: 'ultra',
+};
+
+const EFFORT_LADDER = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+
+/** The Codex effort one reasoning level maps to (before per-model clamping).
+ *  Exported for the mapping tests. */
+export function codexEffort(effort: ReasoningEffort | null | undefined): string | undefined {
+  if (!effort) return undefined;
+  return EFFORT_MAP[effort];
+}
+
+/** Clamp a nominal effort to a model's advertised set: the value itself if
+ *  listed, else the highest listed value below it, else the model's lowest. */
+function clampEffort(nominal: string | undefined, supported: string[] | undefined): string | undefined {
+  if (!nominal || !supported || supported.length === 0) return nominal;
+  if (supported.includes(nominal)) return nominal;
+  const idx = EFFORT_LADDER.indexOf(nominal);
+  for (let i = idx - 1; i >= 0; i--) {
+    if (supported.includes(EFFORT_LADDER[i])) return EFFORT_LADDER[i];
+  }
+  for (const level of EFFORT_LADDER) if (supported.includes(level)) return level;
+  return nominal;
+}
+
+// The Codex thread-item types we surface as tool progress, mapped to a short
+// tool name and a one-line label. Everything else (reasoning, sub-agent
+// activity, plan updates) is handled elsewhere or ignored.
+function toolProgressOf(item: CodexItem): { tool: string; label?: string } | null {
+  const trim = (s?: string | null): string | undefined =>
+    s && s.trim() ? (s.length > 120 ? `${s.slice(0, 117)}...` : s) : undefined;
+  switch (item.type) {
+    case 'commandExecution':
+      return { tool: 'shell', label: trim(item.command) };
+    case 'fileChange':
+      return { tool: 'edit', label: trim(item.changes?.[0]?.path) };
+    case 'mcpToolCall':
+      return { tool: item.tool ? `${item.server ?? 'mcp'}.${item.tool}` : 'mcp', label: trim(item.tool) };
+    case 'webSearch':
+      return { tool: 'web_search', label: trim(item.query) };
+    default:
+      return null;
+  }
+}
+
+/** Map a failed turn's typed error to a worker error code + message. */
+function turnErrorEvent(error: CodexTurnError | null | undefined): StreamEvent {
+  const info = error?.codexErrorInfo;
+  const message = error?.message || 'Codex ended the turn on an error.';
+  const httpStatus =
+    info && typeof info === 'object'
+      ? Number(
+          (Object.values(info)[0] as { httpStatusCode?: number } | undefined)?.httpStatusCode ?? NaN,
+        )
+      : NaN;
+  const kind = typeof info === 'string' ? info : '';
+  const text = `${kind} ${message}`;
+
+  let code = 'agent_error';
+  if (kind === 'unauthorized' || httpStatus === 401 || /\b401\b|unauthor|not logged in|\blogin\b/i.test(text)) {
+    code = 'auth_error';
+  } else if (kind === 'usageLimitExceeded' || kind === 'sessionBudgetExceeded') {
+    code = 'quota_exhausted';
+  } else if (kind === 'serverOverloaded' || httpStatus === 429 || /\b429\b|rate.?limit/i.test(text)) {
+    code = 'rate_limit';
+  } else if (/\bmodel\b/i.test(text) && /not found|unknown|unsupported/i.test(text)) {
+    code = 'model_error';
+  }
+  return {
+    type: 'error',
+    code,
+    error: message,
+    ...(code === 'auth_error' ? { hint: LOGIN_HINT } : {}),
+  };
+}
+
+let pathBin: string | null = null;
+
+/** The `codex` binary: CODEX_BIN, else the one on PATH. Throws ENOENT when
+ *  neither exists — the gateway renders that as 503 agent_unavailable. */
+function requireCodexBin(): string {
+  let bin = process.env.CODEX_BIN?.trim();
+  if (!bin) {
+    if (!pathBin) {
+      try {
+        pathBin = execFileSync('which', ['codex'], { encoding: 'utf8' }).trim() || null;
+      } catch {
+        pathBin = null;
+      }
+    }
+    bin = pathBin ?? undefined;
+  }
+  if (!bin || !existsSync(bin)) {
+    const error: NodeJS.ErrnoException = new Error(
+      `Codex binary not found${bin ? ` at ${bin}` : ' on PATH'}. Install Codex or set CODEX_BIN.`,
+    );
+    error.code = 'ENOENT';
+    throw error;
+  }
+  return bin;
+}
+
+function workspaceCwd(): string {
+  const dir = resolveWorkspaceDir();
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** True when Codex has an account configured (`codex login`, or auth written
+ *  from an API key). Cheap subprocess, mirroring the Claude Code health probe. */
+function loggedIn(): Promise<boolean> {
+  let bin: string;
+  try {
+    bin = requireCodexBin();
+  } catch {
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve) => {
+    execFile(bin, ['login', 'status'], { timeout: 15_000 }, (error) => resolve(!error));
+  });
+}
+
+interface ActiveTurn {
+  client: CodexClient;
+  turnId?: string;
+  killTimer?: NodeJS.Timeout;
+}
+
+export class CodexAdapter implements AgentAdapter {
+  private readonly child = new IdleChild<CodexClient>({
+    idleMs: IDLE_MS,
+    start: () => spawnCodexClient(requireCodexBin(), workspaceCwd()),
+  });
+  private readonly activeTurns = new Map<string, ActiveTurn>();
+  private health: { at: number; ok: boolean } | null = null;
+  // model id → advertised reasoning efforts, refreshed by getModels; used to
+  // clamp a turn's effort without an extra model/list call.
+  private modelEfforts = new Map<string, string[]>();
+
+  // The responses route calls this before a response begins: create a thread
+  // (no id) or verify one (with id). The thread id becomes the session id.
+  async resolveSession(sessionId?: string): Promise<string> {
+    const client = await this.child.acquire();
+    try {
+      if (!sessionId) {
+        const thread = await client.startThread(workspaceCwd());
+        return thread.id;
+      }
+      try {
+        await client.ensureLoaded(sessionId);
+      } catch (error) {
+        if (error instanceof CodexError) {
+          throw validationError(`No Codex session with id '${sessionId}'.`, 'session_id');
+        }
+        throw error;
+      }
+      return sessionId;
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async *chatStream(sessionId: string, message: string, options?: AgentRunOptions): AsyncIterable<StreamEvent> {
+    requireCodexBin();
+    const client = await this.child.acquire();
+    const turn: ActiveTurn = { client };
+    this.activeTurns.set(sessionId, turn);
+
+    const tools = new Map<string, { tool: string; startedAt: number }>();
+    let usageInput = 0;
+    let usageOutput = 0;
+    let lastBreakdown: ThreadTokenUsage['last'] | undefined;
+    let contextWindow: number | null | undefined;
+    let finalTurn: CodexTurn | undefined;
+
+    try {
+      // A logged-out turn would otherwise spend ~15s retrying a 401; a cheap
+      // account check turns that into an immediate, documented auth_error.
+      const account = await client.readAccount();
+      if (!account) {
+        yield { type: 'error', code: 'auth_error', error: 'Codex has no account configured on this instance.', hint: LOGIN_HINT };
+        return;
+      }
+
+      await client.ensureLoaded(sessionId);
+
+      const settings = options?.settings;
+      const model = settings?.model ?? undefined;
+      const nominal = codexEffort(settings?.reasoningEffort);
+      const effort = clampEffort(nominal, model ? this.modelEfforts.get(model) : undefined);
+
+      for await (const n of client.runTurn(
+        sessionId,
+        message,
+        { effort, model, sandboxPolicy: { type: 'dangerFullAccess' } },
+        (turnId) => {
+          turn.turnId = turnId;
+        },
+      )) {
+        const params = n.params as Record<string, unknown>;
+        switch (n.method) {
+          case 'item/agentMessage/delta': {
+            const delta = params.delta as string;
+            if (delta) yield { type: 'text_delta', content: delta };
+            break;
+          }
+          case 'item/reasoning/summaryTextDelta':
+          case 'item/reasoning/textDelta': {
+            const delta = params.delta as string;
+            if (delta) yield { type: 'thinking_delta', content: delta };
+            break;
+          }
+          case 'item/started': {
+            const item = params.item as CodexItem;
+            const progress = toolProgressOf(item);
+            if (progress) {
+              tools.set(item.id, { tool: progress.tool, startedAt: Number(params.startedAtMs) || Date.now() });
+              yield { type: 'tool_progress', tool: progress.tool, status: 'running', label: progress.label };
+            }
+            break;
+          }
+          case 'item/completed': {
+            const item = params.item as CodexItem;
+            const started = tools.get(item.id);
+            if (!started) break;
+            tools.delete(item.id);
+            const failed = item.type === 'commandExecution' && typeof item.exitCode === 'number' && item.exitCode !== 0;
+            const duration = item.durationMs ?? (Number(params.completedAtMs) || Date.now()) - started.startedAt;
+            yield failed
+              ? { type: 'tool_progress', tool: started.tool, status: 'error' }
+              : { type: 'tool_progress', tool: started.tool, status: 'completed', duration };
+            break;
+          }
+          case 'thread/tokenUsage/updated': {
+            const usage = params.tokenUsage as ThreadTokenUsage;
+            if (usage?.last) {
+              usageInput += usage.last.inputTokens ?? 0;
+              usageOutput += usage.last.outputTokens ?? 0;
+              lastBreakdown = usage.last;
+              contextWindow = usage.modelContextWindow;
+            }
+            break;
+          }
+          case 'turn/completed':
+            finalTurn = params.turn as CodexTurn;
+            break;
+        }
+      }
+    } catch (error) {
+      // A dead child or an RPC failure mid-turn: fall through to the terminal
+      // handling below rather than throwing (driveResponse expects a stream).
+      if (!finalTurn) {
+        yield { type: 'error', code: 'agent_error', error: error instanceof Error ? error.message : 'Codex turn failed.' };
+        return;
+      }
+    } finally {
+      clearTimeout(turn.killTimer);
+      this.activeTurns.delete(sessionId);
+      this.child.release();
+    }
+
+    const usage: TurnUsage = { input_tokens: usageInput, output_tokens: usageOutput, cost_usd: null };
+    const context: ContextUsage | null =
+      lastBreakdown && contextWindow
+        ? { used_tokens: lastBreakdown.inputTokens + lastBreakdown.outputTokens, window_tokens: contextWindow }
+        : null;
+
+    if (!finalTurn) {
+      yield { type: 'error', code: 'agent_error', error: 'Codex ended the turn before it completed.' };
+    } else if (finalTurn.status === 'interrupted') {
+      yield { type: 'done', sessionId, usage: null, interrupted: true };
+    } else if (finalTurn.status === 'completed') {
+      yield { type: 'done', sessionId, usage, context, interrupted: false };
+    } else {
+      yield turnErrorEvent(finalTurn.error);
+    }
+  }
+
+  async interruptChat(sessionId: string): Promise<boolean> {
+    const turn = this.activeTurns.get(sessionId);
+    if (!turn || !turn.turnId) return false;
+    // Backstop: if the graceful interrupt doesn't close the turn, kill the child.
+    turn.killTimer = setTimeout(() => void this.child.stop(), INTERRUPT_GRACE_MS);
+    try {
+      await turn.client.interruptTurn(sessionId, turn.turnId);
+    } catch {
+      await this.child.stop();
+    }
+    return true;
+  }
+
+  async healthCheck(): Promise<boolean> {
+    if (this.health && Date.now() - this.health.at < (this.health.ok ? HEALTHY_TTL_MS : UNHEALTHY_TTL_MS)) {
+      return this.health.ok;
+    }
+    const ok = await loggedIn();
+    this.health = { at: Date.now(), ok };
+    return ok;
+  }
+
+  async listSessions(): Promise<SessionSummary[]> {
+    const client = await this.child.acquire();
+    try {
+      const threads = await client.listThreads();
+      return threads.map((thread: CodexThread) => ({
+        id: thread.id,
+        title: thread.name ?? null,
+        last_active: epochMillis(thread.updatedAt),
+        message_count: null,
+        preview: thread.preview?.trim() || null,
+      }));
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    const client = await this.child.acquire();
+    let thread: CodexThread;
+    try {
+      await client.ensureLoaded(sessionId);
+      thread = await client.readThread(sessionId);
+    } catch (error) {
+      // The harness owns existence: an unknown/deleted thread projects to [].
+      if (error instanceof CodexError) return [];
+      throw error;
+    } finally {
+      this.child.release();
+    }
+
+    const out: HermesMessage[] = [];
+    let pendingThinking = '';
+    for (const codexTurn of thread.turns ?? []) {
+      const created = epochMillis(codexTurn.startedAt) ?? 0;
+      for (const item of codexTurn.items ?? []) {
+        if (item.type === 'reasoning') {
+          const text = (item.summary ?? []).join('\n').trim();
+          if (text) pendingThinking = pendingThinking ? `${pendingThinking}\n\n${text}` : text;
+          continue;
+        }
+        if (item.type === 'userMessage') {
+          const text = (item.content ?? [])
+            .filter((c) => c.type === 'text')
+            .map((c) => c.text ?? '')
+            .join('');
+          if (!text.trim()) continue;
+          out.push({ id: item.id, task_id: sessionId, role: 'user', content: text, created_at: created });
+          pendingThinking = '';
+        } else if (item.type === 'agentMessage') {
+          const text = item.text ?? '';
+          if (!text.trim()) continue;
+          const previous = out.at(-1);
+          if (previous?.role === 'assistant') {
+            previous.content += `\n\n${text}`;
+            if (pendingThinking) previous.thinking = previous.thinking ? `${previous.thinking}\n\n${pendingThinking}` : pendingThinking;
+          } else {
+            out.push({
+              id: item.id,
+              task_id: sessionId,
+              role: 'assistant',
+              content: text,
+              thinking: pendingThinking || undefined,
+              created_at: created,
+            });
+          }
+          pendingThinking = '';
+        }
+      }
+    }
+    return out;
+  }
+
+  async getSessionMetadata(): Promise<SessionMetadata | null> {
+    // No route reads this today; Codex history carries no per-session cost.
+    return null;
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    const client = await this.child.acquire();
+    try {
+      await client.deleteThread(sessionId);
+      return true;
+    } catch (error) {
+      if (error instanceof CodexError) return false;
+      throw error;
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async renameSession(sessionId: string, title: string): Promise<boolean> {
+    const client = await this.child.acquire();
+    try {
+      await client.renameThread(sessionId, title);
+      return true;
+    } catch (error) {
+      if (error instanceof CodexError) return false;
+      throw error;
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async getModels(): Promise<AgentModelsResponse> {
+    const client = await this.child.acquire();
+    let models: CodexModel[];
+    try {
+      models = await client.listModels();
+    } finally {
+      this.child.release();
+    }
+    this.modelEfforts.clear();
+    let defaultModel: string | null = null;
+    for (const model of models) {
+      const efforts = (model.supportedReasoningEfforts ?? []).map((e) => e.reasoningEffort);
+      if (efforts.length) this.modelEfforts.set(model.id, efforts);
+      if (model.isDefault) defaultModel = model.id;
+    }
+    return {
+      defaultModel,
+      activeProvider: 'openai',
+      groups: [
+        {
+          provider: 'openai',
+          models: models.map((model) => ({
+            id: model.id,
+            label: model.displayName || model.id,
+            source: 'catalog',
+            provider: 'openai',
+            isCurrentDefault: model.isDefault,
+          })),
+        },
+      ],
+    };
+  }
+
+  async getDefaults(): Promise<AgentDefaults> {
+    return { provider: 'openai', model: null, baseUrl: null, apiMode: null, reasoningEffort: null, showReasoning: true };
+  }
+
+  async stop(): Promise<void> {
+    for (const turn of this.activeTurns.values()) clearTimeout(turn.killTimer);
+    this.activeTurns.clear();
+    await this.child.stop();
+  }
+}

--- a/server/adapters/codex-app-server.ts
+++ b/server/adapters/codex-app-server.ts
@@ -301,12 +301,17 @@ export class CodexClient {
     onTurnId: (turnId: string) => void,
   ): AsyncIterable<Notification> {
     const queue = new AsyncQueue<Notification>();
+    let turnId: string | undefined;
     // Watchdog: a turn that goes silent (no notification) for too long is
-    // treated as stalled and the stream is ended, releasing the session lock.
+    // treated as stalled — interrupt the backend turn (so its tools/file edits
+    // stop) and end the stream, releasing the session lock.
     let idleTimer: NodeJS.Timeout | undefined;
     const resetIdle = (): void => {
       clearTimeout(idleTimer);
-      idleTimer = setTimeout(() => queue.end(), TURN_IDLE_MS);
+      idleTimer = setTimeout(() => {
+        if (turnId) void this.interruptTurn(threadId, turnId).catch(() => {});
+        queue.end();
+      }, TURN_IDLE_MS);
       idleTimer.unref();
     };
     const unsubscribe = this.onNotification((n) => {
@@ -329,7 +334,7 @@ export class CodexClient {
         ...(opts.effort ? { effort: opts.effort } : {}),
         ...(opts.model ? { model: opts.model } : {}),
       });
-      const turnId = res.turn.id;
+      turnId = res.turn.id;
       onTurnId(turnId);
       for await (const n of queue) {
         // Only this turn's notifications (a shared thread can interleave).

--- a/server/adapters/codex-app-server.ts
+++ b/server/adapters/codex-app-server.ts
@@ -110,6 +110,15 @@ interface JsonRpcResponse {
 }
 
 const CLIENT_INFO = { name: 'agent37-gateway', title: 'Agent37 Gateway', version: '1' };
+// A control RPC (initialize, thread/*, model/list, account/read, turn/start's
+// ack) must answer promptly; without a cap a child that stays alive but never
+// replies would hang the HTTP response and hold the session lock open.
+const REQUEST_TIMEOUT_MS = Number(process.env.CODEX_REQUEST_TIMEOUT_MS) || 60_000;
+// A running turn streams notifications continuously (deltas, tool progress); if
+// none arrives for this long the turn is treated as stalled and the stream ends
+// so the session lock releases. Generous so a legitimately long silent tool run
+// isn't cut off.
+const TURN_IDLE_MS = Number(process.env.CODEX_TURN_IDLE_MS) || 300_000;
 
 export class CodexError extends Error {
   constructor(
@@ -180,17 +189,24 @@ export class CodexClient {
     // "never" and the sandbox is danger-full-access, so there is nothing to ask.
   }
 
-  request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+  request<T = unknown>(method: string, params: Record<string, unknown> = {}, timeoutMs = REQUEST_TIMEOUT_MS): Promise<T> {
     if (this.closed) return Promise.reject(new CodexError('codex app-server is not running'));
     const id = this.nextId++;
     return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new CodexError(`codex ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      timer.unref();
       this.pending.set(id, (res) => {
+        clearTimeout(timer);
         if (res.error) reject(new CodexError(res.error.message, res.error.code));
         else resolve(res.result as T);
       });
       try {
         this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
       } catch (error) {
+        clearTimeout(timer);
         this.pending.delete(id);
         reject(error);
       }
@@ -285,13 +301,25 @@ export class CodexClient {
     onTurnId: (turnId: string) => void,
   ): AsyncIterable<Notification> {
     const queue = new AsyncQueue<Notification>();
+    // Watchdog: a turn that goes silent (no notification) for too long is
+    // treated as stalled and the stream is ended, releasing the session lock.
+    let idleTimer: NodeJS.Timeout | undefined;
+    const resetIdle = (): void => {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => queue.end(), TURN_IDLE_MS);
+      idleTimer.unref();
+    };
     const unsubscribe = this.onNotification((n) => {
       if (n.method === 'app-server/exit') {
         queue.end();
         return;
       }
-      if (n.params.threadId === threadId) queue.push(n);
+      if (n.params.threadId === threadId) {
+        resetIdle();
+        queue.push(n);
+      }
     });
+    resetIdle();
     try {
       const res = await this.request<{ turn: CodexTurn }>('turn/start', {
         threadId,
@@ -310,6 +338,7 @@ export class CodexClient {
         if (n.method === 'turn/completed' && (n.params.turn as CodexTurn | undefined)?.id === turnId) break;
       }
     } finally {
+      clearTimeout(idleTimer);
       unsubscribe();
     }
   }

--- a/server/adapters/codex-app-server.ts
+++ b/server/adapters/codex-app-server.ts
@@ -1,0 +1,352 @@
+// A thin client for `codex app-server --listen stdio://`: newline-delimited
+// JSON-RPC 2.0 over the child's stdin/stdout. It spawns the process, does the
+// initialize handshake, correlates request/response by id, and fans server
+// notifications out to subscribers. The CodexAdapter builds the AgentAdapter
+// seam on top of this; nothing here is Agent37-specific.
+//
+// The app-server schema is versioned per Codex release and labelled
+// experimental. Only the ~dozen shapes used below are typed; regenerate them
+// with `codex app-server generate-json-schema` (v2) on every CODEX_VERSION bump
+// and re-check.
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createInterface, type Interface } from 'node:readline';
+import { AsyncQueue, type StartedChild } from './idle-child.js';
+
+// --- Protocol shapes (subset) -------------------------------------------------
+
+export type SandboxPolicy =
+  | { type: 'dangerFullAccess' }
+  | { type: 'externalSandbox'; networkAccess?: boolean }
+  | { type: 'readOnly'; networkAccess?: boolean };
+
+export interface CodexThread {
+  id: string;
+  name?: string | null;
+  preview?: string;
+  createdAt?: number;
+  updatedAt?: number;
+  turns?: CodexTurn[];
+}
+
+export interface CodexTurn {
+  id: string;
+  status: 'completed' | 'interrupted' | 'failed' | 'inProgress';
+  error?: CodexTurnError | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
+  durationMs?: number | null;
+  items?: CodexItem[];
+}
+
+export interface CodexTurnError {
+  message: string;
+  additionalDetails?: string | null;
+  // A string enum ("unauthorized", "badRequest", …) or a tagged object
+  // ({ responseStreamDisconnected: { httpStatusCode } }, …) or "other".
+  codexErrorInfo?: unknown;
+}
+
+export interface CodexItem {
+  type: string;
+  id: string;
+  // agentMessage
+  text?: string;
+  // userMessage
+  content?: Array<{ type: string; text?: string }>;
+  // reasoning
+  summary?: string[];
+  // commandExecution
+  command?: string;
+  exitCode?: number | null;
+  durationMs?: number | null;
+  // fileChange
+  changes?: Array<{ path?: string }>;
+  // mcpToolCall
+  server?: string;
+  tool?: string;
+  // webSearch
+  query?: string;
+}
+
+export interface CodexModel {
+  id: string;
+  model: string;
+  displayName: string;
+  isDefault: boolean;
+  hidden: boolean;
+  supportedReasoningEfforts?: Array<{ reasoningEffort: string }>;
+  defaultReasoningEffort?: string;
+}
+
+export interface CodexAccount {
+  type: 'apiKey' | 'chatgpt' | string;
+  email?: string | null;
+}
+
+export interface TokenUsageBreakdown {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  reasoningOutputTokens?: number;
+}
+
+export interface ThreadTokenUsage {
+  last: TokenUsageBreakdown;
+  total: TokenUsageBreakdown;
+  modelContextWindow?: number | null;
+}
+
+export interface Notification {
+  method: string;
+  params: Record<string, unknown> & { threadId?: string; turnId?: string };
+}
+
+interface JsonRpcResponse {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+const CLIENT_INFO = { name: 'agent37-gateway', title: 'Agent37 Gateway', version: '1' };
+
+export class CodexError extends Error {
+  constructor(
+    message: string,
+    readonly rpcCode?: number,
+  ) {
+    super(message);
+    this.name = 'CodexError';
+  }
+}
+
+export class CodexClient {
+  private nextId = 1;
+  private readonly pending = new Map<number, (res: JsonRpcResponse) => void>();
+  private readonly subscribers = new Set<(n: Notification) => void>();
+  // Threads this process has created or resumed. Tied to the client instance:
+  // when the idle child is killed and respawned, a fresh (empty) set forces a
+  // resume, so a continuing turn on a cold process reloads the rollout.
+  private readonly loaded = new Set<string>();
+  private readonly rl: Interface;
+  private closed = false;
+  readonly exited: Promise<void>;
+
+  constructor(private readonly child: ChildProcessWithoutNullStreams) {
+    this.rl = createInterface({ input: child.stdout });
+    this.rl.on('line', (line) => this.onLine(line));
+    this.exited = new Promise<void>((resolve) => {
+      child.once('exit', () => {
+        this.closed = true;
+        // Fail every awaiting request and close every open turn stream.
+        for (const resolver of this.pending.values()) {
+          resolver({ id: -1, error: { code: -1, message: 'codex app-server exited' } });
+        }
+        this.pending.clear();
+        for (const notify of this.subscribers) {
+          notify({ method: 'app-server/exit', params: {} });
+        }
+        this.subscribers.clear();
+        resolve();
+      });
+    });
+    // Draining stderr keeps the pipe from filling; the content is only useful
+    // when debugging a spawn that never handshakes.
+    child.stderr.on('data', () => {});
+  }
+
+  private onLine(line: string): void {
+    if (!line.trim()) return;
+    let message: JsonRpcResponse & Partial<Notification>;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (typeof message.id === 'number' && (message.result !== undefined || message.error !== undefined)) {
+      const resolver = this.pending.get(message.id);
+      if (resolver) {
+        this.pending.delete(message.id);
+        resolver(message as JsonRpcResponse);
+      }
+      return;
+    }
+    if (typeof message.method === 'string' && message.id === undefined) {
+      const notification: Notification = { method: message.method, params: (message.params ?? {}) as Notification['params'] };
+      for (const notify of this.subscribers) notify(notification);
+    }
+    // Server-initiated requests (approvals) never arrive: approvalPolicy is
+    // "never" and the sandbox is danger-full-access, so there is nothing to ask.
+  }
+
+  request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    if (this.closed) return Promise.reject(new CodexError('codex app-server is not running'));
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, (res) => {
+        if (res.error) reject(new CodexError(res.error.message, res.error.code));
+        else resolve(res.result as T);
+      });
+      try {
+        this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+      } catch (error) {
+        this.pending.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  private notify(method: string, params: Record<string, unknown> = {}): void {
+    if (this.closed) return;
+    this.child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+  }
+
+  onNotification(cb: (n: Notification) => void): () => void {
+    this.subscribers.add(cb);
+    return () => this.subscribers.delete(cb);
+  }
+
+  /** The handshake: initialize, then the `initialized` notification. */
+  async handshake(): Promise<void> {
+    await this.request('initialize', { clientInfo: CLIENT_INFO });
+    this.notify('initialized');
+  }
+
+  // --- High-level calls (typed to the subset the adapter uses) ---------------
+
+  async startThread(cwd: string): Promise<CodexThread> {
+    const res = await this.request<{ thread: CodexThread }>('thread/start', {
+      cwd,
+      approvalPolicy: 'never',
+      sandbox: 'danger-full-access',
+    });
+    this.loaded.add(res.thread.id);
+    return res.thread;
+  }
+
+  async resumeThread(threadId: string): Promise<void> {
+    await this.request('thread/resume', { threadId });
+    this.loaded.add(threadId);
+  }
+
+  /** Load a thread's rollout into this process if it isn't already, so a turn,
+   *  read, or rename can act on it. Throws CodexError when Codex has no rollout
+   *  for the id. */
+  async ensureLoaded(threadId: string): Promise<void> {
+    if (this.loaded.has(threadId)) return;
+    await this.resumeThread(threadId);
+  }
+
+  async listThreads(): Promise<CodexThread[]> {
+    const res = await this.request<{ data: CodexThread[] }>('thread/list', {
+      limit: 200,
+      sortKey: 'updated_at',
+      sortDirection: 'desc',
+      sourceKinds: ['cli', 'vscode', 'exec', 'appServer'],
+    });
+    return res.data ?? [];
+  }
+
+  async readThread(threadId: string): Promise<CodexThread> {
+    const res = await this.request<{ thread: CodexThread }>('thread/read', { threadId, includeTurns: true });
+    return res.thread;
+  }
+
+  async deleteThread(threadId: string): Promise<void> {
+    await this.request('thread/delete', { threadId });
+  }
+
+  async renameThread(threadId: string, name: string): Promise<void> {
+    await this.request('thread/name/set', { threadId, name });
+  }
+
+  async listModels(): Promise<CodexModel[]> {
+    const res = await this.request<{ data: CodexModel[] }>('model/list', { includeHidden: false });
+    return res.data ?? [];
+  }
+
+  async readAccount(): Promise<CodexAccount | null> {
+    const res = await this.request<{ account: CodexAccount | null }>('account/read', {});
+    return res.account ?? null;
+  }
+
+  async interruptTurn(threadId: string, turnId: string): Promise<void> {
+    await this.request('turn/interrupt', { threadId, turnId });
+  }
+
+  /** Start a turn and stream this turn's notifications until it completes. The
+   *  turn id is available via `onTurnId` once `turn/start` returns, so the
+   *  adapter can interrupt it. */
+  async *runTurn(
+    threadId: string,
+    input: string,
+    opts: { effort?: string; model?: string; sandboxPolicy: SandboxPolicy },
+    onTurnId: (turnId: string) => void,
+  ): AsyncIterable<Notification> {
+    const queue = new AsyncQueue<Notification>();
+    const unsubscribe = this.onNotification((n) => {
+      if (n.method === 'app-server/exit') {
+        queue.end();
+        return;
+      }
+      if (n.params.threadId === threadId) queue.push(n);
+    });
+    try {
+      const res = await this.request<{ turn: CodexTurn }>('turn/start', {
+        threadId,
+        input: [{ type: 'text', text: input }],
+        approvalPolicy: 'never',
+        sandboxPolicy: opts.sandboxPolicy,
+        ...(opts.effort ? { effort: opts.effort } : {}),
+        ...(opts.model ? { model: opts.model } : {}),
+      });
+      const turnId = res.turn.id;
+      onTurnId(turnId);
+      for await (const n of queue) {
+        // Only this turn's notifications (a shared thread can interleave).
+        if (n.params.turnId && n.params.turnId !== turnId) continue;
+        yield n;
+        if (n.method === 'turn/completed' && (n.params.turn as CodexTurn | undefined)?.id === turnId) break;
+      }
+    } finally {
+      unsubscribe();
+    }
+  }
+
+  kill(): void {
+    this.closed = true;
+    try {
+      this.child.kill('SIGKILL');
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/** Spawn `codex app-server`, complete the handshake, and return a started child
+ *  for the IdleChild pool. Throws (with `.code = 'ENOENT'`) when the binary is
+ *  missing, so the adapter can surface `503 agent_unavailable`. */
+export async function spawnCodexClient(bin: string, cwd: string): Promise<StartedChild<CodexClient>> {
+  let child: ChildProcessWithoutNullStreams;
+  try {
+    child = spawn(bin, ['app-server', '--listen', 'stdio://'], {
+      cwd,
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    throw error;
+  }
+  const spawnError = new Promise<never>((_, reject) => {
+    child.once('error', reject);
+  });
+  const client = new CodexClient(child);
+  try {
+    await Promise.race([client.handshake(), spawnError]);
+  } catch (error) {
+    client.kill();
+    throw error;
+  }
+  return { value: client, kill: () => client.kill(), exited: client.exited };
+}

--- a/server/adapters/idle-child.ts
+++ b/server/adapters/idle-child.ts
@@ -27,6 +27,10 @@ export class IdleChild<T> {
   private starting: Promise<T> | null = null;
   private inflight = 0;
   private idleTimer: NodeJS.Timeout | null = null;
+  // Bumped on every stop(); a spawn in flight when stop() ran checks this and
+  // kills the freshly-started child instead of publishing it, so teardown can't
+  // be outraced by a pending start (a subsequent acquire() starts a new one).
+  private generation = 0;
 
   constructor(private readonly opts: { idleMs: number; start: () => Promise<StartedChild<T>> }) {}
 
@@ -40,9 +44,16 @@ export class IdleChild<T> {
     try {
       if (this.current) return this.current.value;
       if (!this.starting) {
+        const startGeneration = this.generation;
         this.starting = this.opts
           .start()
           .then((started) => {
+            // A stop() landed while we were spawning: don't publish a child the
+            // teardown already reported killing — kill it here instead.
+            if (startGeneration !== this.generation) {
+              started.kill();
+              throw new Error('idle child start aborted by stop()');
+            }
             this.current = started;
             started.exited.then(() => {
               if (this.current === started) this.current = null;
@@ -66,8 +77,10 @@ export class IdleChild<T> {
     this.armIdle();
   }
 
-  /** Kill the child immediately and drop all in-flight accounting. */
+  /** Kill the child immediately and drop all in-flight accounting. A spawn in
+   *  flight is invalidated (see `generation`) so it can't republish a child. */
   async stop(): Promise<void> {
+    this.generation++;
     this.inflight = 0;
     this.killNow();
   }

--- a/server/adapters/idle-child.ts
+++ b/server/adapters/idle-child.ts
@@ -13,6 +13,10 @@
 // between spawns (the integration tests flip CODEX_HOME / *_BIN) is honoured
 // without any explicit snapshot bookkeeping.
 
+// Signals that a spawn resolved after a stop() invalidated it, so acquire()
+// should discard it and start a fresh child rather than hand back a dead one.
+const INVALIDATED = Symbol('idle-child-invalidated');
+
 export interface StartedChild<T> {
   /** The protocol client the adapter talks to. */
   value: T;
@@ -24,7 +28,7 @@ export interface StartedChild<T> {
 
 export class IdleChild<T> {
   private current: StartedChild<T> | null = null;
-  private starting: Promise<T> | null = null;
+  private starting: Promise<T | typeof INVALIDATED> | null = null;
   private inflight = 0;
   private idleTimer: NodeJS.Timeout | null = null;
   // Bumped on every stop(); a spawn in flight when stop() ran checks this and
@@ -42,29 +46,34 @@ export class IdleChild<T> {
     this.clearIdle();
     this.inflight++;
     try {
-      if (this.current) return this.current.value;
-      if (!this.starting) {
-        const startGeneration = this.generation;
-        this.starting = this.opts
-          .start()
-          .then((started) => {
-            // A stop() landed while we were spawning: don't publish a child the
-            // teardown already reported killing — kill it here instead.
-            if (startGeneration !== this.generation) {
-              started.kill();
-              throw new Error('idle child start aborted by stop()');
-            }
-            this.current = started;
-            started.exited.then(() => {
-              if (this.current === started) this.current = null;
+      for (;;) {
+        if (this.current) return this.current.value;
+        if (!this.starting) {
+          const startGeneration = this.generation;
+          this.starting = this.opts
+            .start()
+            .then((started) => {
+              // A stop() landed while we were spawning: don't publish a child
+              // the teardown already reported killing. Kill it and signal
+              // INVALIDATED so a waiter starts a fresh one instead of failing.
+              if (startGeneration !== this.generation) {
+                started.kill();
+                return INVALIDATED;
+              }
+              this.current = started;
+              started.exited.then(() => {
+                if (this.current === started) this.current = null;
+              });
+              return started.value;
+            })
+            .finally(() => {
+              this.starting = null;
             });
-            return started.value;
-          })
-          .finally(() => {
-            this.starting = null;
-          });
+        }
+        const result = await this.starting;
+        if (result !== INVALIDATED) return result;
+        // Invalidated by a stop() during startup — loop and spawn a fresh child.
       }
-      return await this.starting;
     } catch (error) {
       this.inflight--;
       throw error;

--- a/server/adapters/idle-child.ts
+++ b/server/adapters/idle-child.ts
@@ -1,0 +1,135 @@
+// A lazily-spawned child process with reference-counted use and an idle timer.
+//
+// Two harnesses share it with different timeouts: Codex spawns `codex
+// app-server` per call and lingers ~30s so a UI burst (list + read + turn)
+// reuses one process, then falls to zero RAM; OpenCode keeps `opencode serve`
+// resident and kills it after ~10 idle minutes. In both cases a turn in flight
+// blocks the kill, the idle timer is `unref()`'d so it never holds the event
+// loop open, and `stop()` (test teardown / SIGTERM) kills immediately.
+//
+// The generic parameter T is the per-spawn protocol client the adapter builds
+// on the child (a JSON-RPC client for Codex, an HTTP client for OpenCode). The
+// `start` closure reads the environment fresh on every spawn, so an env change
+// between spawns (the integration tests flip CODEX_HOME / *_BIN) is honoured
+// without any explicit snapshot bookkeeping.
+
+export interface StartedChild<T> {
+  /** The protocol client the adapter talks to. */
+  value: T;
+  /** Kill the child now (SIGKILL-strength; must be prompt). */
+  kill: () => void;
+  /** Resolves when the child has exited for any reason. */
+  exited: Promise<void>;
+}
+
+export class IdleChild<T> {
+  private current: StartedChild<T> | null = null;
+  private starting: Promise<T> | null = null;
+  private inflight = 0;
+  private idleTimer: NodeJS.Timeout | null = null;
+
+  constructor(private readonly opts: { idleMs: number; start: () => Promise<StartedChild<T>> }) {}
+
+  /** Ensure a live child, cancel any pending idle-kill, and count one use. The
+   *  caller MUST call `release()` once (a `try/finally`). Throws if the spawn
+   *  fails (e.g. ENOENT for a missing binary) — the adapter lets that surface
+   *  as `503 agent_unavailable`. */
+  async acquire(): Promise<T> {
+    this.clearIdle();
+    this.inflight++;
+    try {
+      if (this.current) return this.current.value;
+      if (!this.starting) {
+        this.starting = this.opts
+          .start()
+          .then((started) => {
+            this.current = started;
+            started.exited.then(() => {
+              if (this.current === started) this.current = null;
+            });
+            return started.value;
+          })
+          .finally(() => {
+            this.starting = null;
+          });
+      }
+      return await this.starting;
+    } catch (error) {
+      this.inflight--;
+      throw error;
+    }
+  }
+
+  /** Release one use. When the last use ends, arm the idle-kill timer. */
+  release(): void {
+    if (this.inflight > 0) this.inflight--;
+    this.armIdle();
+  }
+
+  /** Kill the child immediately and drop all in-flight accounting. */
+  async stop(): Promise<void> {
+    this.inflight = 0;
+    this.killNow();
+  }
+
+  /** True while a child is alive. */
+  get running(): boolean {
+    return this.current !== null;
+  }
+
+  private armIdle(): void {
+    this.clearIdle();
+    if (this.inflight > 0 || !this.current) return;
+    this.idleTimer = setTimeout(() => {
+      if (this.inflight === 0) this.killNow();
+    }, this.opts.idleMs);
+    this.idleTimer.unref();
+  }
+
+  private clearIdle(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  private killNow(): void {
+    this.clearIdle();
+    const child = this.current;
+    this.current = null;
+    if (child) child.kill();
+  }
+}
+
+/** A minimal push/pull async queue: producers `push`, one consumer iterates,
+ *  `end()` closes the iterator. Used to hand app-server notifications to a
+ *  streaming turn. */
+export class AsyncQueue<T> {
+  private items: T[] = [];
+  private resolvers: ((result: IteratorResult<T>) => void)[] = [];
+  private ended = false;
+
+  push(item: T): void {
+    if (this.ended) return;
+    const resolve = this.resolvers.shift();
+    if (resolve) resolve({ value: item, done: false });
+    else this.items.push(item);
+  }
+
+  end(): void {
+    if (this.ended) return;
+    this.ended = true;
+    let resolve;
+    while ((resolve = this.resolvers.shift())) resolve({ value: undefined as never, done: true });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: (): Promise<IteratorResult<T>> => {
+        if (this.items.length) return Promise.resolve({ value: this.items.shift() as T, done: false });
+        if (this.ended) return Promise.resolve({ value: undefined as never, done: true });
+        return new Promise((resolve) => this.resolvers.push(resolve));
+      },
+    };
+  }
+}

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -57,6 +57,16 @@ export interface StreamEvent {
  * the backend(s) it was provisioned with.)
  */
 export interface AgentAdapter {
+  /** Resolve the session id a turn will run on, BEFORE the response begins.
+   *  Harnesses whose own store mints the id (Codex threads, OpenCode sessions)
+   *  implement this: with no id it creates a session and returns the native id;
+   *  with an id it verifies the session exists and returns it, or throws
+   *  `validationError(..., 'session_id')`. The responses route awaits it before
+   *  `beginResponse()` (the id rides in `response.created`, and a stream event
+   *  cannot change the HTTP status). Harnesses that accept any key omit it, and
+   *  the gateway keeps minting ids for them. */
+  resolveSession?(sessionId?: string): Promise<string>;
+
   /** Stream a single turn. The async iterable ends after a `done` or `error`. */
   chatStream(
     sessionId: string,

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -1,6 +1,7 @@
 import { HermesWorkerAdapter } from './adapters/hermes-worker.js';
 import { OpenClawAdapter } from './adapters/openclaw-adapter.js';
 import { ClaudeCodeAdapter } from './adapters/claude-code-adapter.js';
+import { CodexAdapter } from './adapters/codex-adapter.js';
 import type { AgentAdapter } from './adapters/types.js';
 import { resolveConfiguredDefaultAgent, SUPPORTED_AGENTS, type AgentType } from '../shared/types.js';
 import { optionalEnum, queryParam } from './errors.js';
@@ -14,6 +15,7 @@ const registry: Record<AgentType, GatewayAdapter> = {
   hermes: new HermesWorkerAdapter(),
   openclaw: new OpenClawAdapter(),
   'claude-code': new ClaudeCodeAdapter(),
+  codex: new CodexAdapter(),
 };
 
 export function getAdapter(agent: AgentType): GatewayAdapter {

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { adapter, getAdapter } from './agent.js';
 import { shutdownLiveRuns } from './live-runs.js';
 import { shutdownResponseStore } from './response-store.js';
 import { ensureGatewayStateDirs } from './paths.js';
+import { SUPPORTED_AGENTS } from '../shared/types.js';
 
 ensureGatewayStateDirs();
 
@@ -93,9 +94,7 @@ async function shutdown(reason: ShutdownReason, exitCode = 0): Promise<void> {
   shutdownResponseStore();
   const results = await Promise.allSettled([
     closeHttpServer(),
-    adapter.stop?.() ?? Promise.resolve(),
-    getAdapter('openclaw').stop?.() ?? Promise.resolve(),
-    getAdapter('claude-code').stop?.() ?? Promise.resolve(),
+    ...SUPPORTED_AGENTS.map((name) => getAdapter(name).stop?.() ?? Promise.resolve()),
   ]);
   for (const result of results) {
     if (result.status === 'rejected') console.error(result.reason);

--- a/server/routes/responses.ts
+++ b/server/routes/responses.ts
@@ -5,8 +5,8 @@ import {
   RESPONSE_MODES,
   SUPPORTED_AGENTS,
 } from '../../shared/types.js';
-import { isRecord, optionalEnum, responseNotFound, validationError } from '../errors.js';
-import { INSTANCE_DEFAULT_AGENT } from '../agent.js';
+import { GatewayError, gatewayErrorFromWorker, isRecord, optionalEnum, responseNotFound, validationError } from '../errors.js';
+import { getAdapter, INSTANCE_DEFAULT_AGENT } from '../agent.js';
 import { resolveHomeAwarePath } from '../paths.js';
 import { initSSE, writeStreamEvent } from '../sse.js';
 import { attach, hasRun } from '../live-runs.js';
@@ -127,13 +127,25 @@ responsesRouter.post('/', async (req, res, next) => {
   let begun;
   let request: ResponseRequest;
   let stream: boolean;
+  let agent: string | undefined;
   try {
     const parsed = parseResponseBody(req.body);
     request = parsed.request;
     stream = parsed.stream;
+    agent = request.agent;
+    // Harnesses whose store owns the id (Codex, OpenCode) resolve it here,
+    // before the response begins: create-on-first-turn, or verify an existing
+    // one. A missing binary throws ENOENT → 503 agent_unavailable (headers are
+    // not sent yet); a bad client-supplied id throws validationError → 400.
+    const adapter = getAdapter(request.agent);
+    if (adapter.resolveSession) {
+      request.sessionId = await adapter.resolveSession(request.sessionId);
+    }
     begun = beginResponse(request);
   } catch (error) {
-    return next(error);
+    return next(
+      error instanceof GatewayError ? error : gatewayErrorFromWorker(error, 'Could not create session', agent),
+    );
   }
 
   if (stream) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -12,14 +12,14 @@
 
 /** `max` is the top plain thinking level; `ultra` is the harness's own Ultra
  *  mode — top thinking plus agentic orchestration (Hermes `ultra`, OpenClaw
- *  `ultra`, Claude Code ultracode). */
+ *  `ultra`, Claude Code ultracode, Codex's multi-agent mode). */
 export const REASONING_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
 export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
 /** Response modes. `chat` runs one turn; `goal` is reserved for a fast-follow. */
 export const RESPONSE_MODES = ['chat', 'goal'] as const;
 
-export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code'] as const;
+export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code', 'codex'] as const;
 export type AgentType = (typeof SUPPORTED_AGENTS)[number];
 export const DEFAULT_AGENT: AgentType = 'hermes';
 

--- a/test/agent-unavailable.integration.test.ts
+++ b/test/agent-unavailable.integration.test.ts
@@ -13,6 +13,7 @@ let base: string;
 before(async () => {
   process.env.OPENCLAW_BASE_URL = 'http://127.0.0.1:59321';
   process.env.CLAUDE_CODE_BIN = '/nonexistent/claude';
+  process.env.CODEX_BIN = '/nonexistent/codex';
   server = await startTestServer();
   base = server.base;
 });
@@ -60,5 +61,29 @@ test('a claude-code request without the claude binary fails with agent_unavailab
   assert.equal(body.error?.code, 'agent_unavailable');
 
   const health = (await (await fetch(`${base}/v1/health?agent=claude-code`)).json()) as { healthy: boolean };
+  assert.equal(health.healthy, false);
+});
+
+test('a codex request without the codex binary fails with agent_unavailable', async () => {
+  const models = await fetch(`${base}/v1/models?agent=codex`);
+  assert.equal(models.status, 503);
+  const modelsBody = (await models.json()) as { error: { code: string; message: string } };
+  assert.equal(modelsBody.error.code, 'agent_unavailable');
+  assert.match(modelsBody.error.message, /codex/);
+
+  // Codex resolves its session before the response begins, so a missing binary
+  // is caught while headers are still open: the turn is a real 503, not a
+  // 200 failed body (unlike Hermes/OpenClaw/Claude Code, which have no
+  // resolveSession and settle mid-stream).
+  const turn = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'codex', input: 'hello' }),
+  });
+  assert.equal(turn.status, 503);
+  const turnBody = (await turn.json()) as { error: { code: string } };
+  assert.equal(turnBody.error.code, 'agent_unavailable');
+
+  const health = (await (await fetch(`${base}/v1/health?agent=codex`)).json()) as { healthy: boolean };
   assert.equal(health.healthy, false);
 });

--- a/test/codex-nologin.integration.test.ts
+++ b/test/codex-nologin.integration.test.ts
@@ -1,0 +1,60 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startTestServer, postJson, type TestServer } from './test-helpers.js';
+
+// Point Codex at an empty CODEX_HOME so it has no account. A turn must settle
+// as a failed response with the documented auth_error and the login hint, and
+// health must be false. Unlike Claude Code, a bare OPENAI_API_KEY does NOT
+// authenticate Codex's app-server (it needs `codex login` / auth.json), so an
+// empty home is logged-out regardless of the environment. node:test isolates
+// each file in its own process, so this CODEX_HOME override doesn't leak.
+
+const codexMissing = await new Promise<false | string>((resolve) => {
+  execFile(process.env.CODEX_BIN?.trim() || 'codex', ['--version'], { timeout: 15_000 }, (error) => {
+    resolve(error ? 'no Codex CLI installed' : false);
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+let configDir: string;
+let previousHome: string | undefined;
+
+before(async () => {
+  previousHome = process.env.CODEX_HOME;
+  configDir = mkdtempSync(join(tmpdir(), 'a37gw-codex-nologin-'));
+  process.env.CODEX_HOME = configDir;
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+  if (previousHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = previousHome;
+  // Codex keeps writing into CODEX_HOME (a plugins clone) briefly after the
+  // child is killed, so a plain rmdir can race to ENOTEMPTY. Retry, and never
+  // fail the suite on temp-dir cleanup.
+  try {
+    rmSync(configDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  } catch {
+    // best effort — the OS reaps the temp dir
+  }
+});
+
+test('a codex turn without an account fails with auth_error', { skip: codexMissing }, async () => {
+  const failed = (await (await postJson(base, { agent: 'codex', input: 'hello', reasoning_effort: 'low' })).json()) as {
+    status: string;
+    error: { code: string; hint?: string } | null;
+  };
+  assert.equal(failed.status, 'failed');
+  assert.equal(failed.error?.code, 'auth_error');
+  assert.match(failed.error?.hint ?? '', /codex login/);
+
+  const health = (await (await fetch(`${base}/v1/health?agent=codex`)).json()) as { healthy: boolean };
+  assert.equal(health.healthy, false);
+});

--- a/test/codex.integration.test.ts
+++ b/test/codex.integration.test.ts
@@ -1,0 +1,200 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+// --- Codex adapter. Like Claude Code (and unlike the optional OpenClaw probe),
+// Codex ships in a release image, so a missing or logged-out CLI FAILS the
+// suite via the gate test below rather than silently skipping. Turns run on
+// Codex's own login and cost real usage.
+
+const codexSkip = await new Promise<false | string>((resolve) => {
+  execFile(process.env.CODEX_BIN?.trim() || 'codex', ['login', 'status'], { timeout: 15_000 }, (error) => {
+    if (!error) resolve(false);
+    else resolve('Codex is not installed or not logged in');
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+interface ResponseBody {
+  id: string;
+  session_id: string;
+  status: string;
+  agent: string;
+  output_text: string;
+  usage: { input_tokens: number; output_tokens: number; cost_usd: number | null } | null;
+  context: { used_tokens: number; window_tokens: number } | null;
+  error: { code: string; message: string; hint?: string } | null;
+}
+
+async function jsonOk<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  assert.equal(res.status, 200, JSON.stringify(body));
+  return body as T;
+}
+
+test('Codex CLI is installed and logged in (required — its tests must run)', () => {
+  assert.equal(codexSkip, false, `Codex tests did not run: ${codexSkip}. Install Codex and \`codex login\` — a green suite must include this harness.`);
+});
+
+test('codex responses complete, resume, and manage sessions on Codex\'s own store', { skip: codexSkip }, async () => {
+  const marker = `codex-marker-${Date.now()}`;
+  const created = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'codex',
+      input: `Remember this marker: ${marker}. Reply with just OK.`,
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(created.status, 'completed', JSON.stringify(created.error));
+  assert.equal(created.agent, 'codex');
+  // A Codex thread id is a UUID; the harness store owns it, so the client can't
+  // bring its own on the first turn (see the made-up-id case below).
+  assert.match(created.session_id, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  assert.ok(created.output_text.trim().length > 0);
+  assert.ok(created.usage && created.usage.output_tokens > 0);
+  assert.equal(created.usage.cost_usd, null); // Codex reports no USD cost.
+  assert.ok(created.context && created.context.used_tokens > 0);
+  assert.ok(created.context.window_tokens >= created.context.used_tokens);
+
+  assert.deepEqual(await jsonOk(await fetch(`${base}/v1/health?agent=codex`)), {
+    ok: true,
+    agent: 'codex',
+    healthy: true,
+  });
+
+  // A known session id resumes the thread, so the marker is recalled.
+  const recalled = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'codex',
+      session_id: created.session_id,
+      input: 'Reply with just the marker I asked you to remember.',
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(recalled.status, 'completed', JSON.stringify(recalled.error));
+  assert.equal(recalled.session_id, created.session_id);
+  assert.ok(recalled.output_text.includes(marker), recalled.output_text);
+
+  // History projects Codex's own thread; reads name `?agent=codex`.
+  const session = await jsonOk<{ history: { role: string; content: string; created_at: number }[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=codex`),
+  );
+  assert.ok(session.history.some((m) => m.role === 'user' && m.content.includes(marker)));
+  assert.ok(session.history.some((m) => m.role === 'assistant'));
+
+  // The list is Codex's own thread list for this workspace.
+  const list = await jsonOk<{ agent: string; data: Array<{ id: string; title: string | null; last_active: number | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=codex`),
+  );
+  assert.equal(list.agent, 'codex');
+  const row = list.data.find((s) => s.id === created.session_id);
+  assert.ok(row, 'created session appears in the list');
+  assert.equal(typeof row.last_active, 'number');
+
+  // Rename writes Codex's thread name; it reads back as the row title.
+  const title = `integration-rename-${marker}`;
+  const rename = await jsonOk<{ renamed: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=codex`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    }),
+  );
+  assert.equal(rename.renamed, true);
+  const renamedList = await jsonOk<{ data: Array<{ id: string; title: string | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=codex`),
+  );
+  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.title, title);
+
+  // Models are Codex's live catalog.
+  const models = await jsonOk<{ agent: string; data: Array<{ id: string; owned_by: string; source: string }> }>(
+    await fetch(`${base}/v1/models?agent=codex`),
+  );
+  assert.equal(models.agent, 'codex');
+  assert.ok(models.data.length > 0);
+  assert.ok(models.data.every((m) => m.owned_by === 'openai' && m.source === 'catalog'));
+
+  const stream = await postJson(base, {
+    agent: 'codex',
+    input: 'Reply with exactly this word: PONG',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(stream.status, 200);
+  const events = await new SseReader(stream).drain();
+  assert.equal(events[0]?.event, 'response.created');
+  assert.ok(events.some((event) => event.event === 'response.output_text.delta'));
+  assert.equal(events.at(-1)?.event, 'response.completed');
+  await fetch(`${base}/v1/sessions/${events[0]?.data.session_id as string}?agent=codex`, { method: 'DELETE' });
+
+  // Delete removes the thread; it leaves the list and its history projects empty.
+  const deleted = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=codex`, { method: 'DELETE' }),
+  );
+  assert.equal(deleted.deleted, true);
+  const gone = await jsonOk<{ history: unknown[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=codex`),
+  );
+  assert.deepEqual(gone.history, []);
+
+  // Deleting an unknown thread is not an error.
+  const unknown = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/00000000-0000-0000-0000-000000000000?agent=codex`, { method: 'DELETE' }),
+  );
+  assert.equal(unknown.deleted, false);
+
+  // A client cannot invent a session_id on codex: an unknown id is a 400.
+  const madeUp = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'codex', session_id: 'not-a-real-thread', input: 'hello' }),
+  });
+  assert.equal(madeUp.status, 400);
+  const madeUpBody = (await madeUp.json()) as { error: { code: string; param?: string } };
+  assert.equal(madeUpBody.error.code, 'validation_error');
+  assert.equal(madeUpBody.error.param, 'session_id');
+});
+
+test('an in-flight codex turn can be cancelled', { skip: codexSkip }, async () => {
+  const slow = await postJson(base, {
+    agent: 'codex',
+    input: 'Run the shell command `sleep 30` and then reply with the word done.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(slow.status, 200);
+
+  const reader = new SseReader(slow);
+  const opening = await reader.until((event) => event.event !== 'response.created');
+  const created = opening.find((event) => event.event === 'response.created');
+  assert.ok(created);
+  const responseId = created.data.id as string;
+  const sessionId = created.data.session_id as string;
+
+  const cancel = await fetch(`${base}/v1/responses/${responseId}/cancel`, { method: 'POST' });
+  assert.equal(cancel.status, 200);
+  await reader.drain();
+
+  const settled = await jsonOk<{ active_response_id: string | null }>(
+    await fetch(`${base}/v1/sessions/${sessionId}?agent=codex`),
+  );
+  assert.equal(settled.active_response_id, null);
+  const replay = await new SseReader(await fetch(`${base}/v1/responses/${responseId}/stream`)).drain();
+  assert.equal(replay.at(-1)?.event, 'response.completed');
+  // A cancelled turn reports no usage or context.
+  assert.equal(replay.at(-1)?.data.usage, null);
+
+  await fetch(`${base}/v1/sessions/${sessionId}?agent=codex`, { method: 'DELETE' });
+});

--- a/test/default-agent.test.ts
+++ b/test/default-agent.test.ts
@@ -7,5 +7,6 @@ test('GATEWAY_DEFAULT_AGENT resolution: unset falls back, known passes, garbage 
   assert.equal(resolveConfiguredDefaultAgent('  '), DEFAULT_AGENT);
   assert.equal(resolveConfiguredDefaultAgent('openclaw'), 'openclaw');
   assert.equal(resolveConfiguredDefaultAgent('claude-code'), 'claude-code');
-  assert.throws(() => resolveConfiguredDefaultAgent('opencalw'), /must be one of: hermes, openclaw, claude-code/);
+  assert.equal(resolveConfiguredDefaultAgent('codex'), 'codex');
+  assert.throws(() => resolveConfiguredDefaultAgent('opencalw'), /must be one of: hermes, openclaw, claude-code, codex/);
 });

--- a/test/reasoning-mapping.test.ts
+++ b/test/reasoning-mapping.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import { REASONING_EFFORTS } from '../shared/types.js';
 import { effortOptions } from '../server/adapters/claude-code-adapter.js';
 import { THINKING_MAP } from '../server/adapters/openclaw-adapter.js';
+import { codexEffort } from '../server/adapters/codex-adapter.js';
 
 test('the public enum runs none through ultra', () => {
   assert.deepEqual([...REASONING_EFFORTS], ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
@@ -22,6 +23,22 @@ test('claude-code: none disables thinking, ultra is ultracode, the rest are effo
   assert.deepEqual(effortOptions('xhigh'), { effort: 'xhigh' });
   assert.deepEqual(effortOptions('max'), { effort: 'max' });
   assert.deepEqual(effortOptions('ultra'), { effort: 'xhigh', settings: { ultracode: true } });
+});
+
+test('codex: none/minimal floor to low, the rest map by name, ultra stays ultra', () => {
+  assert.equal(codexEffort(null), undefined);
+  assert.equal(codexEffort(undefined), undefined);
+  assert.equal(codexEffort('none'), 'low');
+  assert.equal(codexEffort('minimal'), 'low');
+  assert.equal(codexEffort('low'), 'low');
+  assert.equal(codexEffort('medium'), 'medium');
+  assert.equal(codexEffort('high'), 'high');
+  assert.equal(codexEffort('xhigh'), 'xhigh');
+  assert.equal(codexEffort('max'), 'max');
+  assert.equal(codexEffort('ultra'), 'ultra');
+  // Every public effort resolves to a Codex value (the turn/start effort is a
+  // free-form string, but a mapping must exist for each level).
+  for (const effort of REASONING_EFFORTS) assert.ok(codexEffort(effort), `${effort} unmapped`);
 });
 
 test('openclaw: every effort has a thinking level', () => {

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -19,8 +19,9 @@ export async function startTestServer(): Promise<TestServer> {
   process.env.NODE_ENV = 'test';
 
   const { default: app } = await import('../server/app.js');
-  const { adapter, getAdapter } = await import('../server/agent.js');
+  const { getAdapter } = await import('../server/agent.js');
   const { shutdownLiveRuns } = await import('../server/live-runs.js');
+  const { SUPPORTED_AGENTS } = await import('../shared/types.js');
 
   const server: Server = createServer(app);
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -31,9 +32,7 @@ export async function startTestServer(): Promise<TestServer> {
     close: async () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
       shutdownLiveRuns();
-      await adapter.stop?.();
-      await getAdapter('openclaw').stop?.();
-      await getAdapter('claude-code').stop?.();
+      await Promise.all(SUPPORTED_AGENTS.map((name) => getAdapter(name).stop?.()));
     },
   };
 }


### PR DESCRIPTION
## What

Adds `agent: "codex"` to the gateway, driving the Codex CLI through `codex app-server` (newline-delimited JSON-RPC over stdio) behind the existing `AgentAdapter` seam. Same Responses-style API, streaming contract, and error vocabulary as the other three harnesses.

## How it works

- **Process model.** `codex app-server --listen stdio://` spawned on demand, lingering ~30s after the last call so a UI burst (list + read + turn) shares one process, then falling to **zero idle RAM** (~125 MB while alive). New `server/adapters/idle-child.ts` owns the spawn/idle-kill/refcount lifecycle and is shared with the OpenCode adapter to follow.
- **Session ids.** A Codex thread id **is** the gateway session id. New optional seam hook `resolveSession(sessionId?)` runs in the responses route **before** the response begins: no id creates a thread, an id resumes it (unknown id → `400 validation_error`, param `session_id`). Consequence, documented: a missing binary on a fresh-session turn is a real **503** (headers still open), not a 200 failed body.
- **Store-owned everything.** Threads, history, rename, and delete project from Codex's own store (`~/.codex/sessions/**/rollout-*.jsonl`); the gateway keeps no index and passes no credential (Codex runs on its own login; a bare `OPENAI_API_KEY` does not authenticate the app-server, so the image boot script materializes it via `codex login --with-api-key`).
- **Reasoning effort** maps onto Codex efforts (none/minimal → low, low…xhigh by name, max, ultra → Codex's multi-agent mode), clamped to the target model's advertised set.
- **Usage/context** from `thread/tokenUsage/updated` (`cost_usd` null; Codex bills its own account). Cancel is real (`turn/interrupt`).

## Verified in a real gVisor instance (Phase 0)

- `danger-full-access` works under gVisor with **no** `externalSandbox` fallback needed.
- Codex `turn/interrupt` yields `status: interrupted` (was docs-only).
- The managed LLM proxy speaks only `chat/completions` (404 on `/responses`), so Codex is BYO-credential.

## Tests

- `test/codex.integration.test.ts` — create / resume marker recall / history / list / rename round-trip / models / streaming order / cancel / delete / post-delete `[]` / made-up id → 400.
- `test/codex-nologin.integration.test.ts` — empty `CODEX_HOME` → turn `auth_error` + login hint, health false.
- `agent-unavailable` and `reasoning-mapping` gain Codex cases.

`npm run typecheck` clean. `npm test` green **except** two OpenClaw turns (`openclaw responses…`, `in-flight openclaw…`) that fail identically on clean `main` (local OpenClaw funding on this dev box, unrelated to this change; verified by stashing).

Part of the Codex + OpenCode harness plan; OpenCode is the next PR (v0.12.0).