### PR TITLE
OpenCode adapter: a fifth harness behind the same seam (v0.12.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # --- Gateway HTTP server ---
 PORT=3737                 # Port to listen on
 HOST=0.0.0.0              # Interface to bind (0.0.0.0 so the host/Docker can reach it)
-GATEWAY_DEFAULT_AGENT=    # Agent a turn routes to when the request omits `agent` (hermes|openclaw|claude-code; default hermes; any other value fails at boot)
+GATEWAY_DEFAULT_AGENT=    # Agent a turn routes to when the request omits `agent` (hermes|openclaw|claude-code|codex|opencode; default hermes; any other value fails at boot)
 
 # --- Gateway state ---
 AGENT37_GATEWAY_HOME=~/.agent37-gateway   # Root for the SQLite db, logs, and the agent workspace
@@ -37,3 +37,11 @@ CLAUDE_CODE_BIN=                           # Path to the `claude` binary (defaul
 CODEX_BIN=                                 # Path to the `codex` binary (default: the one on PATH)
 CODEX_HOME=                                # Codex config/credentials dir (default: ~/.codex)
 CODEX_IDLE_MS=30000                        # How long `codex app-server` lingers after the last call before it is killed
+
+# --- OpenCode (the `agent: "opencode"` route) ---
+# The adapter drives a resident `opencode serve` over its local HTTP API. It
+# answers on the managed Agent37 model out of the box; providers and the default
+# model come from OpenCode's own config (~/.config/opencode). BYO providers via
+# their env keys (e.g. OPENAI_API_KEY, OPENROUTER_API_KEY). No gateway-side credentials.
+OPENCODE_BIN=                              # Path to the `opencode` binary (default: the one on PATH)
+OPENCODE_IDLE_MS=600000                    # How long `opencode serve` stays resident after the last call before it is killed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ Guidance for AI coding agents working in this repo. `CLAUDE.md` imports this fil
 
 ## What this is
 
-The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), Claude Code (the Claude Agent SDK), and Codex (`codex app-server` over stdio). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
+The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), Claude Code (the Claude Agent SDK), Codex (`codex app-server` over stdio), and OpenCode (a resident `opencode serve` over HTTP). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
 
 Orientation (Node >= 24, TypeScript ESM):
 
 - `server/routes/` — the `/v1` surface (responses, sessions, models, files)
-- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, Claude Code, and Codex adapters (Codex: `codex-adapter.ts` + `codex-app-server.ts`, sharing the `idle-child.ts` spawn-with-idle-kill helper), and the JSONL worker protocol (`worker-protocol.ts`)
+- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, Claude Code, Codex, and OpenCode adapters (Codex: `codex-adapter.ts` + `codex-app-server.ts`; OpenCode: `opencode-adapter.ts` + `opencode-server.ts`; both share the `idle-child.ts` spawn-with-idle-kill helper), and the JSONL worker protocol (`worker-protocol.ts`)
 - `server/workers/hermes_worker.py` — the Python side; imports Hermes directly. `npm run selftest:worker` checks it can reach Hermes without booting the server
 - `server/live-runs.ts` + `server/response-store.ts` — in-memory replayable event buffers for in-flight responses, and in-memory (TTL/count-bounded, lost on restart) response metadata; session metadata is never stored — session lists and transcripts project from the session's harness backend (Hermes' SessionDB, OpenClaw's history, ...)
 - `shared/types.ts` — the public API types; `test/` — the integration suite; `bruno/` — hand-poke collection (see `bruno/README.md`)
@@ -32,7 +32,7 @@ Both must pass. Never open a PR on a red or un-run suite — fix the code (or th
 
 The OpenClaw tests in the suite auto-skip when no local OpenClaw gateway is running. If your change touches the OpenClaw adapter or routing, start OpenClaw locally (`openclaw start`, port 18789) so those tests actually run. The adapter speaks OpenClaw's WebSocket gateway RPC and needs one thing from `~/.openclaw/openclaw.json`: its `gateway.auth.token` copied into `OPENCLAW_TOKEN` in your `.env`. See "Set up OpenClaw" in `README.md`.
 
-The Claude Code and Codex tests are NOT optional: a missing or logged-out CLI fails the suite (both ship in release images, so a green run must include them). Install the CLIs and log in (`claude auth login`; `codex login`, or `codex login --with-api-key`); the tests run on those logins and cost real usage.
+The Claude Code, Codex, and OpenCode tests are NOT optional: a missing CLI fails the suite (all three ship in release images, so a green run must include them). Install the CLIs and log in where needed (`claude auth login`; `codex login`, or `codex login --with-api-key`; OpenCode runs on a free or managed model, no login); the Claude Code and Codex tests run on those logins and cost real usage.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ work back, and keeps the conversation going. The streaming contract and request
 shape are the same whatever agent is behind it — so client code doesn't change
 when the agent does.
 
-Today it routes to **Hermes** (the default), **OpenClaw**, **Claude Code**, and
-**Codex**: pick per request with the `agent` field.
+Today it routes to **Hermes** (the default), **OpenClaw**, **Claude Code**,
+**Codex**, and **OpenCode**: pick per request with the `agent` field.
 
 > Want the hosted API? Use [Agent37 Cloud](https://www.agent37.com/cloud). This
 > repo is the gateway service that powers an Agent37 agent.
@@ -179,6 +179,54 @@ environment does **not** authenticate Codex's app-server on its own — write it
 to `~/.codex/auth.json` with `codex login --with-api-key` (the Agent37 image's
 boot script does this from `OPENAI_API_KEY` automatically).
 
+## How it talks to OpenCode
+
+The OpenCode adapter drives the [OpenCode CLI](https://opencode.ai) through a
+resident `opencode serve` (its local HTTP API plus one Server-Sent-Events
+stream): the server is spawned on demand, kept warm so back-to-back turns reuse
+it, and killed after `OPENCODE_IDLE_MS` idle (10 minutes by default) so a casual
+user costs zero RAM. Tools run with permissions set to `allow` (the instance is
+the customer's own box, as with the other harnesses). Text and reasoning deltas,
+tool calls and their results stream back as the same SSE events, and cancel is
+real (`POST /session/{id}/abort`).
+
+A gateway session id **is** an OpenCode session id: the harness store owns the
+id, so the gateway resolves it before a turn begins. A turn with no `session_id`
+creates an OpenCode session and returns its id; a turn with one continues that
+session (an id OpenCode doesn't know is a `400 validation_error`). Sessions,
+history, rename, and delete all go through OpenCode's own store; the gateway
+keeps no index. `GET /v1/sessions?agent=opencode` lists that store (including
+sessions started from a terminal), `GET /v1/sessions/{id}` projects the
+transcript, `PATCH /v1/sessions/{id}` (rename) writes OpenCode's session title,
+and `DELETE /v1/sessions/{id}` removes the session.
+
+OpenCode answers on the managed Agent37 model out of the box (configured on the
+Agent37 image), so `GET /v1/health?agent=opencode` is `healthy: true` with no
+login step. Bring your own provider by setting its key in the instance
+environment (for example `OPENAI_API_KEY` or `OPENROUTER_API_KEY`): the provider
+then appears in the model list and a turn can target it.
+
+`GET /v1/models?agent=opencode` lists OpenCode's provider catalog (each model
+`owned_by` its provider, id in `provider/model` form); a turn's `model` picks
+one and `reasoning_effort` maps onto OpenCode's `variant` (`none` omits it,
+`low`…`xhigh` by name, `max` and `ultra` to `max`), clamped to the target
+model's advertised set. `usage` reports OpenCode's per-turn tokens and cost
+(`cost_usd` is `0` on free or unpriced models) and `context` its window
+occupancy.
+
+### Set up OpenCode
+
+Install OpenCode on the machine the gateway runs on:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Then route any turn to it with `"agent": "opencode"`. The adapter runs the
+`opencode` on `PATH`; set `OPENCODE_BIN` to pin a specific binary. Providers and
+the default model come from OpenCode's own config (`~/.config/opencode`); the
+Agent37 image writes the managed `agent37` provider there.
+
 ## Quickstart
 
 **Prerequisites:**
@@ -229,7 +277,7 @@ behind the host, which handles and forwards authentication.
 | Field | Type | Notes |
 | --- | --- | --- |
 | `input` | string, required | The message or task. |
-| `agent` | string | `hermes`, `openclaw`, `claude-code`, or `codex`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
+| `agent` | string | `hermes`, `openclaw`, `claude-code`, `codex`, or `opencode`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
 | `session_id` | string | Continue a conversation. Omit to start a new one. |
 | `files` | string[] | Absolute paths of files to attach (write them first with `PUT /v1/files/content`). Appended to the message as an `[Attached files: …]` block; the agent reads them from disk. |
 | `stream` | boolean | `true` for Server-Sent Events; default `false`. |
@@ -284,9 +332,9 @@ running response as `active_response_id`.
 
 | Action | Endpoint |
 | --- | --- |
-| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code\|codex`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
+| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code\|codex\|opencode`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
 | Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history, context }` (`?agent=` to pick the harness; `context` is the session's last reported context window, null until a turn reports one) |
-| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title; Codex stores it as the thread name). A harness without an editable title answers `405 rename_unsupported`. |
+| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title; Codex stores it as the thread name; OpenCode stores it as the session title). A harness without an editable title answers `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |
 
 `active_response_id` is the id of the `in_progress` response on the session, or
@@ -436,7 +484,10 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 Agent/worker failures surface their own `code` and `hint` where available (e.g.
 `auth_error`, `quota_exhausted`, `model_error`). One response runs at a time per
 session; sending a new turn while one is in flight returns `409 session_busy`,
-with the running response's id in `error.response_id`.
+with the running response's id in `error.response_id`. On `codex` and
+`opencode`, which resolve the session before the turn starts, a turn that can't
+reach the harness (its binary isn't on the instance) is a real `503
+agent_unavailable`, not a `200` failed body.
 
 ## Testing
 
@@ -448,9 +499,10 @@ npm test          # integration suite against the real local Hermes worker/LLM
 state dir. Response tests call the local Hermes worker and configured LLM; the
 suite also covers replay, `session_busy`, cancel, history, and
 error bodies. The OpenClaw tests run against a local OpenClaw gateway and are
-skipped automatically when none is running; the Claude Code and Codex tests run the
-Claude Code and Codex CLIs installed on this machine, on their own logins, and
-fail the suite when either isn't installed or logged in.
+skipped automatically when none is running; the Claude Code, Codex, and OpenCode
+tests run the Claude Code, Codex, and OpenCode CLIs installed on this machine
+(Claude Code and Codex on their own logins, OpenCode on a free or managed model)
+and fail the suite when one isn't installed.
 
 ### Poke it by hand (Bruno)
 
@@ -460,8 +512,9 @@ open that folder in Bruno, pick the **local** environment (`baseUrl`
 saves the `session_id` and response id into the environment, so *Continue
 Session*, *Cancel*, and *Delete Session* just work. The
 *(openclaw)* requests do the same for OpenClaw (start `openclaw` locally first),
-the *(claude-code)* requests for Claude Code, and the *(codex)* requests for
-Codex (each installed and logged in).
+the *(claude-code)* requests for Claude Code, the *(codex)* requests for Codex,
+and the *(opencode)* requests for OpenCode (each installed, and logged in where
+it needs credentials).
 *Upload File* writes a file via `PUT /v1/files/content` and saves its path for
 *Download File*.
 
@@ -471,8 +524,9 @@ All optional — see [`.env.example`](.env.example). Highlights: `PORT` (3737),
 `HOST` (0.0.0.0), `GATEWAY_DEFAULT_AGENT` (the harness a turn routes to when the
 request omits `agent`; `hermes` by default), `AGENT37_GATEWAY_HOME`
 (`~/.agent37-gateway`), the `HERMES_*` variables that locate the Hermes install,
-`OPENCLAW_BASE_URL` / `OPENCLAW_TOKEN` for the OpenClaw route, `CLAUDE_CODE_BIN` for the Claude Code route, and `CODEX_BIN` / `CODEX_HOME`
-(and `CODEX_IDLE_MS`) for the Codex route.
+`OPENCLAW_BASE_URL` / `OPENCLAW_TOKEN` for the OpenClaw route, `CLAUDE_CODE_BIN` for the Claude Code route, `CODEX_BIN` / `CODEX_HOME`
+(and `CODEX_IDLE_MS`) for the Codex route, and `OPENCODE_BIN` (and
+`OPENCODE_IDLE_MS`) for the OpenCode route.
 
 ## Roadmap
 

--- a/bruno/environments/local.example.bru
+++ b/bruno/environments/local.example.bru
@@ -8,5 +8,7 @@ vars {
   claudeCodeResponseId:
   codexSessionId:
   codexResponseId:
+  opencodeSessionId:
+  opencodeResponseId:
   uploadedFilePath:
 }

--- a/bruno/gateway/01 Health (opencode).bru
+++ b/bruno/gateway/01 Health (opencode).bru
@@ -1,0 +1,35 @@
+meta {
+  name: 01 Health (opencode)
+  type: http
+  seq: 34
+}
+
+get {
+  url: {{baseUrl}}/v1/health?agent=opencode
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: opencode
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("reports OpenCode health", function () {
+    expect(res.body.ok).to.equal(true);
+    expect(res.body.agent).to.equal("opencode");
+    expect(res.body.healthy).to.be.a("boolean");
+  });
+}
+
+docs {
+  Liveness + whether the OpenCode harness backend is ready, selected
+  with `?agent=opencode`. The gateway drives a resident `opencode serve`.
+  `healthy` is true as soon as OpenCode is installed (`opencode` on PATH,
+  or OPENCODE_BIN): it answers on the managed Agent37 model out of the box,
+  so there is no login step.
+}

--- a/bruno/gateway/03 List Models (opencode).bru
+++ b/bruno/gateway/03 List Models (opencode).bru
@@ -1,0 +1,38 @@
+meta {
+  name: 03 List Models (opencode)
+  type: http
+  seq: 35
+}
+
+get {
+  url: {{baseUrl}}/v1/models?agent=opencode
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: opencode
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("is an OpenCode model list", function () {
+    expect(res.body.object).to.equal("list");
+    expect(res.body.agent).to.equal("opencode");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The models the OpenCode harness can run, selected with
+  `?agent=opencode`. Omit the filter (see "03 List Models") for the gateway's
+  configured default. This is OpenCode's provider catalog: each model id is in
+  `provider/model` form and `owned_by` its provider (the managed `agent37`
+  provider is always present; BYO providers appear once their key is in the
+  instance environment). Needs OpenCode installed on this machine
+  (`opencode` on PATH, or OPENCODE_BIN): otherwise the gateway returns
+  503 agent_unavailable.
+}

--- a/bruno/gateway/04 Create Response (opencode).bru
+++ b/bruno/gateway/04 Create Response (opencode).bru
@@ -1,0 +1,57 @@
+meta {
+  name: 04 Create Response (opencode)
+  type: http
+  seq: 36
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "What is the time now in IST?",
+    "agent": "opencode",
+    "reasoning_effort": "low"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body) {
+    if (res.body.session_id) bru.setEnvVar("opencodeSessionId", res.body.session_id, { persist: true });
+    if (res.body.id) bru.setEnvVar("opencodeResponseId", res.body.id, { persist: true });
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("completed with text", function () {
+    expect(res.body.id).to.be.a("string");
+    expect(res.body.session_id).to.be.a("string");
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("opencode");
+    expect(res.body.output_text).to.be.a("string");
+  });
+}
+
+docs {
+  Start a new OpenCode session. Pass `"agent": "opencode"`: the gateway
+  drives a resident `opencode serve`, spawned on demand and answering on the
+  managed Agent37 model (or a BYO provider whose key is in the instance
+  environment).
+
+  The reply saves `opencodeSessionId` and `opencodeResponseId` to the
+  environment so the follow-up requests below can reuse them.
+
+  OpenCode must be installed on this machine (`opencode` on PATH, or
+  OPENCODE_BIN).
+}

--- a/bruno/gateway/05 Continue Session (opencode).bru
+++ b/bruno/gateway/05 Continue Session (opencode).bru
@@ -1,0 +1,42 @@
+meta {
+  name: 05 Continue Session (opencode)
+  type: http
+  seq: 37
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "session_id": "{{opencodeSessionId}}",
+    "input": "In one short sentence, what did I just ask you to say?",
+    "agent": "opencode",
+    "reasoning_effort": "low"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("same session, completed", function () {
+    expect(res.body.session_id).to.equal(bru.getEnvVar("opencodeSessionId"));
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("opencode");
+  });
+}
+
+docs {
+  Continue an OpenCode conversation. Reuses `opencodeSessionId` saved by
+  "04 Create Response (opencode)". Always include `"agent": "opencode"`
+  so the gateway routes the turn to the right backend.
+}

--- a/bruno/gateway/07 Create Response (streaming) (opencode).bru
+++ b/bruno/gateway/07 Create Response (streaming) (opencode).bru
@@ -1,0 +1,40 @@
+meta {
+  name: 07 Create Response (streaming) (opencode)
+  type: http
+  seq: 38
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "Count from 1 to 5, one number per line.",
+    "agent": "opencode",
+    "reasoning_effort": "low",
+    "stream": true
+  }
+}
+
+docs {
+  Streaming is agent-agnostic: pass `"agent": "opencode"` alongside
+  `"stream": true` and the gateway streams the OpenCode turn back as
+  Server-Sent Events, exactly like the Hermes streaming request above:
+    response.created -> response.reasoning.delta / response.output_text.delta /
+    response.tool_call.* -> response.completed (or response.failed)
+
+  The OpenCode adapter reads `opencode serve`'s `/global/event` stream and
+  re-emits it as gateway SSE, so there is no extra setup beyond an OpenCode
+  install:
+
+    curl -N localhost:3737/v1/responses \
+      -H 'content-type: application/json' \
+      -d '{"input":"hi","agent":"opencode","stream":true}'
+}

--- a/bruno/gateway/09 List Sessions (opencode).bru
+++ b/bruno/gateway/09 List Sessions (opencode).bru
@@ -1,0 +1,34 @@
+meta {
+  name: 09 List Sessions (opencode)
+  type: http
+  seq: 39
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions?agent=opencode
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: opencode
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("opencode sessions", function () {
+    expect(res.body.agent).to.equal("opencode");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The OpenCode chat sessions on this instance, selected with
+  `?agent=opencode`, projected from OpenCode's own session store as
+  `{ agent, data }`. Omitting `?agent=` falls back to the instance's default
+  harness: not a merged listing. Unknown agent values return a
+  400 validation_error.
+}

--- a/bruno/gateway/10 Get Session (opencode history).bru
+++ b/bruno/gateway/10 Get Session (opencode history).bru
@@ -1,0 +1,30 @@
+meta {
+  name: 10 Get Session (opencode history)
+  type: http
+  seq: 40
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions/{{opencodeSessionId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("includes transcript history", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("opencodeSessionId"));
+    expect(res.body.agent).to.equal("opencode");
+    expect(res.body.history).to.be.an("array");
+  });
+}
+
+docs {
+  The OpenCode session plus its transcript. Reuses `opencodeSessionId`
+  saved by "04 Create Response (opencode)". History is projected on demand
+  from OpenCode's own message store: the gateway never duplicates messages.
+  An unknown or deleted id projects to an empty array.
+}

--- a/bruno/gateway/12 Delete Session (opencode).bru
+++ b/bruno/gateway/12 Delete Session (opencode).bru
@@ -1,0 +1,30 @@
+meta {
+  name: 12 Delete Session (opencode)
+  type: http
+  seq: 41
+}
+
+delete {
+  url: {{baseUrl}}/v1/sessions/{{opencodeSessionId}}?agent=opencode
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: opencode
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("deleted", function () {
+    expect(res.body.deleted).to.equal(true);
+  });
+}
+
+docs {
+  Permanently remove the OpenCode session from OpenCode's own store.
+  Other sessions on the instance are untouched.
+}

--- a/bruno/gateway/15 Rename Session (opencode).bru
+++ b/bruno/gateway/15 Rename Session (opencode).bru
@@ -1,0 +1,46 @@
+meta {
+  name: 15 Rename Session (opencode)
+  type: http
+  seq: 42
+}
+
+patch {
+  url: {{baseUrl}}/v1/sessions/{{opencodeSessionId}}?agent=opencode
+  body: json
+  auth: none
+}
+
+params:query {
+  agent: opencode
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "title": "Renamed from Bruno"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("renamed", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("opencodeSessionId"));
+    expect(res.body.renamed).to.equal(true);
+  });
+}
+
+docs {
+  Rename an OpenCode session by writing its title straight into OpenCode's
+  own store (`PATCH /v1/sessions/:id?agent=opencode`, body
+  `{ "title": "…" }` -> `{ id, agent, renamed }`). The gateway calls OpenCode's
+  `PATCH /session/:id`, which the session list reads back as its title.
+  Harnesses without an editable title (OpenClaw) return
+  `405 rename_unsupported`. Reuses the `opencodeSessionId` saved by
+  "04 Create Response (opencode)".
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent37-gateway",
-  "version": "0.11.0",
-  "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, Claude Code, or Codex.",
+  "version": "0.12.0",
+  "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, Claude Code, Codex, or OpenCode.",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/server/adapters/opencode-adapter.ts
+++ b/server/adapters/opencode-adapter.ts
@@ -261,6 +261,21 @@ export class OpenCodeAdapter implements AgentAdapter {
       return;
     }
 
+    // A model must be one of OpenCode's own "provider/model" ids (as listed by
+    // GET /v1/models?agent=opencode). Reject a bare or malformed id rather than
+    // silently dropping it and running the default while the response mislabels
+    // it as the requested model.
+    const settings = options?.settings;
+    const model = splitModel(settings?.model);
+    if (settings?.model && !model) {
+      yield {
+        type: 'error',
+        code: 'model_error',
+        error: `model '${settings.model}' must be in "provider/model" form (see GET /v1/models?agent=opencode).`,
+      };
+      return;
+    }
+
     const client = await this.child.acquire();
     const turn: ActiveTurn = {
       client,
@@ -275,6 +290,9 @@ export class OpenCodeAdapter implements AgentAdapter {
     const toolsRunning = new Set<string>(); // partIDs that have emitted `running`
     const assistantMsgs = new Map<string, OpenCodeAssistantMessage>(); // id → latest
     let streamError: OpenCodeErrorInfo | undefined;
+    // The text streamed via deltas so far, reconciled against the prompt
+    // result's final parts at the end so a dropped SSE can't truncate output.
+    let streamedText = '';
 
     let idleTimer: NodeJS.Timeout | undefined;
     const resetIdle = (): void => {
@@ -295,10 +313,8 @@ export class OpenCodeAdapter implements AgentAdapter {
     });
     resetIdle();
 
-    // Effort/model resolution needs the model's advertised variants, so refresh
-    // the providers cache before firing (cheap and cached 60s).
-    const settings = options?.settings;
-    const model = splitModel(settings?.model);
+    // Effort resolution needs the model's advertised variants, so refresh the
+    // providers cache before firing (cheap and cached 60s).
     let variant: string | undefined;
     try {
       const providers = await this.loadProviders(client);
@@ -366,7 +382,10 @@ export class OpenCodeAdapter implements AgentAdapter {
             // the part type registered from message.part.updated.
             const type = partTypes.get(props.partID as string);
             if (type === 'reasoning') yield { type: 'thinking_delta', content: delta };
-            else if (type === 'text') yield { type: 'text_delta', content: delta };
+            else if (type === 'text') {
+              streamedText += delta;
+              yield { type: 'text_delta', content: delta };
+            }
             break;
           }
           case 'message.updated': {
@@ -415,6 +434,18 @@ export class OpenCodeAdapter implements AgentAdapter {
       }
       yield errorEvent(failure);
       return;
+    }
+
+    // The prompt result carries the turn's final text in its `text` parts. If
+    // the event stream dropped mid-turn, the streamed deltas are a prefix of it
+    // (or empty); emit the missing tail so `output_text` is never truncated. In
+    // the normal case the two match and nothing extra is sent.
+    const finalText = (settled.result.parts ?? [])
+      .filter((p) => p.type === 'text')
+      .map((p) => p.text ?? '')
+      .join('');
+    if (finalText.length > streamedText.length && finalText.startsWith(streamedText)) {
+      yield { type: 'text_delta', content: finalText.slice(streamedText.length) };
     }
 
     // Usage sums every assistant message of this turn (multi-step tool loops

--- a/server/adapters/opencode-adapter.ts
+++ b/server/adapters/opencode-adapter.ts
@@ -1,0 +1,630 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  HermesMessage,
+  ReasoningEffort,
+  SessionMetadata,
+  SessionSummary,
+  TurnUsage,
+} from '../../shared/types.js';
+import type { AgentAdapter, AgentRunOptions, ContextUsage, StreamEvent } from './types.js';
+import { AsyncQueue, IdleChild } from './idle-child.js';
+import { resolveWorkspaceDir } from '../paths.js';
+import { validationError } from '../errors.js';
+import {
+  OpenCodeClient,
+  OpenCodeError,
+  spawnOpenCodeClient,
+  type OpenCodeAssistantMessage,
+  type OpenCodeErrorInfo,
+  type OpenCodeEvent,
+  type OpenCodePart,
+  type OpenCodeProviders,
+  type OpenCodeSession,
+} from './opencode-server.js';
+
+// The adapter drives OpenCode through a resident `opencode serve` (its local
+// HTTP API plus one `/global/event` SSE stream), kept warm by the IdleChild and
+// killed after ~10 idle minutes so a casual user costs zero RAM. A gateway
+// session id IS an OpenCode session id: the harness store owns the id, so the
+// responses route calls `resolveSession` before a response begins
+// (create-on-first-turn, or verify an existing session). Sessions, history,
+// rename and delete all go through OpenCode's own store — the gateway keeps no
+// index. The managed Agent37 model rides in via the image's config
+// (`provider.agent37`); BYO keys register their own providers from the instance
+// env. The gateway never reads credentials.
+
+const HEALTHY_TTL_MS = 60_000;
+const UNHEALTHY_TTL_MS = 10_000;
+// How long the resident server lingers after the last call before it is killed.
+const IDLE_MS = Number(process.env.OPENCODE_IDLE_MS) || 600_000;
+// After abort(), how long OpenCode gets to close the turn before the child is
+// killed outright.
+const INTERRUPT_GRACE_MS = 5_000;
+// A turn that streams no event for this long is treated as stalled: the backend
+// turn is aborted and the stream ends so the session lock releases.
+const TURN_IDLE_MS = Number(process.env.OPENCODE_TURN_IDLE_MS) || 300_000;
+const AUTH_HINT = 'Set the provider API key in the instance environment (e.g. OPENAI_API_KEY), or use the managed Agent37 model.';
+
+// Our public effort ladder → OpenCode's prompt `variant`. OpenCode has no
+// none/max/ultra of its own: `none` omits the variant, `max`/`ultra` map to
+// `max` (its top reasoning), and each value is clamped at call time to the
+// target model's advertised `variants` (a weaker model never rejects a turn).
+const VARIANT_MAP: Record<ReasoningEffort, string | undefined> = {
+  none: undefined,
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+  max: 'max',
+  ultra: 'max',
+};
+
+const VARIANT_LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+
+/** The OpenCode variant one reasoning level maps to (before per-model clamping).
+ *  Exported for the mapping tests. */
+export function opencodeVariant(effort: ReasoningEffort | null | undefined): string | undefined {
+  if (!effort) return undefined;
+  return VARIANT_MAP[effort];
+}
+
+/** Clamp a nominal variant to a model's advertised set: the value itself if
+ *  listed, else the highest listed value below it, else the lowest. A model
+ *  that lists no variants gets none (undefined) — sending one it doesn't know
+ *  would error. */
+function clampVariant(nominal: string | undefined, listed: string[] | undefined): string | undefined {
+  if (!nominal) return undefined;
+  if (!listed || listed.length === 0) return undefined;
+  if (listed.includes(nominal)) return nominal;
+  const idx = VARIANT_LADDER.indexOf(nominal);
+  for (let i = idx - 1; i >= 0; i--) {
+    if (listed.includes(VARIANT_LADDER[i])) return VARIANT_LADDER[i];
+  }
+  for (const level of VARIANT_LADDER) if (listed.includes(level)) return level;
+  return undefined;
+}
+
+/** Split a "providerID/modelID" model id (OpenClaw uses the same composite
+ *  form). Returns null when the client passed no model or a bare id, so the
+ *  turn falls back to OpenCode's configured default. */
+function splitModel(model: string | null | undefined): { providerID: string; modelID: string } | null {
+  if (!model) return null;
+  const slash = model.indexOf('/');
+  if (slash <= 0 || slash === model.length - 1) return null;
+  return { providerID: model.slice(0, slash), modelID: model.slice(slash + 1) };
+}
+
+const trim = (s?: string | null): string | undefined =>
+  s && s.trim() ? (s.length > 120 ? `${s.slice(0, 117)}...` : s) : undefined;
+
+/** Sum the prompt-side tokens of an assistant message: fresh input plus what
+ *  the cache served. OpenCode's `input` is already cache-adjusted downward, so
+ *  adding the cache counts is the true prompt size. */
+function inputTokens(message: OpenCodeAssistantMessage): number {
+  const t = message.tokens ?? {};
+  return (t.input ?? 0) + (t.cache?.read ?? 0) + (t.cache?.write ?? 0);
+}
+
+/** Map a tagged OpenCode error (`session.error` payload or an assistant
+ *  message's `error`) to a worker error code + message. */
+function errorEvent(info: OpenCodeErrorInfo): StreamEvent {
+  const name = info.name;
+  const message = info.data?.message || name || 'OpenCode ended the turn on an error.';
+  const status = info.data?.statusCode;
+  let code = 'agent_error';
+  if (name === 'ProviderAuthError' || status === 401) code = 'auth_error';
+  else if (status === 402) code = 'quota_exhausted';
+  else if (status === 429) code = 'rate_limit';
+  else if (name === 'ContextOverflowError' || name === 'MessageOutputLengthError' || name === 'ContentFilterError') {
+    code = 'agent_error';
+  }
+  return {
+    type: 'error',
+    code,
+    error: name && name !== 'APIError' && name !== 'UnknownError' ? `${name}: ${message}` : message,
+    ...(code === 'auth_error' ? { hint: AUTH_HINT } : {}),
+  };
+}
+
+let pathBin: string | null = null;
+
+/** The `opencode` binary: OPENCODE_BIN, else the one on PATH. Throws ENOENT
+ *  when neither exists — the gateway renders that as 503 agent_unavailable. */
+function requireOpenCodeBin(): string {
+  let bin = process.env.OPENCODE_BIN?.trim();
+  if (!bin) {
+    if (!pathBin) {
+      try {
+        pathBin = execFileSync('which', ['opencode'], { encoding: 'utf8' }).trim() || null;
+      } catch {
+        pathBin = null;
+      }
+    }
+    bin = pathBin ?? undefined;
+  }
+  if (!bin || !existsSync(bin)) {
+    const error: NodeJS.ErrnoException = new Error(
+      `OpenCode binary not found${bin ? ` at ${bin}` : ' on PATH'}. Install OpenCode or set OPENCODE_BIN.`,
+    );
+    error.code = 'ENOENT';
+    throw error;
+  }
+  return bin;
+}
+
+function workspaceCwd(): string {
+  const dir = resolveWorkspaceDir();
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+interface ActiveTurn {
+  client: OpenCodeClient;
+  directory?: string;
+  interrupted: boolean;
+  fetchAbort: AbortController;
+  killTimer?: NodeJS.Timeout;
+}
+
+interface ProvidersCache {
+  at: number;
+  windows: Map<string, number>; // "providerID/modelID" → context window
+  variants: Map<string, string[]>; // "providerID/modelID" → advertised variants
+  providers: OpenCodeProviders;
+}
+
+export class OpenCodeAdapter implements AgentAdapter {
+  private readonly child = new IdleChild<OpenCodeClient>({
+    idleMs: IDLE_MS,
+    start: () => this.spawnWithRetry(),
+  });
+  private readonly activeTurns = new Map<string, ActiveTurn>();
+  // OpenCode session id → its own working directory, cached from
+  // create/resolve so a turn on a session created elsewhere (a terminal in a
+  // different folder) runs its tools in the right place.
+  private readonly sessionDir = new Map<string, string>();
+  private health: { at: number; ok: boolean } | null = null;
+  private providersCache: ProvidersCache | null = null;
+
+  // OpenCode's shared SQLite can be locked while another OpenCode process (a
+  // user's TUI) boots; retry the spawn a few times before giving up.
+  private async spawnWithRetry(): ReturnType<typeof spawnOpenCodeClient> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        return await spawnOpenCodeClient(requireOpenCodeBin(), workspaceCwd());
+      } catch (error) {
+        lastError = error;
+        if ((error as { name?: string }).name !== 'OpenCodeLockedError') throw error;
+        await new Promise((r) => setTimeout(r, 250 * (attempt + 1)));
+      }
+    }
+    throw lastError;
+  }
+
+  private async loadProviders(client: OpenCodeClient): Promise<ProvidersCache> {
+    if (this.providersCache && Date.now() - this.providersCache.at < HEALTHY_TTL_MS) {
+      return this.providersCache;
+    }
+    const providers = await client.getProviders();
+    const windows = new Map<string, number>();
+    const variants = new Map<string, string[]>();
+    for (const provider of providers.providers ?? []) {
+      for (const model of Object.values(provider.models ?? {})) {
+        const key = `${provider.id}/${model.id}`;
+        if (model.limit?.context) windows.set(key, model.limit.context);
+        const names = model.variants ? Object.keys(model.variants) : [];
+        if (names.length) variants.set(key, names);
+      }
+    }
+    this.providersCache = { at: Date.now(), windows, variants, providers };
+    return this.providersCache;
+  }
+
+  // The responses route calls this before a response begins: create a session
+  // (no id) or verify one (with id). The session id becomes the gateway session id.
+  async resolveSession(sessionId?: string): Promise<string> {
+    const client = await this.child.acquire();
+    try {
+      if (!sessionId) {
+        const session = await client.createSession(workspaceCwd());
+        if (session.directory) this.sessionDir.set(session.id, session.directory);
+        return session.id;
+      }
+      let session: OpenCodeSession;
+      try {
+        session = await client.getSession(sessionId);
+      } catch (error) {
+        if (error instanceof OpenCodeError && error.status === 404) {
+          throw validationError(`No OpenCode session with id '${sessionId}'.`, 'session_id');
+        }
+        throw error;
+      }
+      if (session.directory) this.sessionDir.set(sessionId, session.directory);
+      return sessionId;
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async *chatStream(sessionId: string, message: string, options?: AgentRunOptions): AsyncIterable<StreamEvent> {
+    requireOpenCodeBin();
+    // The gateway already serializes turns it starts per session; this guards
+    // against a turn OpenCode is running for another client (a terminal) on the
+    // same session — OpenCode's prompt route never 409s, it silently joins.
+    if (this.activeTurns.has(sessionId)) {
+      yield { type: 'error', code: 'task_busy', error: 'A turn is already running on this session.' };
+      return;
+    }
+
+    const client = await this.child.acquire();
+    const turn: ActiveTurn = {
+      client,
+      directory: this.sessionDir.get(sessionId),
+      interrupted: false,
+      fetchAbort: new AbortController(),
+    };
+    this.activeTurns.set(sessionId, turn);
+
+    const queue = new AsyncQueue<OpenCodeEvent>();
+    const partTypes = new Map<string, string>(); // partID → part type
+    const toolsRunning = new Set<string>(); // partIDs that have emitted `running`
+    const assistantMsgs = new Map<string, OpenCodeAssistantMessage>(); // id → latest
+    let streamError: OpenCodeErrorInfo | undefined;
+
+    let idleTimer: NodeJS.Timeout | undefined;
+    const resetIdle = (): void => {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        void client.abort(sessionId, turn.directory).catch(() => {});
+        // Cut the prompt fetch too, so the terminal `await promptDone` can't
+        // hang if the abort doesn't settle the request.
+        turn.fetchAbort.abort();
+        queue.end();
+      }, TURN_IDLE_MS);
+      idleTimer.unref();
+    };
+    const unsubscribe = client.onEvent((event) => {
+      if (event.properties?.sessionID !== sessionId) return;
+      resetIdle();
+      queue.push(event);
+    });
+    resetIdle();
+
+    // Effort/model resolution needs the model's advertised variants, so refresh
+    // the providers cache before firing (cheap and cached 60s).
+    const settings = options?.settings;
+    const model = splitModel(settings?.model);
+    let variant: string | undefined;
+    try {
+      const providers = await this.loadProviders(client);
+      const modelKey = model
+        ? `${model.providerID}/${model.modelID}`
+        : (await client.getConfig().catch(() => ({ model: undefined }))).model;
+      variant = clampVariant(opencodeVariant(settings?.reasoningEffort), modelKey ? providers.variants.get(modelKey) : undefined);
+    } catch {
+      // A provider fetch failure is not fatal to the turn; run without a variant.
+      variant = undefined;
+    }
+
+    // Fire the prompt (do not await): it resolves with the final { info, parts }
+    // once the turn completes. Deltas arrive concurrently on the event stream.
+    let settled: TurnSettled | undefined;
+    const promptDone = client
+      .prompt(
+        sessionId,
+        turn.directory,
+        {
+          agent: 'build',
+          parts: [{ type: 'text', text: message }],
+          ...(model ? { model } : {}),
+          ...(variant ? { variant } : {}),
+        },
+        turn.fetchAbort.signal,
+      )
+      .then(
+        (result) => {
+          settled = { ok: true, result };
+        },
+        (error) => {
+          settled = { ok: false, error };
+        },
+      )
+      .finally(() => queue.end());
+
+    try {
+      for await (const event of queue) {
+        const props = event.properties ?? {};
+        switch (event.type) {
+          case 'message.part.updated': {
+            const part = props.part as OpenCodePart | undefined;
+            if (!part) break;
+            partTypes.set(part.id, part.type);
+            if (part.type === 'tool') {
+              const status = part.state?.status;
+              if (status === 'running' && !toolsRunning.has(part.id)) {
+                toolsRunning.add(part.id);
+                yield { type: 'tool_progress', tool: part.tool || 'tool', status: 'running', label: trim(part.state?.title) };
+              } else if (status === 'completed' && toolsRunning.delete(part.id)) {
+                const start = part.state?.time?.start ?? 0;
+                const end = part.state?.time?.end ?? Date.now();
+                yield { type: 'tool_progress', tool: part.tool || 'tool', status: 'completed', duration: start ? end - start : undefined };
+              } else if (status === 'error' && toolsRunning.delete(part.id)) {
+                yield { type: 'tool_progress', tool: part.tool || 'tool', status: 'error', label: trim(part.state?.error) };
+              }
+            }
+            break;
+          }
+          case 'message.part.delta': {
+            const delta = props.delta as string | undefined;
+            if (!delta) break;
+            // Reasoning and text parts both stream as field "text"; classify by
+            // the part type registered from message.part.updated.
+            const type = partTypes.get(props.partID as string);
+            if (type === 'reasoning') yield { type: 'thinking_delta', content: delta };
+            else if (type === 'text') yield { type: 'text_delta', content: delta };
+            break;
+          }
+          case 'message.updated': {
+            const info = props.info as OpenCodeMessageInfo | undefined;
+            if (info && info.role === 'assistant') assistantMsgs.set(info.id, info);
+            break;
+          }
+          case 'session.error': {
+            const err = props.error as OpenCodeErrorInfo | undefined;
+            if (err) streamError = err;
+            break;
+          }
+        }
+      }
+    } catch (error) {
+      if (!settled) settled = { ok: false, error };
+    } finally {
+      clearTimeout(idleTimer);
+      clearTimeout(turn.killTimer);
+      unsubscribe();
+      this.activeTurns.delete(sessionId);
+      this.child.release();
+    }
+
+    if (!settled) await promptDone;
+    if (!settled) settled = { ok: false, error: new Error('OpenCode turn did not settle.') };
+
+    if (turn.interrupted) {
+      yield { type: 'done', sessionId, usage: null, interrupted: true };
+      return;
+    }
+    if (!settled.ok) {
+      const error = settled.error;
+      const message = error instanceof Error ? error.message : 'OpenCode turn failed.';
+      const code = error instanceof OpenCodeError && error.status === 401 ? 'auth_error' : 'agent_error';
+      yield { type: 'error', code, error: message, ...(code === 'auth_error' ? { hint: AUTH_HINT } : {}) };
+      return;
+    }
+
+    const info = settled.result.info;
+    const failure = info.error ?? streamError;
+    if (failure) {
+      if (failure.name === 'MessageAbortedError') {
+        yield { type: 'done', sessionId, usage: null, interrupted: true };
+        return;
+      }
+      yield errorEvent(failure);
+      return;
+    }
+
+    // Usage sums every assistant message of this turn (multi-step tool loops
+    // emit several); each fires message.updated repeatedly, so dedupe by id and
+    // match the turn by parentID = our user message.
+    assistantMsgs.set(info.id, info);
+    const parentId = info.parentID;
+    const messages = [...assistantMsgs.values()].filter((m) => (parentId ? m.parentID === parentId : m.id === info.id));
+    let inputTotal = 0;
+    let outputTotal = 0;
+    let costTotal = 0;
+    for (const m of messages) {
+      inputTotal += inputTokens(m);
+      outputTotal += m.tokens?.output ?? 0;
+      costTotal += m.cost ?? 0;
+    }
+    const usage: TurnUsage = { input_tokens: inputTotal, output_tokens: outputTotal, cost_usd: costTotal };
+
+    // Context occupancy = the final message's prompt plus its output, against
+    // the model's advertised window.
+    const used = inputTokens(info) + (info.tokens?.output ?? 0);
+    const window = info.providerID && info.modelID ? this.providersCache?.windows.get(`${info.providerID}/${info.modelID}`) : undefined;
+    const context: ContextUsage | null = window && used > 0 ? { used_tokens: used, window_tokens: window } : null;
+
+    yield { type: 'done', sessionId, usage, context, interrupted: false };
+  }
+
+  async interruptChat(sessionId: string): Promise<boolean> {
+    const turn = this.activeTurns.get(sessionId);
+    if (!turn) return false;
+    turn.interrupted = true;
+    // Backstop: if the abort doesn't close the turn, cut the prompt fetch.
+    turn.killTimer = setTimeout(() => turn.fetchAbort.abort(), INTERRUPT_GRACE_MS);
+    try {
+      await turn.client.abort(sessionId, turn.directory);
+    } catch {
+      turn.fetchAbort.abort();
+    }
+    return true;
+  }
+
+  async healthCheck(): Promise<boolean> {
+    if (this.health && Date.now() - this.health.at < (this.health.ok ? HEALTHY_TTL_MS : UNHEALTHY_TTL_MS)) {
+      return this.health.ok;
+    }
+    let ok: boolean;
+    try {
+      requireOpenCodeBin();
+      // OpenCode is ready to chat as soon as the binary is present (the managed
+      // model always answers). If the server is already warm, confirm it is
+      // live; don't spawn a resident server just to answer a health probe.
+      if (this.child.running) {
+        const client = await this.child.acquire();
+        try {
+          ok = await client.health();
+        } finally {
+          this.child.release();
+        }
+      } else {
+        ok = true;
+      }
+    } catch {
+      ok = false;
+    }
+    this.health = { at: Date.now(), ok };
+    return ok;
+  }
+
+  async listSessions(): Promise<SessionSummary[]> {
+    const client = await this.child.acquire();
+    let sessions: OpenCodeSession[];
+    try {
+      sessions = await client.listSessions();
+    } finally {
+      this.child.release();
+    }
+    return (sessions ?? [])
+      .filter((session) => !session.parentID) // top-level sessions only
+      .map((session) => ({
+        id: session.id,
+        title: session.title?.trim() || null,
+        last_active: session.time?.updated ?? session.time?.created ?? null,
+        message_count: null,
+        preview: null,
+      }));
+  }
+
+  async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    const client = await this.child.acquire();
+    let rows: Awaited<ReturnType<OpenCodeClient['getMessages']>>;
+    try {
+      rows = await client.getMessages(sessionId);
+    } catch (error) {
+      // The harness owns existence: an unknown/deleted session projects to [].
+      if (error instanceof OpenCodeError && error.status === 404) return [];
+      throw error;
+    } finally {
+      this.child.release();
+    }
+
+    const out: HermesMessage[] = [];
+    for (const row of rows ?? []) {
+      const role = row.info.role;
+      if (role !== 'user' && role !== 'assistant') continue;
+      const text = (row.parts ?? [])
+        .filter((p) => p.type === 'text')
+        .map((p) => p.text ?? '')
+        .join('');
+      const thinking = (row.parts ?? [])
+        .filter((p) => p.type === 'reasoning')
+        .map((p) => p.text ?? '')
+        .join('\n\n')
+        .trim();
+      if (!text.trim()) continue;
+      out.push({
+        id: row.info.id,
+        task_id: sessionId,
+        role,
+        content: text,
+        thinking: role === 'assistant' && thinking ? thinking : undefined,
+        created_at: row.info.time?.created ?? 0,
+      });
+    }
+    return out;
+  }
+
+  async getSessionMetadata(): Promise<SessionMetadata | null> {
+    // No route reads this today.
+    return null;
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    const client = await this.child.acquire();
+    try {
+      await client.deleteSession(sessionId, this.sessionDir.get(sessionId));
+      this.sessionDir.delete(sessionId);
+      return true;
+    } catch (error) {
+      if (error instanceof OpenCodeError && error.status === 404) return false;
+      throw error;
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async renameSession(sessionId: string, title: string): Promise<boolean> {
+    const client = await this.child.acquire();
+    try {
+      await client.renameSession(sessionId, title, this.sessionDir.get(sessionId));
+      return true;
+    } catch (error) {
+      if (error instanceof OpenCodeError && error.status === 404) return false;
+      throw error;
+    } finally {
+      this.child.release();
+    }
+  }
+
+  async getModels(): Promise<AgentModelsResponse> {
+    const client = await this.child.acquire();
+    let providers: OpenCodeProviders;
+    let defaultModel: string | null;
+    try {
+      // Force a fresh read so a newly-added BYO key shows up.
+      this.providersCache = null;
+      providers = (await this.loadProviders(client)).providers;
+      defaultModel = (await client.getConfig().catch(() => ({ model: undefined }))).model ?? null;
+    } finally {
+      this.child.release();
+    }
+    const groups = (providers.providers ?? []).map((provider) => ({
+      provider: provider.id,
+      models: Object.values(provider.models ?? {}).map((model) => {
+        const id = `${provider.id}/${model.id}`;
+        return {
+          id,
+          label: model.name || model.id,
+          source: 'catalog' as const,
+          provider: provider.id,
+          isCurrentDefault: id === defaultModel,
+        };
+      }),
+    }));
+    return {
+      defaultModel,
+      activeProvider: defaultModel ? defaultModel.split('/')[0] : (providers.providers?.[0]?.id ?? null),
+      groups,
+    };
+  }
+
+  async getDefaults(): Promise<AgentDefaults> {
+    return { provider: null, model: null, baseUrl: null, apiMode: null, reasoningEffort: null, showReasoning: true };
+  }
+
+  async stop(): Promise<void> {
+    for (const turn of this.activeTurns.values()) {
+      clearTimeout(turn.killTimer);
+      turn.fetchAbort.abort();
+    }
+    this.activeTurns.clear();
+    await this.child.stop();
+  }
+}
+
+// message.updated carries a full Message (user or assistant); we only read the
+// assistant shape's usage fields.
+type OpenCodeMessageInfo = OpenCodeAssistantMessage & { role: 'user' | 'assistant' };
+
+// The outcome of the sync prompt call, captured off the event loop so the
+// stream can drain first.
+type TurnSettled =
+  | { ok: true; result: Awaited<ReturnType<OpenCodeClient['prompt']>> }
+  | { ok: false; error: unknown };

--- a/server/adapters/opencode-server.ts
+++ b/server/adapters/opencode-server.ts
@@ -1,0 +1,426 @@
+// A thin client for `opencode serve`: OpenCode's local HTTP API plus its one
+// `GET /global/event` Server-Sent-Events stream. It spawns the process, waits
+// for the "listening" line, opens the event stream, and fans each event out to
+// subscribers (demultiplexed per session by the adapter). The OpenCodeAdapter
+// builds the AgentAdapter seam on top of this; nothing here is Agent37-specific.
+//
+// Unlike Codex (one short-lived stdio process per burst), OpenCode is a resident
+// server the IdleChild keeps warm and kills after ~10 idle minutes, so a regular
+// user gets warm turns and a casual one costs zero RAM. Requests carry HTTP
+// basic auth (`opencode:<per-spawn password>`); the shared SQLite store can be
+// locked while another OpenCode process (a user's TUI) boots, so a spawn that
+// hits `database is locked` is retried by the adapter's start closure.
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createServer } from 'node:net';
+import { randomBytes } from 'node:crypto';
+import type { StartedChild } from './idle-child.js';
+
+// --- Protocol shapes (the subset the adapter reads) --------------------------
+
+export interface OpenCodeSession {
+  id: string;
+  directory?: string;
+  parentID?: string | null;
+  title?: string;
+  cost?: number;
+  tokens?: OpenCodeTokens;
+  time?: { created?: number; updated?: number };
+}
+
+export interface OpenCodeTokens {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache?: { read?: number; write?: number };
+}
+
+export interface OpenCodeAssistantMessage {
+  id: string;
+  role: 'assistant';
+  parentID?: string;
+  providerID?: string;
+  modelID?: string;
+  cost?: number;
+  tokens?: OpenCodeTokens;
+  time?: { created?: number; completed?: number };
+  error?: OpenCodeErrorInfo | null;
+}
+
+export interface OpenCodeUserMessage {
+  id: string;
+  role: 'user';
+  time?: { created?: number };
+}
+
+export type OpenCodeMessage = OpenCodeUserMessage | OpenCodeAssistantMessage;
+
+export interface OpenCodePart {
+  id: string;
+  type: string; // text | reasoning | tool | step-start | step-finish | ...
+  text?: string;
+  tool?: string;
+  state?: OpenCodeToolState;
+}
+
+export interface OpenCodeToolState {
+  status: 'pending' | 'running' | 'completed' | 'error';
+  title?: string;
+  error?: string;
+  time?: { start?: number; end?: number };
+}
+
+/** A tagged `{ name, data }` failure from a `session.error` event or an
+ *  assistant message's `error` field. */
+export interface OpenCodeErrorInfo {
+  name: string;
+  data?: { message?: string; statusCode?: number; providerID?: string };
+}
+
+export interface OpenCodeModel {
+  id: string;
+  name?: string;
+  limit?: { context?: number };
+  variants?: Record<string, unknown>;
+}
+
+export interface OpenCodeProvider {
+  id: string;
+  name?: string;
+  source?: string;
+  models: Record<string, OpenCodeModel>;
+}
+
+export interface OpenCodeProviders {
+  providers: OpenCodeProvider[];
+  default: Record<string, string>;
+}
+
+export interface OpenCodeMessageRow {
+  info: OpenCodeMessage;
+  parts: OpenCodePart[];
+}
+
+export interface OpenCodePromptResult {
+  info: OpenCodeAssistantMessage;
+  parts: OpenCodePart[];
+}
+
+/** One `GET /global/event` frame's payload: `{ type, properties }`. Frames we
+ *  don't model (sync, heartbeat, plugin.added, …) still parse; the adapter
+ *  filters by `type` and `properties.sessionID`. */
+export interface OpenCodeEvent {
+  type: string;
+  properties?: { sessionID?: string; [key: string]: unknown };
+}
+
+export class OpenCodeError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'OpenCodeError';
+  }
+}
+
+/** Thrown by the spawn when OpenCode's shared SQLite is locked (another
+ *  OpenCode process is booting); the adapter's start closure retries it. */
+export class OpenCodeLockedError extends Error {
+  constructor() {
+    super('opencode database is locked');
+    this.name = 'OpenCodeLockedError';
+  }
+}
+
+const READY_TIMEOUT_MS = Number(process.env.OPENCODE_READY_TIMEOUT_MS) || 30_000;
+const LISTENING_RE = /listening on https?:\/\/[^:]+:(\d+)/i;
+
+/** An ephemeral loopback port. There is a small TOCTOU window between closing
+ *  this and OpenCode binding it; a collision surfaces as a spawn failure the
+ *  start closure retries. `--port 0` is avoided because OpenCode reads it as
+ *  "try 4096 first", which a user's terminal `opencode serve` may already hold. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const address = srv.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      srv.close(() => (port ? resolve(port) : reject(new Error('could not pick a free port'))));
+    });
+  });
+}
+
+export class OpenCodeClient {
+  private readonly base: string;
+  private readonly authHeader: string;
+  private readonly subscribers = new Set<(event: OpenCodeEvent) => void>();
+  private readonly sseAbort = new AbortController();
+  private closed = false;
+  readonly exited: Promise<void>;
+
+  constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    port: number,
+    password: string,
+  ) {
+    this.base = `http://127.0.0.1:${port}`;
+    this.authHeader = `Basic ${Buffer.from(`opencode:${password}`).toString('base64')}`;
+    this.exited = new Promise<void>((resolve) => {
+      child.once('exit', () => {
+        this.closed = true;
+        this.sseAbort.abort();
+        this.subscribers.clear();
+        resolve();
+      });
+    });
+    child.stderr.on('data', () => {}); // keep the pipe drained
+  }
+
+  // --- Event stream ----------------------------------------------------------
+
+  /** Open the single `/global/event` SSE connection and demultiplex frames to
+   *  subscribers. Runs for the child's lifetime; a read error while the child
+   *  is alive ends the loop (a turn still completes via its sync prompt call,
+   *  just without live deltas). */
+  startEventStream(): void {
+    void this.readEvents();
+  }
+
+  private async readEvents(): Promise<void> {
+    let res: Response;
+    try {
+      res = await fetch(`${this.base}/global/event`, {
+        headers: { Authorization: this.authHeader, Accept: 'text/event-stream' },
+        signal: this.sseAbort.signal,
+      });
+    } catch {
+      return;
+    }
+    if (!res.body) return;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const frames = buffer.split('\n\n');
+        buffer = frames.pop() ?? '';
+        for (const frame of frames) {
+          const line = frame.split('\n').find((l) => l.startsWith('data:'));
+          if (!line) continue;
+          let parsed: { payload?: OpenCodeEvent };
+          try {
+            parsed = JSON.parse(line.slice(5).trim());
+          } catch {
+            continue;
+          }
+          const payload = parsed.payload;
+          if (payload && typeof payload.type === 'string') {
+            for (const notify of this.subscribers) notify(payload);
+          }
+        }
+      }
+    } catch {
+      // aborted (stop) or a mid-stream read error — nothing more to demux.
+    }
+  }
+
+  onEvent(cb: (event: OpenCodeEvent) => void): () => void {
+    this.subscribers.add(cb);
+    return () => this.subscribers.delete(cb);
+  }
+
+  // --- HTTP ------------------------------------------------------------------
+
+  async request<T = unknown>(
+    method: string,
+    path: string,
+    opts: { query?: Record<string, string | undefined>; body?: unknown; signal?: AbortSignal } = {},
+  ): Promise<T> {
+    if (this.closed) throw new OpenCodeError('opencode server is not running');
+    const url = new URL(this.base + path);
+    for (const [key, value] of Object.entries(opts.query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, value);
+    }
+    const headers: Record<string, string> = { Authorization: this.authHeader };
+    if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: opts.signal,
+    });
+    if (!res.ok) {
+      let message = `opencode ${method} ${path} -> ${res.status}`;
+      try {
+        const problem = (await res.json()) as { message?: string; error?: string; data?: { message?: string } };
+        message = problem.data?.message || problem.message || problem.error || message;
+      } catch {
+        // non-JSON body
+      }
+      throw new OpenCodeError(message, res.status);
+    }
+    if (res.status === 204) return undefined as T;
+    const text = await res.text();
+    return (text ? JSON.parse(text) : undefined) as T;
+  }
+
+  createSession(directory: string): Promise<OpenCodeSession> {
+    return this.request('POST', '/session', { query: { directory }, body: {} });
+  }
+
+  getSession(sessionId: string): Promise<OpenCodeSession> {
+    return this.request('GET', `/session/${sessionId}`);
+  }
+
+  listSessions(): Promise<OpenCodeSession[]> {
+    return this.request('GET', '/session');
+  }
+
+  getMessages(sessionId: string): Promise<OpenCodeMessageRow[]> {
+    return this.request('GET', `/session/${sessionId}/message`);
+  }
+
+  deleteSession(sessionId: string, directory?: string): Promise<unknown> {
+    return this.request('DELETE', `/session/${sessionId}`, { query: { directory } });
+  }
+
+  renameSession(sessionId: string, title: string, directory?: string): Promise<unknown> {
+    return this.request('PATCH', `/session/${sessionId}`, { query: { directory }, body: { title } });
+  }
+
+  abort(sessionId: string, directory?: string): Promise<unknown> {
+    return this.request('POST', `/session/${sessionId}/abort`, { query: { directory } });
+  }
+
+  prompt(
+    sessionId: string,
+    directory: string | undefined,
+    body: {
+      agent: string;
+      parts: Array<{ type: 'text'; text: string }>;
+      model?: { providerID: string; modelID: string };
+      variant?: string;
+      system?: string;
+    },
+    signal?: AbortSignal,
+  ): Promise<OpenCodePromptResult> {
+    return this.request('POST', `/session/${sessionId}/message`, { query: { directory }, body, signal });
+  }
+
+  getProviders(): Promise<OpenCodeProviders> {
+    return this.request('GET', '/config/providers');
+  }
+
+  getConfig(): Promise<{ model?: string }> {
+    return this.request('GET', '/config');
+  }
+
+  async health(): Promise<boolean> {
+    try {
+      const body = await this.request<{ healthy?: boolean }>('GET', '/global/health');
+      return body?.healthy === true;
+    } catch {
+      return false;
+    }
+  }
+
+  kill(): void {
+    this.closed = true;
+    this.sseAbort.abort();
+    try {
+      this.child.kill('SIGKILL');
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/** Spawn `opencode serve` on a fresh loopback port, wait for the listening
+ *  line, open the event stream, and return a started child for the IdleChild
+ *  pool. Throws (with `.code = 'ENOENT'`) when the binary is missing so the
+ *  adapter can surface `503 agent_unavailable`, and `OpenCodeLockedError` when
+ *  the store is locked so the start closure can retry. */
+export async function spawnOpenCodeClient(bin: string, cwd: string): Promise<StartedChild<OpenCodeClient>> {
+  const port = await freePort();
+  const password = randomBytes(18).toString('hex');
+  const child = spawn(bin, ['serve', '--hostname', '127.0.0.1', '--port', String(port)], {
+    cwd,
+    env: {
+      ...process.env,
+      OPENCODE_SERVER_PASSWORD: password,
+      OPENCODE_DISABLE_AUTOUPDATE: '1',
+      OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
+      // Inline config wins over files, so the managed/user config in
+      // ~/.config/opencode still supplies providers, model, and MCP; this only
+      // pins the sandbox posture (run tools unprompted; never block on a
+      // question) to match the other harnesses.
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        permission: { '*': 'allow', question: 'deny' },
+        autoupdate: false,
+        share: 'disabled',
+      }),
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  try {
+    await waitForListening(child);
+  } catch (error) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // already gone
+    }
+    throw error;
+  }
+
+  const client = new OpenCodeClient(child, port, password);
+  client.startEventStream();
+  return { value: client, kill: () => client.kill(), exited: client.exited };
+}
+
+/** Resolve once OpenCode prints its "listening" line; reject on early exit
+ *  (ENOENT for a missing binary, OpenCodeLockedError for a locked store) or the
+ *  readiness timeout. */
+function waitForListening(child: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let stderrTail = '';
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.stdout.off('data', onStdout);
+      child.stderr.off('data', onStderr);
+      child.off('exit', onExit);
+      child.off('error', onError);
+      if (error) reject(error);
+      else resolve();
+    };
+    const scan = (text: string): void => {
+      if (LISTENING_RE.test(text)) finish();
+    };
+    const onStdout = (chunk: Buffer): void => scan(chunk.toString());
+    const onStderr = (chunk: Buffer): void => {
+      stderrTail = (stderrTail + chunk.toString()).slice(-4096);
+      scan(stderrTail);
+      if (/database is locked/i.test(stderrTail)) finish(new OpenCodeLockedError());
+    };
+    const onExit = (): void => {
+      if (/database is locked/i.test(stderrTail)) finish(new OpenCodeLockedError());
+      else finish(new Error(`opencode serve exited before listening.${stderrTail.trim() ? ` ${stderrTail.trim()}` : ''}`));
+    };
+    const onError = (error: NodeJS.ErrnoException): void => finish(error);
+    const timer = setTimeout(() => finish(new Error(`opencode serve did not start within ${READY_TIMEOUT_MS}ms`)), READY_TIMEOUT_MS);
+    timer.unref();
+    child.stdout.on('data', onStdout);
+    child.stderr.on('data', onStderr);
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
+}

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -2,6 +2,7 @@ import { HermesWorkerAdapter } from './adapters/hermes-worker.js';
 import { OpenClawAdapter } from './adapters/openclaw-adapter.js';
 import { ClaudeCodeAdapter } from './adapters/claude-code-adapter.js';
 import { CodexAdapter } from './adapters/codex-adapter.js';
+import { OpenCodeAdapter } from './adapters/opencode-adapter.js';
 import type { AgentAdapter } from './adapters/types.js';
 import { resolveConfiguredDefaultAgent, SUPPORTED_AGENTS, type AgentType } from '../shared/types.js';
 import { optionalEnum, queryParam } from './errors.js';
@@ -16,6 +17,7 @@ const registry: Record<AgentType, GatewayAdapter> = {
   openclaw: new OpenClawAdapter(),
   'claude-code': new ClaudeCodeAdapter(),
   codex: new CodexAdapter(),
+  opencode: new OpenCodeAdapter(),
 };
 
 export function getAdapter(agent: AgentType): GatewayAdapter {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,7 +19,7 @@ export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 /** Response modes. `chat` runs one turn; `goal` is reserved for a fast-follow. */
 export const RESPONSE_MODES = ['chat', 'goal'] as const;
 
-export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code', 'codex'] as const;
+export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code', 'codex', 'opencode'] as const;
 export type AgentType = (typeof SUPPORTED_AGENTS)[number];
 export const DEFAULT_AGENT: AgentType = 'hermes';
 

--- a/test/agent-unavailable.integration.test.ts
+++ b/test/agent-unavailable.integration.test.ts
@@ -14,6 +14,7 @@ before(async () => {
   process.env.OPENCLAW_BASE_URL = 'http://127.0.0.1:59321';
   process.env.CLAUDE_CODE_BIN = '/nonexistent/claude';
   process.env.CODEX_BIN = '/nonexistent/codex';
+  process.env.OPENCODE_BIN = '/nonexistent/opencode';
   server = await startTestServer();
   base = server.base;
 });
@@ -85,5 +86,28 @@ test('a codex request without the codex binary fails with agent_unavailable', as
   assert.equal(turnBody.error.code, 'agent_unavailable');
 
   const health = (await (await fetch(`${base}/v1/health?agent=codex`)).json()) as { healthy: boolean };
+  assert.equal(health.healthy, false);
+});
+
+test('an opencode request without the opencode binary fails with agent_unavailable', async () => {
+  const models = await fetch(`${base}/v1/models?agent=opencode`);
+  assert.equal(models.status, 503);
+  const modelsBody = (await models.json()) as { error: { code: string; message: string } };
+  assert.equal(modelsBody.error.code, 'agent_unavailable');
+  assert.match(modelsBody.error.message, /opencode/);
+
+  // OpenCode resolves its session before the response begins, so a missing
+  // binary is caught while headers are still open: the turn is a real 503, not
+  // a 200 failed body (like Codex, unlike the harnesses without resolveSession).
+  const turn = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'opencode', input: 'hello' }),
+  });
+  assert.equal(turn.status, 503);
+  const turnBody = (await turn.json()) as { error: { code: string } };
+  assert.equal(turnBody.error.code, 'agent_unavailable');
+
+  const health = (await (await fetch(`${base}/v1/health?agent=opencode`)).json()) as { healthy: boolean };
   assert.equal(health.healthy, false);
 });

--- a/test/default-agent.test.ts
+++ b/test/default-agent.test.ts
@@ -8,5 +8,6 @@ test('GATEWAY_DEFAULT_AGENT resolution: unset falls back, known passes, garbage 
   assert.equal(resolveConfiguredDefaultAgent('openclaw'), 'openclaw');
   assert.equal(resolveConfiguredDefaultAgent('claude-code'), 'claude-code');
   assert.equal(resolveConfiguredDefaultAgent('codex'), 'codex');
-  assert.throws(() => resolveConfiguredDefaultAgent('opencalw'), /must be one of: hermes, openclaw, claude-code, codex/);
+  assert.equal(resolveConfiguredDefaultAgent('opencode'), 'opencode');
+  assert.throws(() => resolveConfiguredDefaultAgent('opencalw'), /must be one of: hermes, openclaw, claude-code, codex, opencode/);
 });

--- a/test/opencode-idle.integration.test.ts
+++ b/test/opencode-idle.integration.test.ts
@@ -1,0 +1,67 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { startTestServer, postJson, type TestServer } from './test-helpers.js';
+
+// OpenCode keeps `opencode serve` resident and kills it after OPENCODE_IDLE_MS
+// idle so a casual user costs zero RAM. Force a 1s idle window, run a turn, wait
+// out the kill, then run another: the second must respawn the server
+// transparently and complete. node:test isolates each file in its own process,
+// so the tiny idle override doesn't leak into the other suites.
+
+const opencodeMissing = await new Promise<false | string>((resolve) => {
+  execFile(process.env.OPENCODE_BIN?.trim() || 'opencode', ['--version'], { timeout: 15_000 }, (error) => {
+    resolve(error ? 'no OpenCode CLI installed' : false);
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+let previousIdle: string | undefined;
+
+before(async () => {
+  previousIdle = process.env.OPENCODE_IDLE_MS;
+  process.env.OPENCODE_IDLE_MS = '1000';
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+  if (previousIdle === undefined) delete process.env.OPENCODE_IDLE_MS;
+  else process.env.OPENCODE_IDLE_MS = previousIdle;
+});
+
+async function pickModel(): Promise<string> {
+  const models = (await (await fetch(`${base}/v1/models?agent=opencode`)).json()) as {
+    default_model: string | null;
+    data: Array<{ id: string }>;
+  };
+  return (
+    models.data.find((m) => /big-pickle$/i.test(m.id))?.id ??
+    models.data.find((m) => /free/i.test(m.id))?.id ??
+    models.data.find((m) => m.id.startsWith('opencode/'))?.id ??
+    models.default_model ??
+    models.data[0].id
+  );
+}
+
+test('a turn after the idle kill respawns the OpenCode server transparently', { skip: opencodeMissing }, async () => {
+  const model = await pickModel();
+
+  const first = (await (
+    await postJson(base, { agent: 'opencode', model, input: 'Reply with just OK.', reasoning_effort: 'low' })
+  ).json()) as { status: string; session_id: string; error: unknown };
+  assert.equal(first.status, 'completed', JSON.stringify(first.error));
+
+  // Wait past OPENCODE_IDLE_MS so the resident server is idle-killed.
+  await new Promise((resolve) => setTimeout(resolve, 1800));
+
+  const second = (await (
+    await postJson(base, { agent: 'opencode', model, session_id: first.session_id, input: 'Reply with just DONE.', reasoning_effort: 'low' })
+  ).json()) as { status: string; session_id: string; error: unknown };
+  assert.equal(second.status, 'completed', JSON.stringify(second.error));
+  assert.equal(second.session_id, first.session_id);
+
+  await fetch(`${base}/v1/sessions/${first.session_id}?agent=opencode`, { method: 'DELETE' });
+});

--- a/test/opencode.integration.test.ts
+++ b/test/opencode.integration.test.ts
@@ -126,8 +126,22 @@ test('opencode responses complete, resume, and manage sessions on OpenCode\'s ow
   assert.ok(row, 'created session appears in the list');
   assert.equal(typeof row.last_active, 'number');
 
-  // Rename writes OpenCode's session title; it reads back as the row title and
-  // survives a following turn (OpenCode auto-titles only the first turn).
+  // OpenCode auto-titles the first turn asynchronously (an LLM summary that can
+  // land seconds later). Wait for it to replace the "New session …" placeholder
+  // before renaming, so that one-shot auto-title can't clobber the rename after
+  // the fact; then the write/read below is the gateway's own contract.
+  const titleRow = async (): Promise<string | null> => {
+    const list = await jsonOk<{ data: Array<{ id: string; title: string | null }> }>(
+      await fetch(`${base}/v1/sessions?agent=opencode`),
+    );
+    return list.data.find((s) => s.id === created.session_id)?.title ?? null;
+  };
+  for (let i = 0; i < 30; i++) {
+    const t = await titleRow();
+    if (t && !/^New session/.test(t)) break;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
   const title = `integration-rename-${marker}`;
   const rename = await jsonOk<{ renamed: boolean }>(
     await fetch(`${base}/v1/sessions/${created.session_id}?agent=opencode`, {
@@ -137,13 +151,7 @@ test('opencode responses complete, resume, and manage sessions on OpenCode\'s ow
     }),
   );
   assert.equal(rename.renamed, true);
-  await jsonOk<ResponseBody>(
-    await postJson(base, { agent: 'opencode', model, session_id: created.session_id, input: 'Reply with just OK.', reasoning_effort: 'low' }),
-  );
-  const renamedList = await jsonOk<{ data: Array<{ id: string; title: string | null }> }>(
-    await fetch(`${base}/v1/sessions?agent=opencode`),
-  );
-  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.title, title);
+  assert.equal(await titleRow(), title);
 
   // Models are OpenCode's provider catalog, each owned by its provider.
   const models = await jsonOk<{ agent: string; data: Array<{ id: string; owned_by: string; source: string }> }>(
@@ -193,6 +201,13 @@ test('opencode responses complete, resume, and manage sessions on OpenCode\'s ow
   const madeUpBody = (await madeUp.json()) as { error: { code: string; param?: string } };
   assert.equal(madeUpBody.error.code, 'validation_error');
   assert.equal(madeUpBody.error.param, 'session_id');
+
+  // A bare/malformed model id is rejected, not silently run on the default and
+  // mislabelled as the requested model.
+  const badModel = await jsonOk<ResponseBody>(await postJson(base, { agent: 'opencode', model: 'not-a-real-model', input: 'hi' }));
+  assert.equal(badModel.status, 'failed');
+  assert.equal(badModel.error?.code, 'model_error');
+  await fetch(`${base}/v1/sessions/${badModel.session_id}?agent=opencode`, { method: 'DELETE' });
 });
 
 test('an in-flight opencode turn can be cancelled', { skip: opencodeSkip }, async () => {

--- a/test/opencode.integration.test.ts
+++ b/test/opencode.integration.test.ts
@@ -1,0 +1,229 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+// --- OpenCode adapter. Like Claude Code and Codex (and unlike the optional
+// OpenClaw probe), OpenCode ships in a release image, so a missing CLI FAILS
+// the suite via the gate test below rather than silently skipping. The happy
+// path runs on a free Zen model (`opencode/*-free`) so it costs nothing; a
+// managed or BYO-keyed instance answers the same way.
+
+const opencodeSkip = await new Promise<false | string>((resolve) => {
+  execFile(process.env.OPENCODE_BIN?.trim() || 'opencode', ['--version'], { timeout: 15_000 }, (error) => {
+    resolve(error ? 'OpenCode is not installed' : false);
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+
+before(async () => {
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+});
+
+interface ResponseBody {
+  id: string;
+  session_id: string;
+  status: string;
+  agent: string;
+  output_text: string;
+  usage: { input_tokens: number; output_tokens: number; cost_usd: number | null } | null;
+  context: { used_tokens: number; window_tokens: number } | null;
+  error: { code: string; message: string; hint?: string } | null;
+}
+
+async function jsonOk<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  assert.equal(res.status, 200, JSON.stringify(body));
+  return body as T;
+}
+
+/** A no-cost model to run the suite on: prefer `big-pickle` (a stable Zen model
+ *  that reports usage), else any free Zen model, else the configured default,
+ *  else the first model the instance advertises. */
+async function pickModel(): Promise<string> {
+  const models = await jsonOk<{ default_model: string | null; data: Array<{ id: string }> }>(
+    await fetch(`${base}/v1/models?agent=opencode`),
+  );
+  assert.ok(models.data.length > 0, 'OpenCode advertises at least one model');
+  return (
+    models.data.find((m) => /big-pickle$/i.test(m.id))?.id ??
+    models.data.find((m) => /free/i.test(m.id))?.id ??
+    models.data.find((m) => m.id.startsWith('opencode/'))?.id ??
+    models.default_model ??
+    models.data[0].id
+  );
+}
+
+test('OpenCode CLI is installed (required — its tests must run)', () => {
+  assert.equal(opencodeSkip, false, `OpenCode tests did not run: ${opencodeSkip}. Install OpenCode — a green suite must include this harness.`);
+});
+
+test('opencode responses complete, resume, and manage sessions on OpenCode\'s own store', { skip: opencodeSkip }, async () => {
+  const model = await pickModel();
+  const marker = `opencode-marker-${Date.now()}`;
+  const created = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'opencode',
+      model,
+      input: `Remember this marker: ${marker}. Reply with just OK.`,
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(created.status, 'completed', JSON.stringify(created.error));
+  assert.equal(created.agent, 'opencode');
+  // An OpenCode session id; the harness store owns it, so a client can't bring
+  // its own on the first turn (see the made-up-id case below).
+  assert.match(created.session_id, /^ses_/);
+  assert.ok(created.output_text.trim().length > 0);
+  // The gateway projects whatever OpenCode reports; the shape is the contract
+  // (some free models report zero token counts, so don't assert a positive).
+  assert.ok(created.usage, 'usage is reported');
+  assert.equal(typeof created.usage.input_tokens, 'number');
+  assert.equal(typeof created.usage.output_tokens, 'number');
+  // OpenCode always reports a cost number (0 on free/unpriced models).
+  assert.equal(typeof created.usage.cost_usd, 'number');
+
+  assert.deepEqual(await jsonOk(await fetch(`${base}/v1/health?agent=opencode`)), {
+    ok: true,
+    agent: 'opencode',
+    healthy: true,
+  });
+
+  // A known session id resumes it, so the marker is recalled.
+  const recalled = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'opencode',
+      model,
+      session_id: created.session_id,
+      input: 'Reply with just the marker I asked you to remember.',
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(recalled.status, 'completed', JSON.stringify(recalled.error));
+  assert.equal(recalled.session_id, created.session_id);
+  assert.ok(recalled.output_text.includes(marker), recalled.output_text);
+
+  // History projects OpenCode's own session; reads name `?agent=opencode`.
+  const session = await jsonOk<{ history: { role: string; content: string; created_at: number }[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=opencode`),
+  );
+  assert.ok(session.history.some((m) => m.role === 'user' && m.content.includes(marker)));
+  assert.ok(session.history.some((m) => m.role === 'assistant'));
+
+  // The list is OpenCode's own session list.
+  const list = await jsonOk<{ agent: string; data: Array<{ id: string; title: string | null; last_active: number | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=opencode`),
+  );
+  assert.equal(list.agent, 'opencode');
+  const row = list.data.find((s) => s.id === created.session_id);
+  assert.ok(row, 'created session appears in the list');
+  assert.equal(typeof row.last_active, 'number');
+
+  // Rename writes OpenCode's session title; it reads back as the row title and
+  // survives a following turn (OpenCode auto-titles only the first turn).
+  const title = `integration-rename-${marker}`;
+  const rename = await jsonOk<{ renamed: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=opencode`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title }),
+    }),
+  );
+  assert.equal(rename.renamed, true);
+  await jsonOk<ResponseBody>(
+    await postJson(base, { agent: 'opencode', model, session_id: created.session_id, input: 'Reply with just OK.', reasoning_effort: 'low' }),
+  );
+  const renamedList = await jsonOk<{ data: Array<{ id: string; title: string | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=opencode`),
+  );
+  assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.title, title);
+
+  // Models are OpenCode's provider catalog, each owned by its provider.
+  const models = await jsonOk<{ agent: string; data: Array<{ id: string; owned_by: string; source: string }> }>(
+    await fetch(`${base}/v1/models?agent=opencode`),
+  );
+  assert.equal(models.agent, 'opencode');
+  assert.ok(models.data.length > 0);
+  assert.ok(models.data.every((m) => m.source === 'catalog' && typeof m.owned_by === 'string'));
+
+  const stream = await postJson(base, {
+    agent: 'opencode',
+    model,
+    input: 'Reply with exactly this word: PONG',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(stream.status, 200);
+  const events = await new SseReader(stream).drain();
+  assert.equal(events[0]?.event, 'response.created');
+  assert.ok(events.some((event) => event.event === 'response.output_text.delta'));
+  assert.equal(events.at(-1)?.event, 'response.completed');
+  await fetch(`${base}/v1/sessions/${events[0]?.data.session_id as string}?agent=opencode`, { method: 'DELETE' });
+
+  // Delete removes the session; its history then projects empty.
+  const deleted = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=opencode`, { method: 'DELETE' }),
+  );
+  assert.equal(deleted.deleted, true);
+  const gone = await jsonOk<{ history: unknown[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=opencode`),
+  );
+  assert.deepEqual(gone.history, []);
+
+  // Deleting an unknown session is not an error.
+  const unknown = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/ses_00000000000000000000000000?agent=opencode`, { method: 'DELETE' }),
+  );
+  assert.equal(unknown.deleted, false);
+
+  // A client cannot invent a session_id on opencode: an unknown id is a 400.
+  const madeUp = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'opencode', session_id: 'ses_notarealsession', input: 'hello' }),
+  });
+  assert.equal(madeUp.status, 400);
+  const madeUpBody = (await madeUp.json()) as { error: { code: string; param?: string } };
+  assert.equal(madeUpBody.error.code, 'validation_error');
+  assert.equal(madeUpBody.error.param, 'session_id');
+});
+
+test('an in-flight opencode turn can be cancelled', { skip: opencodeSkip }, async () => {
+  const model = await pickModel();
+  const slow = await postJson(base, {
+    agent: 'opencode',
+    model,
+    input: 'Run the shell command `sleep 30` and then reply with the word done.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(slow.status, 200);
+
+  const reader = new SseReader(slow);
+  const opening = await reader.until((event) => event.event !== 'response.created');
+  const created = opening.find((event) => event.event === 'response.created');
+  assert.ok(created);
+  const responseId = created.data.id as string;
+  const sessionId = created.data.session_id as string;
+
+  const cancel = await fetch(`${base}/v1/responses/${responseId}/cancel`, { method: 'POST' });
+  assert.equal(cancel.status, 200);
+  await reader.drain();
+
+  // Whatever the model did, the session lock releases and the turn settles.
+  const settled = await jsonOk<{ active_response_id: string | null }>(
+    await fetch(`${base}/v1/sessions/${sessionId}?agent=opencode`),
+  );
+  assert.equal(settled.active_response_id, null);
+  const replay = await new SseReader(await fetch(`${base}/v1/responses/${responseId}/stream`)).drain();
+  assert.equal(replay.at(-1)?.event, 'response.completed');
+
+  await fetch(`${base}/v1/sessions/${sessionId}?agent=opencode`, { method: 'DELETE' });
+});

--- a/test/reasoning-mapping.test.ts
+++ b/test/reasoning-mapping.test.ts
@@ -7,6 +7,7 @@ import { REASONING_EFFORTS } from '../shared/types.js';
 import { effortOptions } from '../server/adapters/claude-code-adapter.js';
 import { THINKING_MAP } from '../server/adapters/openclaw-adapter.js';
 import { codexEffort } from '../server/adapters/codex-adapter.js';
+import { opencodeVariant } from '../server/adapters/opencode-adapter.js';
 
 test('the public enum runs none through ultra', () => {
   assert.deepEqual([...REASONING_EFFORTS], ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
@@ -39,6 +40,24 @@ test('codex: none/minimal floor to low, the rest map by name, ultra stays ultra'
   // Every public effort resolves to a Codex value (the turn/start effort is a
   // free-form string, but a mapping must exist for each level).
   for (const effort of REASONING_EFFORTS) assert.ok(codexEffort(effort), `${effort} unmapped`);
+});
+
+test('opencode: none omits the variant, max/ultra map to max, the rest map by name', () => {
+  assert.equal(opencodeVariant(null), undefined);
+  assert.equal(opencodeVariant(undefined), undefined);
+  assert.equal(opencodeVariant('none'), undefined);
+  assert.equal(opencodeVariant('minimal'), 'minimal');
+  assert.equal(opencodeVariant('low'), 'low');
+  assert.equal(opencodeVariant('medium'), 'medium');
+  assert.equal(opencodeVariant('high'), 'high');
+  assert.equal(opencodeVariant('xhigh'), 'xhigh');
+  assert.equal(opencodeVariant('max'), 'max');
+  assert.equal(opencodeVariant('ultra'), 'max');
+  // Every reasoning level except `none` yields a variant (none is "omit").
+  for (const effort of REASONING_EFFORTS) {
+    if (effort === 'none') continue;
+    assert.ok(opencodeVariant(effort), `${effort} unmapped`);
+  }
 });
 
 test('openclaw: every effort has a thinking level', () => {


### PR DESCRIPTION
## What

Adds **OpenCode** as the fifth harness behind the `AgentAdapter` seam, mirroring the Codex adapter shipped in v0.11.0. Pick it per request with `"agent": "opencode"`.

The adapter drives a resident `opencode serve` (OpenCode's local HTTP API plus its one `/global/event` SSE stream), kept warm by the shared `idle-child` and killed after `OPENCODE_IDLE_MS` idle (10 minutes by default) so a casual user costs zero RAM. A gateway session id **is** an OpenCode session id, resolved before the response begins via the Phase 1 `resolveSession` seam (create-on-first-turn, or verify). It answers on the managed Agent37 model out of the box; BYO providers register from instance env keys. The gateway never reads credentials.

## How it maps

- **Streaming**: `POST /session/{id}/message` (sync final `{info, parts}`) run in parallel with the event stream. Text and reasoning deltas both arrive as `field:"text"`, so the adapter classifies each by the part type registered from `message.part.updated` (never by `field`). Tool progress rides `message.part.updated` state transitions.
- **Usage**: sums the turn's assistant messages (matched by `parentID`, deduped by id); `input + cache.read + cache.write` / `output` / `cost` (0 on free models). Context = final message prompt + output vs the model's `limit.context`.
- **Effort**: `reasoning_effort` maps onto OpenCode's prompt `variant` (`none` omits it, `low`..`xhigh` by name, `max`/`ultra` to `max`), clamped to the target model's advertised `variants`.
- **Sessions / models / health**: OpenCode's own store; models are its provider catalog in `provider/model` form; health is binary-present (probes the server only when already warm).

## Files

- `server/adapters/opencode-server.ts` (spawn + basic-auth HTTP client + SSE demux; retries a locked SQLite store)
- `server/adapters/opencode-adapter.ts` (the seam + exported `opencodeVariant()`)
- registry + `SUPPORTED_AGENTS` + default-agent regex + reasoning-map unit test
- `test/opencode.integration.test.ts`, `test/opencode-idle.integration.test.ts`, `agent-unavailable` opencode cases
- README / AGENTS.md / `.env.example` / bruno (9 requests, seq 34-42) / `package.json` (v0.12.0)

## Testing

`npm run typecheck` clean. `npm test` is **55/57**: the only 2 failures are the pre-existing OpenClaw turn tests (local `operator.write` scope, identical on clean `main`). All OpenCode, Hermes, Claude Code, Codex, and files tests pass. The happy path runs on a free Zen model so it costs nothing.