### PR TITLE
Grok adapter: a sixth harness behind the same seam (v0.13.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # --- Gateway HTTP server ---
 PORT=3737                 # Port to listen on
 HOST=0.0.0.0              # Interface to bind (0.0.0.0 so the host/Docker can reach it)
-GATEWAY_DEFAULT_AGENT=    # Agent a turn routes to when the request omits `agent` (hermes|openclaw|claude-code|codex|opencode; default hermes; any other value fails at boot)
+GATEWAY_DEFAULT_AGENT=    # Agent a turn routes to when the request omits `agent` (hermes|openclaw|claude-code|codex|opencode|grok; default hermes; any other value fails at boot)
 
 # --- Gateway state ---
 AGENT37_GATEWAY_HOME=~/.agent37-gateway   # Root for the SQLite db, logs, and the agent workspace
@@ -45,3 +45,10 @@ CODEX_IDLE_MS=30000                        # How long `codex app-server` lingers
 # their env keys (e.g. OPENAI_API_KEY, OPENROUTER_API_KEY). No gateway-side credentials.
 OPENCODE_BIN=                              # Path to the `opencode` binary (default: the one on PATH)
 OPENCODE_IDLE_MS=600000                    # How long `opencode serve` stays resident after the last call before it is killed
+
+# --- Grok (the `agent: "grok"` route) ---
+# The adapter runs one headless `grok -p` process per turn (no resident server,
+# zero idle RAM) on grok's own credentials: XAI_API_KEY in the environment, or
+# `grok login` on the box. The gateway never reads the key's value.
+GROK_BIN=                                  # Path to the `grok` binary (default: the one on PATH)
+GROK_HOME=                                 # Grok config/session dir (default: ~/.grok)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,12 @@ Guidance for AI coding agents working in this repo. `CLAUDE.md` imports this fil
 
 ## What this is
 
-The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), Claude Code (the Claude Agent SDK), Codex (`codex app-server` over stdio), and OpenCode (a resident `opencode serve` over HTTP). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
+The Agent37 Gateway: the Responses-style HTTP API (`/v1`, port 3737) that runs inside each Agent37 instance and drives whichever harness a request targets through the `AgentAdapter` seam: Hermes (via a Python worker), OpenClaw (its WebSocket RPC), Claude Code (the Claude Agent SDK), Codex (`codex app-server` over stdio), OpenCode (a resident `opencode serve` over HTTP), and Grok (one headless `grok -p` process per turn). A turn picks its harness with the `agent` field; `GATEWAY_DEFAULT_AGENT` sets the default when `agent` is omitted (a container only runs the backend(s) it was provisioned with, so targeting an unprovisioned harness fails at request time). `README.md` is the API contract (request shapes, SSE events, error codes); keep it exact when the surface changes — it feeds the hosted reference at `www.agent37.com/docs`.
 
 Orientation (Node >= 24, TypeScript ESM):
 
 - `server/routes/` — the `/v1` surface (responses, sessions, models, files)
-- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, Claude Code, Codex, and OpenCode adapters (Codex: `codex-adapter.ts` + `codex-app-server.ts`; OpenCode: `opencode-adapter.ts` + `opencode-server.ts`; both share the `idle-child.ts` spawn-with-idle-kill helper), and the JSONL worker protocol (`worker-protocol.ts`)
+- `server/adapters/` — the `AgentAdapter` seam (`types.ts`), the Hermes, OpenClaw, Claude Code, Codex, OpenCode, and Grok adapters (Codex: `codex-adapter.ts` + `codex-app-server.ts`; OpenCode: `opencode-adapter.ts` + `opencode-server.ts`; both share the `idle-child.ts` spawn-with-idle-kill helper; Grok: `grok-adapter.ts`, one process per turn, no resident child), and the JSONL worker protocol (`worker-protocol.ts`)
 - `server/workers/hermes_worker.py` — the Python side; imports Hermes directly. `npm run selftest:worker` checks it can reach Hermes without booting the server
 - `server/live-runs.ts` + `server/response-store.ts` — in-memory replayable event buffers for in-flight responses, and in-memory (TTL/count-bounded, lost on restart) response metadata; session metadata is never stored — session lists and transcripts project from the session's harness backend (Hermes' SessionDB, OpenClaw's history, ...)
 - `shared/types.ts` — the public API types; `test/` — the integration suite; `bruno/` — hand-poke collection (see `bruno/README.md`)
@@ -32,7 +32,7 @@ Both must pass. Never open a PR on a red or un-run suite — fix the code (or th
 
 The OpenClaw tests in the suite auto-skip when no local OpenClaw gateway is running. If your change touches the OpenClaw adapter or routing, start OpenClaw locally (`openclaw start`, port 18789) so those tests actually run. The adapter speaks OpenClaw's WebSocket gateway RPC and needs one thing from `~/.openclaw/openclaw.json`: its `gateway.auth.token` copied into `OPENCLAW_TOKEN` in your `.env`. See "Set up OpenClaw" in `README.md`.
 
-The Claude Code, Codex, and OpenCode tests are NOT optional: a missing CLI fails the suite (all three ship in release images, so a green run must include them). Install the CLIs and log in where needed (`claude auth login`; `codex login`, or `codex login --with-api-key`; OpenCode runs on a free or managed model, no login); the Claude Code and Codex tests run on those logins and cost real usage.
+The Claude Code, Codex, OpenCode, and Grok tests are NOT optional: a missing CLI fails the suite (all four ship in release images, so a green run must include them). Install the CLIs and log in where needed (`claude auth login`; `codex login`, or `codex login --with-api-key`; OpenCode runs on a free or managed model, no login; Grok needs `GROK_BIN` + `XAI_API_KEY` in `.env`); the Claude Code, Codex, and Grok tests run on those credentials and cost real usage.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ shape are the same whatever agent is behind it — so client code doesn't change
 when the agent does.
 
 Today it routes to **Hermes** (the default), **OpenClaw**, **Claude Code**,
-**Codex**, and **OpenCode**: pick per request with the `agent` field.
+**Codex**, **OpenCode**, and **Grok**: pick per request with the `agent` field.
 
 > Want the hosted API? Use [Agent37 Cloud](https://www.agent37.com/cloud). This
 > repo is the gateway service that powers an Agent37 agent.
@@ -227,6 +227,51 @@ Then route any turn to it with `"agent": "opencode"`. The adapter runs the
 the default model come from OpenCode's own config (`~/.config/opencode`); the
 Agent37 image writes the managed `agent37` provider there.
 
+## How it talks to Grok
+
+The Grok adapter drives [Grok Build](https://docs.x.ai/build/overview) (xAI's
+`grok` CLI) headless: one `grok -p` process per turn, streaming NDJSON
+(`--output-format streaming-json`), exiting when the turn ends — no resident
+server, so an idle instance costs zero RAM. Tools run auto-approved
+(`--always-approve`; the instance is the customer's own box, as with the other
+harnesses) with grok's internal sandbox off — the container is the sandbox.
+Text and reasoning deltas, tool calls and their results stream back as the same
+SSE events, and cancel is real (the turn's process is interrupted).
+
+A gateway session id **is** a Grok session id (a UUID in grok's own store,
+`~/.grok/sessions`): the gateway resolves it before a turn begins. A turn with
+no `session_id` mints a UUID and hands it to grok on the session's first turn;
+a turn with one resumes that session (an id grok doesn't know is a
+`400 validation_error`). Sessions, history, and delete all go through grok's
+own store; the gateway keeps no index. `GET /v1/sessions?agent=grok` lists that
+store (including sessions started from a terminal), `GET /v1/sessions/{id}`
+projects the transcript, and `DELETE /v1/sessions/{id}` removes the session.
+Grok stores no editable title, so rename answers `405 rename_unsupported`.
+
+The gateway passes no credential: grok runs on its own auth — `XAI_API_KEY` in
+the instance environment (pay-as-you-go via api.x.ai), or `grok login` on the
+box. Until one is present, a turn fails with the documented `auth_error` and
+`GET /v1/health?agent=grok` reports `healthy: false`.
+
+`GET /v1/models?agent=grok` lists grok's live per-key catalog (`owned_by: xai`);
+unkeyed it is an empty list, never an error. A turn's `model` picks one and
+`reasoning_effort` maps onto grok's `--reasoning-effort` (levels by name,
+`ultra` → `max`; grok ignores the flag on non-reasoning models). `usage`
+reports grok's per-turn tokens and real USD cost.
+
+### Set up Grok
+
+Install Grok Build on the machine the gateway runs on and set a key:
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash
+export XAI_API_KEY=xai-...   # or: grok login
+```
+
+Then route any turn to it with `"agent": "grok"`. The adapter runs the `grok`
+on `PATH`; set `GROK_BIN` to pin a specific binary and `GROK_HOME` to move its
+config/session store (default `~/.grok`).
+
 ## Quickstart
 
 **Prerequisites:**
@@ -277,7 +322,7 @@ behind the host, which handles and forwards authentication.
 | Field | Type | Notes |
 | --- | --- | --- |
 | `input` | string, required | The message or task. |
-| `agent` | string | `hermes`, `openclaw`, `claude-code`, `codex`, or `opencode`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
+| `agent` | string | `hermes`, `openclaw`, `claude-code`, `codex`, `opencode`, or `grok`. Defaults to the gateway's configured default (`GATEWAY_DEFAULT_AGENT`, `hermes` out of the box). Routing is per request, so include it on every turn of a non-default session. |
 | `session_id` | string | Continue a conversation. Omit to start a new one. |
 | `files` | string[] | Absolute paths of files to attach (write them first with `PUT /v1/files/content`). Appended to the message as an `[Attached files: …]` block; the agent reads them from disk. |
 | `stream` | boolean | `true` for Server-Sent Events; default `false`. |
@@ -332,9 +377,9 @@ running response as `active_response_id`.
 
 | Action | Endpoint |
 | --- | --- |
-| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code\|codex\|opencode`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
+| List | `GET /v1/sessions` → `{ agent, data: [...] }` (select the harness with `?agent=hermes\|openclaw\|claude-code\|codex\|opencode\|grok`). Every row is the same shape regardless of harness: `{ id, title, last_active, message_count, preview }` — `title` is the harness's own editable title (what rename writes), `last_active` is epoch ms, and fields a harness doesn't track are `null`. |
 | Retrieve, with history | `GET /v1/sessions/{id}` → `{ id, agent, active_response_id, history, context }` (`?agent=` to pick the harness; `context` is the session's last reported context window, null until a turn reports one) |
-| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title; Codex stores it as the thread name; OpenCode stores it as the session title). A harness without an editable title answers `405 rename_unsupported`. |
+| Rename | `PATCH /v1/sessions/{id}` with `{ "title": "…" }` → `{ id, agent, renamed }`. Writes the title straight into the harness's own store (Hermes titles are length-capped and must be unique — a clash is `409 title_conflict`; OpenClaw stores it as the session label; Claude Code stores it as its custom session title; Codex stores it as the thread name; OpenCode stores it as the session title). A harness without an editable title (Grok) answers `405 rename_unsupported`. |
 | Delete | `DELETE /v1/sessions/{id}` |
 
 `active_response_id` is the id of the `in_progress` response on the session, or
@@ -418,8 +463,8 @@ and stored paths assume the instance's home directory stays stable.
 
 | Action | Endpoint |
 | --- | --- |
-| Models a harness can run | `GET /v1/models` (configured default; add `?agent=hermes\|openclaw\|claude-code\|codex` to target one) |
-| Liveness + harness reachability | `GET /v1/health` (configured default; add `?agent=hermes\|openclaw\|claude-code\|codex` to target one) |
+| Models a harness can run | `GET /v1/models` (configured default; add `?agent=hermes\|openclaw\|claude-code\|codex\|opencode\|grok` to target one) |
+| Liveness + harness reachability | `GET /v1/health` (configured default; add `?agent=hermes\|openclaw\|claude-code\|codex\|opencode\|grok` to target one) |
 | Version | `GET /v1/version` |
 
 `GET /v1/health` reports on the gateway's configured default harness, or the
@@ -484,8 +529,8 @@ Every error returns a stable, machine-readable body. Branch on `code`, show
 Agent/worker failures surface their own `code` and `hint` where available (e.g.
 `auth_error`, `quota_exhausted`, `model_error`). One response runs at a time per
 session; sending a new turn while one is in flight returns `409 session_busy`,
-with the running response's id in `error.response_id`. On `codex` and
-`opencode`, which resolve the session before the turn starts, a turn that can't
+with the running response's id in `error.response_id`. On `codex`, `opencode`,
+and `grok`, which resolve the session before the turn starts, a turn that can't
 reach the harness (its binary isn't on the instance) is a real `503
 agent_unavailable`, not a `200` failed body.
 

--- a/bruno/gateway/01 Health (grok).bru
+++ b/bruno/gateway/01 Health (grok).bru
@@ -1,0 +1,35 @@
+meta {
+  name: 01 Health (grok)
+  type: http
+  seq: 43
+}
+
+get {
+  url: {{baseUrl}}/v1/health?agent=grok
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: grok
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("reports Grok health", function () {
+    expect(res.body.ok).to.equal(true);
+    expect(res.body.agent).to.equal("grok");
+    expect(res.body.healthy).to.be.a("boolean");
+  });
+}
+
+docs {
+  Liveness + whether the Grok harness backend is reachable, selected
+  with `?agent=grok`. The gateway runs Grok Build headless, one `grok -p`
+  process per turn. `healthy` is false until this machine has Grok
+  installed (`grok` on PATH, or GROK_BIN) and a credential present
+  (XAI_API_KEY in the environment, or `grok login` on the box).
+}

--- a/bruno/gateway/03 List Models (grok).bru
+++ b/bruno/gateway/03 List Models (grok).bru
@@ -1,0 +1,35 @@
+meta {
+  name: 03 List Models (grok)
+  type: http
+  seq: 44
+}
+
+get {
+  url: {{baseUrl}}/v1/models?agent=grok
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: grok
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("is a Grok model list", function () {
+    expect(res.body.object).to.equal("list");
+    expect(res.body.agent).to.equal("grok");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The models the Grok harness can run, selected with `?agent=grok`. This
+  is grok's live per-key catalog (`owned_by: xai`); with no XAI_API_KEY
+  set the list is empty (200, `default_model: null`), never an auth
+  error. Needs Grok installed on this machine (`grok` on PATH, or
+  GROK_BIN): otherwise the gateway returns 503 agent_unavailable.
+}

--- a/bruno/gateway/04 Create Response (grok).bru
+++ b/bruno/gateway/04 Create Response (grok).bru
@@ -1,0 +1,56 @@
+meta {
+  name: 04 Create Response (grok)
+  type: http
+  seq: 45
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "What is the time now in IST?",
+    "agent": "grok",
+    "reasoning_effort": "low"
+  }
+}
+
+script:post-response {
+  if (res.status === 200 && res.body) {
+    if (res.body.session_id) bru.setEnvVar("grokSessionId", res.body.session_id, { persist: true });
+    if (res.body.id) bru.setEnvVar("grokResponseId", res.body.id, { persist: true });
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("completed with text", function () {
+    expect(res.body.id).to.be.a("string");
+    expect(res.body.session_id).to.be.a("string");
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("grok");
+    expect(res.body.output_text).to.be.a("string");
+  });
+}
+
+docs {
+  Start a new Grok session. Pass `"agent": "grok"`: the gateway runs
+  Grok Build headless (`grok -p`), one process per turn on grok's own
+  credentials.
+
+  The reply saves `grokSessionId` and `grokResponseId` to the
+  environment so the follow-up requests below can reuse them.
+
+  Grok must be installed on this machine (`grok` on PATH, or GROK_BIN)
+  with XAI_API_KEY in the environment (or `grok login` run on the box).
+}

--- a/bruno/gateway/05 Continue Session (grok).bru
+++ b/bruno/gateway/05 Continue Session (grok).bru
@@ -1,0 +1,42 @@
+meta {
+  name: 05 Continue Session (grok)
+  type: http
+  seq: 46
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "session_id": "{{grokSessionId}}",
+    "input": "In one short sentence, what did I just ask you to say?",
+    "agent": "grok",
+    "reasoning_effort": "low"
+  }
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("same session, completed", function () {
+    expect(res.body.session_id).to.equal(bru.getEnvVar("grokSessionId"));
+    expect(res.body.status).to.equal("completed");
+    expect(res.body.agent).to.equal("grok");
+  });
+}
+
+docs {
+  Continue a Grok conversation. Reuses `grokSessionId` saved by
+  "04 Create Response (grok)". Always include `"agent": "grok"` so the
+  gateway routes the turn to the right backend.
+}

--- a/bruno/gateway/07 Create Response (streaming) (grok).bru
+++ b/bruno/gateway/07 Create Response (streaming) (grok).bru
@@ -1,0 +1,40 @@
+meta {
+  name: 07 Create Response (streaming) (grok)
+  type: http
+  seq: 47
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "input": "Count from 1 to 5, one number per line.",
+    "agent": "grok",
+    "reasoning_effort": "low",
+    "stream": true
+  }
+}
+
+docs {
+  Streaming is agent-agnostic: pass `"agent": "grok"` alongside
+  `"stream": true` and the gateway streams the Grok turn back as
+  Server-Sent Events, exactly like the Hermes streaming request above:
+    response.created -> response.reasoning.delta / response.output_text.delta /
+    response.tool_call.* -> response.completed (or response.failed)
+
+  The Grok adapter reads the turn's `--output-format streaming-json`
+  NDJSON and re-emits it as gateway SSE, so there is no extra setup
+  beyond a Grok install and an XAI_API_KEY:
+
+    curl -N localhost:3737/v1/responses \
+      -H 'content-type: application/json' \
+      -d '{"input":"hi","agent":"grok","stream":true}'
+}

--- a/bruno/gateway/09 List Sessions (grok).bru
+++ b/bruno/gateway/09 List Sessions (grok).bru
@@ -1,0 +1,34 @@
+meta {
+  name: 09 List Sessions (grok)
+  type: http
+  seq: 48
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions?agent=grok
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: grok
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("grok sessions", function () {
+    expect(res.body.agent).to.equal("grok");
+    expect(res.body.data).to.be.an("array");
+  });
+}
+
+docs {
+  The Grok chat sessions on this instance, selected with `?agent=grok`,
+  projected from grok's own session store (`~/.grok/sessions`) as
+  `{ agent, data }`. Omitting `?agent=` falls back to the instance's
+  default harness: not a merged listing. Unknown agent values return a
+  400 validation_error.
+}

--- a/bruno/gateway/10 Get Session (grok history).bru
+++ b/bruno/gateway/10 Get Session (grok history).bru
@@ -1,0 +1,34 @@
+meta {
+  name: 10 Get Session (grok history)
+  type: http
+  seq: 49
+}
+
+get {
+  url: {{baseUrl}}/v1/sessions/{{grokSessionId}}?agent=grok
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: grok
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("includes transcript history", function () {
+    expect(res.body.id).to.equal(bru.getEnvVar("grokSessionId"));
+    expect(res.body.agent).to.equal("grok");
+    expect(res.body.history).to.be.an("array");
+  });
+}
+
+docs {
+  The Grok session plus its transcript. Reuses `grokSessionId` saved by
+  "04 Create Response (grok)". History is projected on demand from
+  grok's own transcript store: the gateway never duplicates messages.
+  An unknown or deleted id projects to an empty array.
+}

--- a/bruno/gateway/12 Delete Session (grok).bru
+++ b/bruno/gateway/12 Delete Session (grok).bru
@@ -1,0 +1,32 @@
+meta {
+  name: 12 Delete Session (grok)
+  type: http
+  seq: 50
+}
+
+delete {
+  url: {{baseUrl}}/v1/sessions/{{grokSessionId}}?agent=grok
+  body: none
+  auth: none
+}
+
+params:query {
+  agent: grok
+}
+
+tests {
+  test("returns 200", function () {
+    expect(res.status).to.equal(200);
+  });
+
+  test("deleted", function () {
+    expect(res.body.deleted).to.equal(true);
+  });
+}
+
+docs {
+  Permanently remove the Grok session from grok's own store. Other
+  sessions on the instance are untouched. Grok has no editable session
+  title, so there is no "15 Rename Session (grok)": a rename PATCH
+  answers 405 rename_unsupported.
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, Claude Code, Codex, or OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/server/adapters/grok-adapter.ts
+++ b/server/adapters/grok-adapter.ts
@@ -1,0 +1,448 @@
+import { execFile, execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import type {
+  AgentDefaults,
+  AgentModelsResponse,
+  HermesMessage,
+  ReasoningEffort,
+  SessionMetadata,
+  SessionSummary,
+  TurnUsage,
+} from '../../shared/types.js';
+import type { AgentAdapter, AgentRunOptions, StreamEvent } from './types.js';
+import { epochMillis } from './types.js';
+import { resolveWorkspaceDir } from '../paths.js';
+import { validationError } from '../errors.js';
+
+// The adapter drives Grok Build (`grok`) headless: one `grok -p` process per
+// turn, streaming NDJSON (`--output-format streaming-json`), exiting when the
+// turn ends — so at-rest RAM is zero and there is no resident server to manage.
+// Session ids are UUIDs living in grok's own store
+// (`~/.grok/sessions/<url-encoded-cwd>/<uuid>/`): the gateway mints the UUID in
+// `resolveSession` and hands it to grok with `-s` on the session's first turn
+// (grok accepts a caller-supplied UUID for a NEW session only), then resumes
+// with `-r`; a client cannot invent an id (400 validation_error). Credentials
+// are grok's own (`XAI_API_KEY` in the instance env, or `grok login` on the
+// box); the gateway never reads the key's value.
+
+const INTERRUPT_GRACE_MS = 5_000;
+const LOGIN_HINT =
+  'Set XAI_API_KEY in the instance environment, or run `grok login --device-code` in the instance terminal.';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Our public effort ladder → grok's `--reasoning-effort`. Grok advertises
+// none/minimal/low/medium/high/xhigh/max and has no ultra (its multi-agent
+// mode is a model, not an effort), so `ultra` maps to `max`. Grok ignores the
+// flag on non-reasoning models, so no per-model clamping is needed.
+const EFFORT_MAP: Record<ReasoningEffort, string> = {
+  none: 'none',
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+  max: 'max',
+  ultra: 'max',
+};
+
+/** The grok effort one reasoning level maps to. Exported for the mapping tests. */
+export function grokEffort(effort: ReasoningEffort | null | undefined): string | undefined {
+  if (!effort) return undefined;
+  return EFFORT_MAP[effort];
+}
+
+let pathBin: string | null = null;
+
+/** The `grok` binary: GROK_BIN, else the one on PATH. Throws ENOENT when
+ *  neither exists — the gateway renders that as 503 agent_unavailable. */
+function requireGrokBin(): string {
+  let bin = process.env.GROK_BIN?.trim();
+  if (!bin) {
+    if (!pathBin) {
+      try {
+        pathBin = execFileSync('which', ['grok'], { encoding: 'utf8' }).trim() || null;
+      } catch {
+        pathBin = null;
+      }
+    }
+    bin = pathBin ?? undefined;
+  }
+  if (!bin || !existsSync(bin)) {
+    const error: NodeJS.ErrnoException = new Error(
+      `Grok binary not found${bin ? ` at ${bin}` : ' on PATH'}. Install Grok Build or set GROK_BIN.`,
+    );
+    error.code = 'ENOENT';
+    throw error;
+  }
+  return bin;
+}
+
+function workspaceCwd(): string {
+  const dir = resolveWorkspaceDir();
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function grokHome(): string {
+  const configured = process.env.GROK_HOME?.trim();
+  return configured || join(homedir(), '.grok');
+}
+
+/** Grok keys its session store by URL-encoded realpath of the cwd. */
+function sessionsDir(): string {
+  let cwd = workspaceCwd();
+  try {
+    cwd = execFileSync('pwd', ['-P'], { cwd, encoding: 'utf8' }).trim() || cwd;
+  } catch {
+    // keep the unresolved path
+  }
+  return join(grokHome(), 'sessions', encodeURIComponent(cwd));
+}
+
+function sessionDir(sessionId: string): string {
+  return join(sessionsDir(), sessionId);
+}
+
+function childEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, GROK_DISABLE_AUTOUPDATER: '1', GROK_SANDBOX: 'off' };
+}
+
+interface GrokSummary {
+  session_summary?: string;
+  created_at?: string;
+  updated_at?: string;
+  last_active_at?: string;
+  num_chat_messages?: number;
+}
+
+function readSummary(dir: string): GrokSummary | null {
+  try {
+    return JSON.parse(readFileSync(join(dir, 'summary.json'), 'utf8')) as GrokSummary;
+  } catch {
+    return null;
+  }
+}
+
+/** Map a grok stream error message to a worker error code + message. */
+function errorEventOf(message: string): StreamEvent {
+  let code = 'agent_error';
+  if (/not signed in|not authenticated|unauthor|\b401\b|api key/i.test(message)) {
+    code = 'auth_error';
+  } else if (/\b429\b|rate.?limit|too many requests/i.test(message)) {
+    code = 'rate_limit';
+  } else if (/quota|credits?\b|billing|insufficient funds/i.test(message)) {
+    code = 'quota_exhausted';
+  } else if (/couldn't set model|unknown model id|model.*(not found|unavailable)/i.test(message)) {
+    code = 'model_error';
+  }
+  return { type: 'error', code, error: message, ...(code === 'auth_error' ? { hint: LOGIN_HINT } : {}) };
+}
+
+// Grok's tool names, mapped to the short names the UI knows, with a one-line
+// label from the tool input. Anything unrecognized passes through by name.
+function toolProgressOf(toolName: string, input: Record<string, unknown> | undefined): { tool: string; label?: string } {
+  const trim = (value: unknown): string | undefined => {
+    const s = typeof value === 'string' ? value.trim() : '';
+    return s ? (s.length > 120 ? `${s.slice(0, 117)}...` : s) : undefined;
+  };
+  switch (toolName) {
+    case 'run_terminal_command':
+      return { tool: 'shell', label: trim(input?.command) };
+    case 'write':
+    case 'search_replace':
+      return { tool: 'edit', label: trim(input?.path ?? input?.file_path) };
+    case 'web_search':
+      return { tool: 'web_search', label: trim(input?.query) };
+    case 'use_tool':
+      return { tool: 'mcp', label: trim(input?.tool_name) };
+    default:
+      return { tool: toolName, label: undefined };
+  }
+}
+
+interface GrokEndEvent {
+  stopReason?: string;
+  sessionId?: string;
+  usage?: {
+    input_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+  };
+  total_cost_usd?: number;
+}
+
+interface ActiveTurn {
+  child: ChildProcessWithoutNullStreams;
+  interrupted: boolean;
+  killTimer?: NodeJS.Timeout;
+}
+
+export class GrokAdapter implements AgentAdapter {
+  private readonly activeTurns = new Map<string, ActiveTurn>();
+
+  // The responses route calls this before a response begins: mint a UUID for a
+  // new session (grok creates it on the first turn via `-s`), or verify an
+  // existing one against grok's own store.
+  async resolveSession(sessionId?: string): Promise<string> {
+    requireGrokBin();
+    if (!sessionId) return randomUUID();
+    if (!UUID_RE.test(sessionId) || !existsSync(sessionDir(sessionId))) {
+      throw validationError(`No Grok session with id '${sessionId}'.`, 'session_id');
+    }
+    return sessionId;
+  }
+
+  async *chatStream(sessionId: string, message: string, options?: AgentRunOptions): AsyncIterable<StreamEvent> {
+    const bin = requireGrokBin();
+    const settings = options?.settings;
+    const isNew = !existsSync(sessionDir(sessionId));
+    const args = [
+      '-p',
+      message,
+      isNew ? '-s' : '-r',
+      sessionId,
+      '--output-format',
+      'streaming-json',
+      '--always-approve',
+    ];
+    if (settings?.model) args.push('-m', settings.model);
+    const effort = grokEffort(settings?.reasoningEffort);
+    if (effort) args.push('--reasoning-effort', effort);
+
+    const child = spawn(bin, args, { cwd: workspaceCwd(), env: childEnv() });
+    const turn: ActiveTurn = { child, interrupted: false };
+    this.activeTurns.set(sessionId, turn);
+
+    let stderrTail = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrTail = (stderrTail + chunk.toString()).slice(-2000);
+    });
+
+    const exited = new Promise<number | null>((resolve) => {
+      child.on('close', (code) => resolve(code));
+      child.on('error', () => resolve(null));
+    });
+
+    const tools = new Map<string, { tool: string; startedAt: number }>();
+    let end: GrokEndEvent | undefined;
+    let errorEvent: StreamEvent | undefined;
+
+    try {
+      for await (const line of createInterface({ input: child.stdout })) {
+        if (!line.trim()) continue;
+        let event: Record<string, unknown>;
+        try {
+          event = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        switch (event.type) {
+          case 'text': {
+            const delta = event.data as string;
+            if (delta) yield { type: 'text_delta', content: delta };
+            break;
+          }
+          case 'thought': {
+            const delta = event.data as string;
+            if (delta) yield { type: 'thinking_delta', content: delta };
+            break;
+          }
+          case 'tool_call': {
+            const id = event.toolCallId as string;
+            const progress = toolProgressOf(String(event.toolName ?? ''), event.rawInput as Record<string, unknown>);
+            tools.set(id, { tool: progress.tool, startedAt: Date.now() });
+            yield { type: 'tool_progress', tool: progress.tool, status: 'running', label: progress.label };
+            break;
+          }
+          case 'tool_call_update': {
+            const started = tools.get(event.toolCallId as string);
+            const status = event.status as string | null;
+            if (!started || (status !== 'completed' && status !== 'failed')) break;
+            tools.delete(event.toolCallId as string);
+            const rawOutput = event.rawOutput as { exit_code?: number } | null;
+            const failed = status === 'failed' || (typeof rawOutput?.exit_code === 'number' && rawOutput.exit_code !== 0);
+            yield failed
+              ? { type: 'tool_progress', tool: started.tool, status: 'error' }
+              : { type: 'tool_progress', tool: started.tool, status: 'completed', duration: Date.now() - started.startedAt };
+            break;
+          }
+          case 'end':
+            end = event as GrokEndEvent;
+            break;
+          case 'error':
+            errorEvent = errorEventOf(String(event.message ?? 'Grok ended the turn on an error.'));
+            break;
+        }
+      }
+    } finally {
+      await exited;
+      clearTimeout(turn.killTimer);
+      this.activeTurns.delete(sessionId);
+    }
+
+    if (turn.interrupted) {
+      yield { type: 'done', sessionId, usage: null, interrupted: true };
+    } else if (errorEvent) {
+      yield errorEvent;
+    } else if (end) {
+      const totals = end.usage ?? {};
+      const output = totals.output_tokens ?? 0;
+      const usage: TurnUsage = {
+        input_tokens: Math.max(0, (totals.total_tokens ?? 0) - output),
+        output_tokens: output,
+        cost_usd: end.total_cost_usd ?? null,
+      };
+      yield { type: 'done', sessionId, usage, context: null, interrupted: false };
+    } else {
+      const detail = stderrTail.trim().split('\n').at(-1);
+      yield { type: 'error', code: 'agent_error', error: detail || 'Grok ended the turn before it completed.' };
+    }
+  }
+
+  async interruptChat(sessionId: string): Promise<boolean> {
+    const turn = this.activeTurns.get(sessionId);
+    if (!turn) return false;
+    turn.interrupted = true;
+    turn.child.kill('SIGINT');
+    // Backstop: if grok doesn't wind down after SIGINT, kill it outright.
+    turn.killTimer = setTimeout(() => turn.child.kill('SIGKILL'), INTERRUPT_GRACE_MS);
+    return true;
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      requireGrokBin();
+    } catch {
+      return false;
+    }
+    const keyed = Boolean(process.env.XAI_API_KEY?.trim() || process.env.GROK_CODE_XAI_API_KEY?.trim());
+    return keyed || existsSync(join(grokHome(), 'auth.json'));
+  }
+
+  async listSessions(): Promise<SessionSummary[]> {
+    const dir = sessionsDir();
+    if (!existsSync(dir)) return [];
+    const rows: SessionSummary[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !UUID_RE.test(entry.name)) continue;
+      const summary = readSummary(join(dir, entry.name));
+      rows.push({
+        id: entry.name,
+        title: summary?.session_summary?.trim() || null,
+        last_active: epochMillis(summary?.last_active_at ?? summary?.updated_at),
+        message_count: summary?.num_chat_messages ?? null,
+        preview: null,
+      });
+    }
+    return rows.sort((a, b) => (b.last_active ?? 0) - (a.last_active ?? 0));
+  }
+
+  async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    const dir = sessionDir(sessionId);
+    let raw: string;
+    try {
+      raw = readFileSync(join(dir, 'chat_history.jsonl'), 'utf8');
+    } catch {
+      // The harness owns existence: an unknown/deleted session projects to [].
+      return [];
+    }
+    const created = epochMillis(readSummary(dir)?.created_at) ?? 0;
+
+    const out: HermesMessage[] = [];
+    let index = 0;
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      let entry: { type?: string; content?: unknown; prompt_index?: number };
+      try {
+        entry = JSON.parse(line) as typeof entry;
+      } catch {
+        continue;
+      }
+      index += 1;
+      if (entry.type === 'user' && typeof entry.prompt_index === 'number') {
+        // Real prompts carry prompt_index; grok wraps them in <user_query>.
+        const text = (Array.isArray(entry.content) ? entry.content : [])
+          .filter((c): c is { type: string; text?: string } => (c as { type?: string }).type === 'text')
+          .map((c) => c.text ?? '')
+          .join('');
+        const inner = /<user_query>\n?([\s\S]*?)\n?<\/user_query>/.exec(text)?.[1] ?? text;
+        if (!inner.trim()) continue;
+        out.push({ id: `${sessionId}-${index}`, task_id: sessionId, role: 'user', content: inner, created_at: created });
+      } else if (entry.type === 'assistant' && typeof entry.content === 'string' && entry.content.trim()) {
+        const previous = out.at(-1);
+        if (previous?.role === 'assistant') previous.content += `\n\n${entry.content}`;
+        else out.push({ id: `${sessionId}-${index}`, task_id: sessionId, role: 'assistant', content: entry.content, created_at: created });
+      }
+    }
+    return out;
+  }
+
+  async getSessionMetadata(): Promise<SessionMetadata | null> {
+    // No route reads this today; per-session cost stays in grok's store.
+    return null;
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    const bin = requireGrokBin();
+    if (!UUID_RE.test(sessionId)) return false;
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(bin, ['sessions', 'delete', sessionId], { cwd: workspaceCwd(), env: childEnv(), timeout: 30_000 }, (error, out) => {
+        if (error && !out) reject(error);
+        else resolve(out);
+      });
+    });
+    // `grok sessions delete` exits 0 either way; stdout says which happened.
+    return /deleted session/i.test(stdout);
+  }
+
+  async getModels(): Promise<AgentModelsResponse> {
+    const bin = requireGrokBin();
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(bin, ['models'], { cwd: workspaceCwd(), env: childEnv(), timeout: 30_000 }, (error, out) => {
+        if (error && !out) reject(error);
+        else resolve(out);
+      });
+    });
+    // Unkeyed, grok prints a static fallback catalog behind "You are not
+    // authenticated." — an unkeyed instance gets an empty list, never an error.
+    if (/not authenticated/i.test(stdout)) {
+      return { defaultModel: null, activeProvider: 'xai', groups: [{ provider: 'xai', models: [] }] };
+    }
+    const defaultModel = /^Default model:\s+(\S+)/m.exec(stdout)?.[1] ?? null;
+    const ids = [...stdout.matchAll(/^\s*[*-]\s+(\S+)/gm)].map((m) => m[1]);
+    return {
+      defaultModel,
+      activeProvider: 'xai',
+      groups: [
+        {
+          provider: 'xai',
+          models: ids.map((id) => ({
+            id,
+            label: id,
+            source: 'catalog',
+            provider: 'xai',
+            isCurrentDefault: id === defaultModel,
+          })),
+        },
+      ],
+    };
+  }
+
+  async getDefaults(): Promise<AgentDefaults> {
+    return { provider: 'xai', model: null, baseUrl: null, apiMode: null, reasoningEffort: null, showReasoning: true };
+  }
+
+  async stop(): Promise<void> {
+    for (const turn of this.activeTurns.values()) {
+      clearTimeout(turn.killTimer);
+      turn.child.kill('SIGKILL');
+    }
+    this.activeTurns.clear();
+  }
+}

--- a/server/adapters/grok-adapter.ts
+++ b/server/adapters/grok-adapter.ts
@@ -344,6 +344,9 @@ export class GrokAdapter implements AgentAdapter {
   }
 
   async getMessages(sessionId: string): Promise<HermesMessage[]> {
+    // The route passes the raw path param; only UUID-shaped ids may touch the
+    // store path (a traversal-shaped id must not resolve outside it).
+    if (!UUID_RE.test(sessionId)) return [];
     const dir = sessionDir(sessionId);
     let raw: string;
     try {

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -3,6 +3,7 @@ import { OpenClawAdapter } from './adapters/openclaw-adapter.js';
 import { ClaudeCodeAdapter } from './adapters/claude-code-adapter.js';
 import { CodexAdapter } from './adapters/codex-adapter.js';
 import { OpenCodeAdapter } from './adapters/opencode-adapter.js';
+import { GrokAdapter } from './adapters/grok-adapter.js';
 import type { AgentAdapter } from './adapters/types.js';
 import { resolveConfiguredDefaultAgent, SUPPORTED_AGENTS, type AgentType } from '../shared/types.js';
 import { optionalEnum, queryParam } from './errors.js';
@@ -18,6 +19,7 @@ const registry: Record<AgentType, GatewayAdapter> = {
   'claude-code': new ClaudeCodeAdapter(),
   codex: new CodexAdapter(),
   opencode: new OpenCodeAdapter(),
+  grok: new GrokAdapter(),
 };
 
 export function getAdapter(agent: AgentType): GatewayAdapter {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,7 +19,7 @@ export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 /** Response modes. `chat` runs one turn; `goal` is reserved for a fast-follow. */
 export const RESPONSE_MODES = ['chat', 'goal'] as const;
 
-export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code', 'codex', 'opencode'] as const;
+export const SUPPORTED_AGENTS = ['hermes', 'openclaw', 'claude-code', 'codex', 'opencode', 'grok'] as const;
 export type AgentType = (typeof SUPPORTED_AGENTS)[number];
 export const DEFAULT_AGENT: AgentType = 'hermes';
 

--- a/test/agent-unavailable.integration.test.ts
+++ b/test/agent-unavailable.integration.test.ts
@@ -15,6 +15,7 @@ before(async () => {
   process.env.CLAUDE_CODE_BIN = '/nonexistent/claude';
   process.env.CODEX_BIN = '/nonexistent/codex';
   process.env.OPENCODE_BIN = '/nonexistent/opencode';
+  process.env.GROK_BIN = '/nonexistent/grok';
   server = await startTestServer();
   base = server.base;
 });
@@ -109,5 +110,28 @@ test('an opencode request without the opencode binary fails with agent_unavailab
   assert.equal(turnBody.error.code, 'agent_unavailable');
 
   const health = (await (await fetch(`${base}/v1/health?agent=opencode`)).json()) as { healthy: boolean };
+  assert.equal(health.healthy, false);
+});
+
+test('a grok request without the grok binary fails with agent_unavailable', async () => {
+  const models = await fetch(`${base}/v1/models?agent=grok`);
+  assert.equal(models.status, 503);
+  const modelsBody = (await models.json()) as { error: { code: string; message: string } };
+  assert.equal(modelsBody.error.code, 'agent_unavailable');
+  assert.match(modelsBody.error.message, /grok/);
+
+  // Grok resolves its session before the response begins, so a missing binary
+  // is caught while headers are still open: the turn is a real 503, not a
+  // 200 failed body (like Codex and OpenCode).
+  const turn = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'grok', input: 'hello' }),
+  });
+  assert.equal(turn.status, 503);
+  const turnBody = (await turn.json()) as { error: { code: string } };
+  assert.equal(turnBody.error.code, 'agent_unavailable');
+
+  const health = (await (await fetch(`${base}/v1/health?agent=grok`)).json()) as { healthy: boolean };
   assert.equal(health.healthy, false);
 });

--- a/test/grok-nokey.integration.test.ts
+++ b/test/grok-nokey.integration.test.ts
@@ -1,0 +1,68 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'dotenv';
+import { startTestServer, postJson, type TestServer } from './test-helpers.js';
+
+// Point Grok at an empty GROK_HOME (no auth.json) with no XAI_API_KEY in the
+// environment. A turn must settle as a failed response with the documented
+// auth_error and the key hint, and health must be false. node:test isolates
+// each file in its own process, so these env overrides don't leak.
+
+try {
+  const env = parse(readFileSync(new URL('../.env', import.meta.url)));
+  if (env.GROK_BIN && !process.env.GROK_BIN) process.env.GROK_BIN = env.GROK_BIN;
+} catch {
+  // no .env — rely on the ambient environment
+}
+
+const grokMissing = await new Promise<false | string>((resolve) => {
+  execFile(process.env.GROK_BIN?.trim() || 'grok', ['--version'], { timeout: 15_000 }, (error) => {
+    resolve(error ? 'no Grok CLI installed' : false);
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+let grokHome: string;
+
+before(async () => {
+  delete process.env.XAI_API_KEY;
+  delete process.env.GROK_CODE_XAI_API_KEY;
+  grokHome = mkdtempSync(join(tmpdir(), 'a37gw-grok-nokey-'));
+  process.env.GROK_HOME = grokHome;
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+  try {
+    rmSync(grokHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  } catch {
+    // best effort — the OS reaps the temp dir
+  }
+});
+
+test('a grok turn without a key fails with auth_error', { skip: grokMissing }, async () => {
+  const failed = (await (await postJson(base, { agent: 'grok', input: 'hello', reasoning_effort: 'low' })).json()) as {
+    status: string;
+    error: { code: string; hint?: string } | null;
+  };
+  assert.equal(failed.status, 'failed');
+  assert.equal(failed.error?.code, 'auth_error');
+  assert.match(failed.error?.hint ?? '', /XAI_API_KEY/);
+
+  const health = (await (await fetch(`${base}/v1/health?agent=grok`)).json()) as { healthy: boolean };
+  assert.equal(health.healthy, false);
+});
+
+test('an unkeyed grok models read is an empty list, not an error', { skip: grokMissing }, async () => {
+  const res = await fetch(`${base}/v1/models?agent=grok`);
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { data: unknown[]; default_model?: string | null };
+  assert.deepEqual(body.data, []);
+});

--- a/test/grok.integration.test.ts
+++ b/test/grok.integration.test.ts
@@ -1,0 +1,223 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'dotenv';
+import { startTestServer, postJson, SseReader, type TestServer } from './test-helpers.js';
+
+// --- Grok adapter. Like Codex, Grok ships in a release image, so a missing or
+// unkeyed CLI FAILS the suite via the gate test below rather than silently
+// skipping. Turns run on the tester's own XAI_API_KEY and cost real usage.
+
+// Pull only the Grok settings from .env; loading the whole file would reshape
+// the Hermes worker's environment too.
+try {
+  const env = parse(readFileSync(new URL('../.env', import.meta.url)));
+  for (const key of ['GROK_BIN', 'XAI_API_KEY'] as const) {
+    if (env[key] && !process.env[key]) process.env[key] = env[key];
+  }
+} catch {
+  // no .env — rely on the ambient environment
+}
+
+const grokSkip = await new Promise<false | string>((resolve) => {
+  execFile(process.env.GROK_BIN?.trim() || 'grok', ['--version'], { timeout: 15_000 }, (error) => {
+    if (error) resolve('Grok is not installed');
+    else if (!process.env.XAI_API_KEY?.trim()) resolve('XAI_API_KEY is not set');
+    else resolve(false);
+  });
+});
+
+let server: TestServer | undefined;
+let base: string;
+let grokHome: string;
+let previousHome: string | undefined;
+
+before(async () => {
+  // An isolated GROK_HOME keeps the run off the developer's own session store,
+  // and its config turns off grok's Claude-compat scanners so a local
+  // ~/.claude.json can't wire personal MCP servers into every test turn.
+  previousHome = process.env.GROK_HOME;
+  grokHome = mkdtempSync(join(tmpdir(), 'a37gw-grok-'));
+  writeFileSync(join(grokHome, 'config.toml'), '[compat.claude]\nmcps = false\n');
+  process.env.GROK_HOME = grokHome;
+  server = await startTestServer();
+  base = server.base;
+});
+
+after(async () => {
+  await server?.close();
+  if (previousHome === undefined) delete process.env.GROK_HOME;
+  else process.env.GROK_HOME = previousHome;
+  try {
+    rmSync(grokHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  } catch {
+    // best effort — the OS reaps the temp dir
+  }
+});
+
+interface ResponseBody {
+  id: string;
+  session_id: string;
+  status: string;
+  agent: string;
+  output_text: string;
+  usage: { input_tokens: number; output_tokens: number; cost_usd: number | null } | null;
+  context: { used_tokens: number; window_tokens: number } | null;
+  error: { code: string; message: string; hint?: string } | null;
+}
+
+async function jsonOk<T>(res: Response): Promise<T> {
+  const body = await res.json();
+  assert.equal(res.status, 200, JSON.stringify(body));
+  return body as T;
+}
+
+test('Grok CLI is installed and keyed (required — its tests must run)', () => {
+  assert.equal(grokSkip, false, `Grok tests did not run: ${grokSkip}. Install Grok Build and set XAI_API_KEY — a green suite must include this harness.`);
+});
+
+test('grok responses complete, resume, and manage sessions on Grok\'s own store', { skip: grokSkip }, async () => {
+  const marker = `grok-marker-${Date.now()}`;
+  const created = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'grok',
+      input: `Remember this marker: ${marker}. Reply with just OK.`,
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(created.status, 'completed', JSON.stringify(created.error));
+  assert.equal(created.agent, 'grok');
+  // A Grok session id is a UUID minted by the gateway and owned by grok's
+  // store; the client can't bring its own (see the made-up-id case below).
+  assert.match(created.session_id, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  assert.ok(created.output_text.trim().length > 0);
+  assert.ok(created.usage && created.usage.output_tokens > 0);
+  assert.equal(typeof created.usage.cost_usd, 'number'); // Grok reports USD cost.
+  assert.equal(created.context, null); // Grok reports no context window.
+
+  assert.deepEqual(await jsonOk(await fetch(`${base}/v1/health?agent=grok`)), {
+    ok: true,
+    agent: 'grok',
+    healthy: true,
+  });
+
+  // A known session id resumes on grok's own store, so the marker is recalled.
+  const recalled = await jsonOk<ResponseBody>(
+    await postJson(base, {
+      agent: 'grok',
+      session_id: created.session_id,
+      input: 'Reply with just the marker I asked you to remember.',
+      reasoning_effort: 'low',
+    }),
+  );
+  assert.equal(recalled.status, 'completed', JSON.stringify(recalled.error));
+  assert.equal(recalled.session_id, created.session_id);
+  assert.ok(recalled.output_text.includes(marker), recalled.output_text);
+
+  // History projects grok's own transcript; reads name `?agent=grok`.
+  const session = await jsonOk<{ history: { role: string; content: string; created_at: number }[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=grok`),
+  );
+  assert.ok(session.history.some((m) => m.role === 'user' && m.content.includes(marker)));
+  assert.ok(session.history.some((m) => m.role === 'assistant'));
+
+  // The list is grok's own session store for this workspace.
+  const list = await jsonOk<{ agent: string; data: Array<{ id: string; title: string | null; last_active: number | null }> }>(
+    await fetch(`${base}/v1/sessions?agent=grok`),
+  );
+  assert.equal(list.agent, 'grok');
+  const row = list.data.find((s) => s.id === created.session_id);
+  assert.ok(row, 'created session appears in the list');
+  assert.equal(typeof row.last_active, 'number');
+
+  // Grok stores no editable title, so rename is a documented 405.
+  const rename = await fetch(`${base}/v1/sessions/${created.session_id}?agent=grok`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'nope' }),
+  });
+  assert.equal(rename.status, 405);
+
+  // Models are grok's live per-key catalog.
+  const models = await jsonOk<{ agent: string; data: Array<{ id: string; owned_by: string; source: string }> }>(
+    await fetch(`${base}/v1/models?agent=grok`),
+  );
+  assert.equal(models.agent, 'grok');
+  assert.ok(models.data.length > 0);
+  assert.ok(models.data.every((m) => m.owned_by === 'xai' && m.source === 'catalog'));
+
+  const stream = await postJson(base, {
+    agent: 'grok',
+    input: 'Reply with exactly this word: PONG',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(stream.status, 200);
+  const events = await new SseReader(stream).drain();
+  assert.equal(events[0]?.event, 'response.created');
+  assert.ok(events.some((event) => event.event === 'response.output_text.delta'));
+  assert.equal(events.at(-1)?.event, 'response.completed');
+  await fetch(`${base}/v1/sessions/${events[0]?.data.session_id as string}?agent=grok`, { method: 'DELETE' });
+
+  // Delete removes the session; it leaves the list and its history projects empty.
+  const deleted = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=grok`, { method: 'DELETE' }),
+  );
+  assert.equal(deleted.deleted, true);
+  const gone = await jsonOk<{ history: unknown[] }>(
+    await fetch(`${base}/v1/sessions/${created.session_id}?agent=grok`),
+  );
+  assert.deepEqual(gone.history, []);
+
+  // Deleting an unknown session is not an error.
+  const unknown = await jsonOk<{ deleted: boolean }>(
+    await fetch(`${base}/v1/sessions/00000000-0000-0000-0000-000000000000?agent=grok`, { method: 'DELETE' }),
+  );
+  assert.equal(unknown.deleted, false);
+
+  // A client cannot invent a session_id on grok: an unknown id is a 400.
+  const madeUp = await fetch(`${base}/v1/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ agent: 'grok', session_id: 'not-a-real-session', input: 'hello' }),
+  });
+  assert.equal(madeUp.status, 400);
+  const madeUpBody = (await madeUp.json()) as { error: { code: string; param?: string } };
+  assert.equal(madeUpBody.error.code, 'validation_error');
+  assert.equal(madeUpBody.error.param, 'session_id');
+});
+
+test('an in-flight grok turn can be cancelled', { skip: grokSkip }, async () => {
+  const slow = await postJson(base, {
+    agent: 'grok',
+    input: 'Run the shell command `sleep 30` and then reply with the word done.',
+    reasoning_effort: 'low',
+    stream: true,
+  });
+  assert.equal(slow.status, 200);
+
+  const reader = new SseReader(slow);
+  const opening = await reader.until((event) => event.event !== 'response.created');
+  const created = opening.find((event) => event.event === 'response.created');
+  assert.ok(created);
+  const responseId = created.data.id as string;
+  const sessionId = created.data.session_id as string;
+
+  const cancel = await fetch(`${base}/v1/responses/${responseId}/cancel`, { method: 'POST' });
+  assert.equal(cancel.status, 200);
+  await reader.drain();
+
+  const settled = await jsonOk<{ active_response_id: string | null }>(
+    await fetch(`${base}/v1/sessions/${sessionId}?agent=grok`),
+  );
+  assert.equal(settled.active_response_id, null);
+  const replay = await new SseReader(await fetch(`${base}/v1/responses/${responseId}/stream`)).drain();
+  assert.equal(replay.at(-1)?.event, 'response.completed');
+  // A cancelled turn reports no usage or context.
+  assert.equal(replay.at(-1)?.data.usage, null);
+
+  await fetch(`${base}/v1/sessions/${sessionId}?agent=grok`, { method: 'DELETE' });
+});

--- a/test/reasoning-mapping.test.ts
+++ b/test/reasoning-mapping.test.ts
@@ -8,6 +8,7 @@ import { effortOptions } from '../server/adapters/claude-code-adapter.js';
 import { THINKING_MAP } from '../server/adapters/openclaw-adapter.js';
 import { codexEffort } from '../server/adapters/codex-adapter.js';
 import { opencodeVariant } from '../server/adapters/opencode-adapter.js';
+import { grokEffort } from '../server/adapters/grok-adapter.js';
 
 test('the public enum runs none through ultra', () => {
   assert.deepEqual([...REASONING_EFFORTS], ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
@@ -40,6 +41,20 @@ test('codex: none/minimal floor to low, the rest map by name, ultra stays ultra'
   // Every public effort resolves to a Codex value (the turn/start effort is a
   // free-form string, but a mapping must exist for each level).
   for (const effort of REASONING_EFFORTS) assert.ok(codexEffort(effort), `${effort} unmapped`);
+});
+
+test('grok: levels map by name, ultra maps to max (grok has no ultra)', () => {
+  assert.equal(grokEffort(null), undefined);
+  assert.equal(grokEffort(undefined), undefined);
+  assert.equal(grokEffort('none'), 'none');
+  assert.equal(grokEffort('minimal'), 'minimal');
+  assert.equal(grokEffort('low'), 'low');
+  assert.equal(grokEffort('medium'), 'medium');
+  assert.equal(grokEffort('high'), 'high');
+  assert.equal(grokEffort('xhigh'), 'xhigh');
+  assert.equal(grokEffort('max'), 'max');
+  assert.equal(grokEffort('ultra'), 'max');
+  for (const effort of REASONING_EFFORTS) assert.ok(grokEffort(effort), `${effort} unmapped`);
 });
 
 test('opencode: none omits the variant, max/ultra map to max, the rest map by name', () => {


### PR DESCRIPTION
Adds `agent: "grok"` driving Grok Build (xAI's `grok` CLI) headless, the per-turn pattern: one `grok -p --output-format streaming-json` process per turn, no resident server, zero RAM at rest. Phase 7.1 of `agent37-web/docs/codex-opencode-harness-plan.md` section 9.

## How it works
- The gateway mints the session UUID in `resolveSession` and hands it to grok with `-s` on the session's first turn (grok accepts a caller-supplied UUID for new sessions only), then resumes with `-r`. A client cannot invent an id (400 `validation_error`), the Codex semantics.
- Sessions, transcripts, and delete project from grok's own store (`~/.grok/sessions/<encoded-cwd>/<uuid>/`: `summary.json`, `chat_history.jsonl`); the gateway keeps no index. Rename answers 405 (no editable title).
- BYO credentials only: `XAI_API_KEY` in the environment, read directly by the CLI (no auth materialization step), or `grok login` on the box. The gateway checks presence for health, never the value.
- `reasoning_effort` maps by name (`ultra` -> `max`); grok ignores the flag on non-reasoning models, so no clamping.
- `usage` reports grok's per-turn tokens plus real USD cost (`total_cost_usd`); `context` is null (grok reports no window).
- Interrupt = SIGINT (grok winds the turn down and persists the session) with a 5s SIGKILL backstop.

## Verified against the real binary (grok 1.0.13)
Every wire shape was probed live before coding (macOS local + a real gVisor B2B instance): streaming-json event set, `-s`/`-r` semantics, unkeyed exit 1 + error JSON, `sessions delete` stdout contract, `grok models` output (keyed and the unkeyed "not authenticated" fallback), `--reasoning-effort low` on a reasoning model, SIGINT behavior, session-store layout.

## Tests
- `test/grok.integration.test.ts`: full lifecycle (create, resume recall, history, list, 405 rename, models, streaming, delete, made-up-id 400) + cancel. **9/9 green locally** with the codex-style gate (missing CLI or key fails the suite).
- `test/grok-nokey.integration.test.ts`: auth_error + hint, unhealthy, empty model list.
- `test/agent-unavailable.integration.test.ts`: grok 503 case.
- `test/reasoning-mapping.test.ts`: `grokEffort` block.

Release: v0.13.0 (tag after merge). Downstream: `agent37-web` `b2b-grok` image + `agent37-grok` template ride this tag.