### PR TITLE
Claude Code models come from its own catalog (v0.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ The gateway passes no credential: Claude Code runs on its own login. Until one
 exists, a turn fails with `auth_error` (and a hint to log in) and
 `GET /v1/health?agent=claude-code` reports `healthy: false`.
 
-`GET /v1/models?agent=claude-code` lists Claude Code's model aliases (`sonnet`,
-`opus`, `fable`, `haiku`, each the latest of its family); a turn's `model` is
+`GET /v1/models?agent=claude-code` lists Claude Code's own model catalog (the
+same rows its `/model` picker shows, so `label` and `description` name the
+versions each row resolves to, and the account's plan decides what is in it); a turn's `model` is
 passed through as is, and `reasoning_effort` maps onto Claude Code's dials
 (`none` → thinking disabled, `minimal|low` → effort `low`,
 `medium|high|xhigh|max` → the same effort, `ultra` → ultracode: `xhigh` effort
@@ -476,8 +477,9 @@ Codex, `healthy` also means an account is configured.
 works. It lists the models of one harness — the configured default, or the one
 named by an optional `?agent=` query param (e.g. `?agent=openclaw`) — and the
 response echoes which `agent` answered. Each entry carries the upstream provider
-in `owned_by` plus `label`, `source`, and `is_default`, so a UI can group models
-by provider and preselect the default:
+in `owned_by` plus `label`, `source`, `is_default`, and, where the harness
+publishes one, a one-line `description`, so a UI can group models by provider,
+say what each one is, and preselect the default:
 
 ```jsonc
 {
@@ -492,6 +494,7 @@ by provider and preselect the default:
       "created": 0,                  // we don't track per-model creation time
       "owned_by": "nous",            // upstream provider
       "label": "Hermes 4 405B",
+      "description": "…",            // only when the harness publishes one
       "source": "catalog",           // current | catalog | custom | alias
       "is_default": true
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent37-gateway",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A unified, Responses-style adapter API that runs on each instance and routes each turn to the harness it targets: Hermes, OpenClaw, Claude Code, Codex, or OpenCode.",
   "license": "MIT",
   "type": "module",

--- a/server/adapters/claude-code-adapter.ts
+++ b/server/adapters/claude-code-adapter.ts
@@ -9,6 +9,7 @@ import {
   listSessions as listClaudeSessions,
   query,
   renameSession as renameClaudeSession,
+  type ModelInfo as SDKModelInfo,
   type Options,
   type Query,
   type SDKAssistantMessage,
@@ -68,14 +69,14 @@ export function effortOptions(effort: ReasoningEffort | null | undefined): Pick<
   return { effort: EFFORT_MAP[effort] };
 }
 
-// Claude Code has no model catalog call; its own /model picker is this fixed
-// set of aliases, each resolving to the latest model of its family.
-const MODEL_ALIASES = [
-  { id: 'sonnet', label: 'Claude Sonnet (latest)' },
-  { id: 'opus', label: 'Claude Opus (latest)' },
-  { id: 'fable', label: 'Claude Fable (latest)' },
-  { id: 'haiku', label: 'Claude Haiku (latest)' },
-];
+// Claude Code has no catalog command; its own /model picker is the SDK's
+// supportedModels() control request, which needs a live query. The answer is
+// the customer's own list — it names the versions each alias resolves to and
+// tracks their plan and CLI release — and every ask spawns a `claude`, so it is
+// cached for a few minutes.
+const CATALOG_TTL_MS = 300_000;
+// The catalog's own "whatever Claude Code picks" row.
+const DEFAULT_MODEL_ID = 'default';
 
 // Claude Code's typed failure signal (SDKAssistantMessage.error) → the worker
 // codes server/errors.ts already knows how to render.
@@ -271,6 +272,29 @@ function loggedIn(): Promise<boolean> {
   });
 }
 
+// One query whose prompt never yields: enough of a session for the control
+// request, torn down as soon as it answers.
+async function modelCatalog(bin: string): Promise<SDKModelInfo[]> {
+  const abort = new AbortController();
+  async function* idle(): AsyncGenerator<SDKUserMessage> {
+    await new Promise<void>((resolve) => abort.signal.addEventListener('abort', () => resolve(), { once: true }));
+  }
+  const q = query({
+    prompt: idle(),
+    options: {
+      cwd: workspaceCwd(),
+      pathToClaudeCodeExecutable: bin,
+      settingSources: ['user'],
+      abortController: abort,
+    },
+  });
+  try {
+    return await q.supportedModels();
+  } finally {
+    abort.abort();
+  }
+}
+
 interface ActiveTurn {
   query: Query;
   abort: AbortController;
@@ -281,6 +305,7 @@ interface ActiveTurn {
 export class ClaudeCodeAdapter implements AgentAdapter {
   private readonly activeTurns = new Map<string, ActiveTurn>();
   private health: { at: number; ok: boolean } | null = null;
+  private catalog: { at: number; models: SDKModelInfo[] } | null = null;
 
   async *chatStream(sessionId: string, message: string, options?: AgentRunOptions): AsyncIterable<StreamEvent> {
     const bin = requireClaudeBin();
@@ -540,19 +565,25 @@ export class ClaudeCodeAdapter implements AgentAdapter {
   }
 
   async getModels(): Promise<AgentModelsResponse> {
-    requireClaudeBin();
+    const bin = requireClaudeBin();
+    const now = Date.now();
+    if (!this.catalog || now - this.catalog.at > CATALOG_TTL_MS) {
+      this.catalog = { at: now, models: await modelCatalog(bin) };
+    }
+    const models = this.catalog.models;
     return {
-      defaultModel: null,
+      defaultModel: models.some((model) => model.value === DEFAULT_MODEL_ID) ? DEFAULT_MODEL_ID : null,
       activeProvider: 'anthropic',
       groups: [
         {
           provider: 'anthropic',
-          models: MODEL_ALIASES.map((alias) => ({
-            id: alias.id,
-            label: alias.label,
-            source: 'alias',
+          models: models.map((model) => ({
+            id: model.value,
+            label: model.displayName || model.value,
+            description: model.description || null,
+            source: 'catalog',
             provider: 'anthropic',
-            isCurrentDefault: false,
+            isCurrentDefault: model.value === DEFAULT_MODEL_ID,
           })),
         },
       ],

--- a/server/routes/models.ts
+++ b/server/routes/models.ts
@@ -11,8 +11,8 @@ const MODEL_CREATED = 0;
 
 // GET /v1/models — the models a harness on this gateway can run on. The body is
 // the OpenAI list shape ({ object: "list", data: [...] }) so standard clients
-// work; the upstream provider rides in `owned_by` and label/source/is_default
-// are additive extensions a UI groups on. `?agent=` selects the harness (default
+// work; the upstream provider rides in `owned_by` and label/description/source/
+// is_default are additive extensions a UI groups on. `?agent=` selects the harness (default
 // = the gateway's configured default), and the response echoes which `agent`
 // answered.
 modelsRouter.get('/', async (req, res, next) => {
@@ -30,6 +30,7 @@ modelsRouter.get('/', async (req, res, next) => {
           created: MODEL_CREATED,
           owned_by: model.provider ?? group.provider,
           label: model.label,
+          ...(model.description ? { description: model.description } : {}),
           source: model.source,
           is_default: Boolean(model.isCurrentDefault),
         });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -224,6 +224,9 @@ export interface AgentDefaults {
 export interface AgentModelOption {
   id: string;
   label: string;
+  /** One line from the harness about the model (what it resolves to, what it
+   *  is for). Only the harnesses that publish one fill it in. */
+  description?: string | null;
   source: 'current' | 'catalog' | 'custom' | 'alias';
   provider?: string | null;
   isCurrentDefault?: boolean;
@@ -278,6 +281,8 @@ export interface ModelInfo {
   created: number;
   owned_by: string;
   label: string;
+  /** Present only when the harness publishes one. */
+  description?: string;
   source: AgentModelOption['source'];
   is_default: boolean;
 }

--- a/test/claude-code.integration.test.ts
+++ b/test/claude-code.integration.test.ts
@@ -132,12 +132,22 @@ test('claude-code responses complete, resume, and manage sessions on Claude Code
   );
   assert.equal(renamedList.data.find((s) => s.id === created.session_id)?.title, title);
 
-  // Models are Claude Code's fixed aliases.
-  const models = await jsonOk<{ agent: string; data: Array<{ id: string; owned_by: string; source: string }> }>(
-    await fetch(`${base}/v1/models?agent=claude-code`),
-  );
+  // Models are Claude Code's own catalog: every row names the model it resolves
+  // to, and one of them is the harness's default.
+  const models = await jsonOk<{
+    agent: string;
+    default_model: string | null;
+    data: Array<{ id: string; owned_by: string; source: string; label: string; description?: string; is_default: boolean }>;
+  }>(await fetch(`${base}/v1/models?agent=claude-code`));
   assert.equal(models.agent, 'claude-code');
-  assert.ok(models.data.some((m) => m.id === 'sonnet' && m.owned_by === 'anthropic' && m.source === 'alias'));
+  const sonnet = models.data.find((m) => m.id === 'sonnet');
+  assert.ok(sonnet, JSON.stringify(models.data));
+  assert.equal(sonnet.owned_by, 'anthropic');
+  assert.equal(sonnet.source, 'catalog');
+  assert.match(sonnet.label, /sonnet/i);
+  assert.ok((sonnet.description ?? '').length > 0);
+  assert.ok(models.default_model);
+  assert.equal(models.data.filter((m) => m.is_default).length, 1);
 
   const stream = await postJson(base, {
     agent: 'claude-code',


### PR DESCRIPTION
`GET /v1/models?agent=claude-code` returned four hardcoded aliases (`sonnet`, `opus`, `fable`, `haiku`) with no versions and no default, because the adapter was written when Claude Code had no catalog call. It has one: the Agent SDK's `supportedModels()` control request, which returns the same rows the CLI's own `/model` picker shows.

Before:

```json
{ "id": "sonnet", "label": "Claude Sonnet (latest)", "source": "alias", "is_default": false }
```

After:

```json
{ "id": "sonnet", "label": "Sonnet", "description": "Sonnet 5 · Efficient for routine tasks", "source": "catalog", "is_default": false }
{ "id": "default", "label": "Default (recommended)", "description": "Opus 5 with 1M context · Best for everyday, complex tasks", "source": "catalog", "is_default": true }
```

The list is the account's own: a logged-out box lists fewer rows (no Fable) rather than erroring, and every id in it is accepted as a turn's `model` (verified against `default`, `opus[1m]`, `claude-fable-5[1m]`).

## Changes

- `claude-code-adapter.ts`: `modelCatalog()` asks one query whose prompt never yields and aborts it as soon as it answers (~2s, no orphan process), cached 5 minutes since each ask spawns a `claude`. The catalog's `default` row becomes `default_model` + `is_default`.
- `shared/types.ts`, `routes/models.ts`: models carry an optional one-line `description`, emitted only when the harness publishes one.
- `test/claude-code.integration.test.ts`: the models assertions cover the catalog shape (display name, description, exactly one default).
- `README.md`: the Claude Code and `GET /v1/models` sections.

## Tests

`npm run typecheck` clean. `npm test`: **62 pass, 2 fail** — both failures are the OpenClaw harness on this machine (`chat.abort → missing scope: operator.write`, a local token scope), untouched by this change. The four claude-code tests pass.